### PR TITLE
cicd: separated workflows for better organization and maintainability

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,73 @@
+name: Backend
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  deploy:
+    name: Deploy
+    environment: DEV
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      
+      - name: LINT - backend/
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.58
+          working-directory: backend
+
+      # This step will "fail" only if no changes were found in the backend
+      # If no changes were found we dont need to build, push, and update the parameter
+      - name: Check for changes in backend/
+        id: backendDiff
+        run: git --no-pager diff --name-only origin/main HEAD | grep backend/; test $? -eq 0
+
+      - name: Get AWS Creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ROLEARN }}
+          role-duration-seconds: 900
+          aws-region: us-east-1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Get Commit SHA
+        id: revparse
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Docker Login
+        run: aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${{ secrets.ECR_REPO_URL }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend/
+          push: true
+          tags: ${{ secrets.ECR_REPO_URL }}:${{ steps.revparse.outputs.sha_short }}
+
+      - name: Update Parameter
+        run: aws ssm put-parameter --name ${{ secrets.PARAMETER_NAME }} --value ${{ steps.revparse.outputs.sha_short }} --overwrite

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,97 +1,51 @@
-name: Deploy
+# name: Deploy
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - reopened
-      - synchronize
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+#     branches:
+#       - main
+#     types:
+#       - opened
+#       - reopened
+#       - synchronize
 
-jobs:
-  deploy:
-    name: Deploy
-    environment: DEV
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+# jobs:
+#   deploy:
+#     name: Deploy
+#     environment: DEV
+#     runs-on: ubuntu-latest
+#     permissions:
+#       id-token: write
+#       contents: read
+#     steps:
+#       - name: Check out repo
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0
 
-      # the following checks will exit non-zero when grep fails to find a match
-      # but that status is used in later if statements hence continue on error
-      - name: Check for changes in backend/
-        id: backendDiff
-        run: git --no-pager diff --name-only origin/main HEAD | grep backend/
-        continue-on-error: true
-
-      - name: Check for changes in infrastructure/
-        id: infraDiff
-        run: git --no-pager diff --name-only origin/main HEAD | grep infrastructure/
-        continue-on-error: true
-
-      - name: Check for changes in ui/
-        id: uiDiff
-        run: git --no-pager diff --name-only origin/main HEAD | grep ui/
-        continue-on-error: true
+#       # the following checks will exit non-zero when grep fails to find a match
+#       # but that status is used in later if statements hence continue on error
       
-      - uses: actions/setup-go@v5
-        if: steps.backendDiff.outcome == 'success'
-        with:
-          go-version: '1.22'
+
+#       - name: Check for changes in infrastructure/
+#         id: infraDiff
+#         run: git --no-pager diff --name-only origin/main HEAD | grep infrastructure/
+#         continue-on-error: true
+
+#       - name: Check for changes in ui/
+#         id: uiDiff
+#         run: git --no-pager diff --name-only origin/main HEAD | grep ui/
+#         continue-on-error: true
       
-      - name: LINT - backend/
-        if: steps.backendDiff.outcome == 'success'
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.58
-          working-directory: backend
-
-      - name: Get AWS Creds
-        if: steps.backendDiff.outcome == 'success' || steps.infraDiff.outcome == 'success' || steps.uiDiff.outcome == 'success'
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.ROLEARN }}
-          role-duration-seconds: 900
-          aws-region: us-east-1
-
-      - name: Set up QEMU
-        if: steps.backendDiff.outcome == 'success'
-        uses: docker/setup-qemu-action@v3
       
-      - name: Set up Docker Buildx
-        if: steps.backendDiff.outcome == 'success'
-        uses: docker/setup-buildx-action@v3
       
-      - name: Get Commit SHA
-        if: steps.backendDiff.outcome == 'success'
-        id: revparse
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+#       - name: Deploy Infrastructure
+#         if: steps.infraDiff.outcome == 'success' || steps.backendImage.outcome == 'success'
+#         run: echo "deploying terraform"
 
-      - name: Docker Login
-        if: steps.backendDiff.outcome == 'success'
-        run: aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${{ secrets.ECR_REPO_URL }}
-
-      - name: Build and Push
-        if: steps.backendDiff.outcome == 'success'
-        uses: docker/build-push-action@v5
-        with:
-          context: ./backend/
-          push: true
-          tags: ${{ secrets.ECR_REPO_URL }}:${{ steps.revparse.outputs.sha_short }}
-      
-      - name: Deploy Infrastructure
-        if: steps.infraDiff.outcome == 'success' || steps.backendImage.outcome == 'success'
-        run: echo "deploying terraform"
-
-      - name: Deploy UI
-        if: steps.uiDiff.outcome == 'success'
-        run: echo "building yard and syncing S3"
+#       - name: Deploy UI
+#         if: steps.uiDiff.outcome == 'success'
+#         run: echo "building yard and syncing S3"


### PR DESCRIPTION
Initial work had all steps in a single workflow. While it technically worked, it required a lot of if: statements and became difficult to reason about and maintain. This moves each `backend/`, `infrastructure/`, and `ui/` into their own workflows