### PR TITLE
refactor: pull all oidc fields from secret

### DIFF
--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -6,4 +6,9 @@ locals {
   db_cred_secret = join("",data.aws_secretsmanager_secrets.rds.arns)
 
   domain_name = "${var.domain_name_prefix}ztmf.cms.gov"
+
+  // simplify referencing of json object fields for aws_verifiedaccess_trust_provider.ztmf_idmokta.oidc_options
+  // technically only one of the fields was a true secret (client_secret), but since we have the space here
+  //  we can use it to simplify code instead of placing all the other fields in TF vars
+  oidc_options = jsondecode(data.aws_secretsmanager_secret_version.ztmf_va_trust_provider_current.secret_string)
 }

--- a/infrastructure/terraform.tf
+++ b/infrastructure/terraform.tf
@@ -10,5 +10,4 @@ terraform {
 
 provider "aws" {
   region  = "us-east-1"
-  profile = "ztmf-${var.environment}"
 }

--- a/infrastructure/verified-access.tf
+++ b/infrastructure/verified-access.tf
@@ -4,13 +4,13 @@ resource "aws_verifiedaccess_trust_provider" "ztmf_idmokta" {
   user_trust_provider_type = "oidc"
   policy_reference_name    = "ztmf_idm_okta"
   oidc_options {
-    authorization_endpoint = "https://test.idp.idm.cms.gov/oauth2/ausmi72sydh3BuvsV297/v1/authorize"
-    client_id              = jsondecode(data.aws_secretsmanager_secret_version.ztmf_va_trust_provider_current.secret_string)["client_id"]
-    issuer                 = "https://test.idp.idm.cms.gov/oauth2/ausmi72sydh3BuvsV297"
+    authorization_endpoint = local.oidc_options["authorization_endpoint"]
+    client_id              = local.oidc_options["client_id"]
+    issuer                 = local.oidc_options["issuer"]
     scope                  = "openid profile email groups"
-    token_endpoint         = "https://test.idp.idm.cms.gov/oauth2/ausmi72sydh3BuvsV297/v1/token"
-    user_info_endpoint     = "https://test.idp.idm.cms.gov/oauth2/ausmi72sydh3BuvsV297/v1/userinfo"
-    client_secret          = jsondecode(data.aws_secretsmanager_secret_version.ztmf_va_trust_provider_current.secret_string)["client_secret"]
+    token_endpoint         = local.oidc_options["token_endpoint"]
+    user_info_endpoint     = local.oidc_options["user_info_endpoint"]
+    client_secret          = local.oidc_options["client_secret"]
   }
   tags = {
     "Name" = "ztmf_idm_okta"


### PR DESCRIPTION
Instead of hard coding, or using TF vars, the OIDC details were put into the existing secret along with client_id and client_secret. While not necessary to do so it simplified code by obviating the need for another 4 tf vars while also keeping those values out of the codebase.

Also remove profile from the config which now allows TF to fall back to `AWS_` env vars which will be used by github actions in a future PR