### PR TITLE
fix: removed once.Do which was only caching first key

### DIFF
--- a/backend/cmd/api/internal/auth/token.go
+++ b/backend/cmd/api/internal/auth/token.go
@@ -7,17 +7,13 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"sync"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/graph-gophers/graphql-go/errors"
 )
 
-var (
-	keys = make(map[string]jwt.VerificationKey)
-	once sync.Once
-)
+var keys = make(map[string]jwt.VerificationKey)
 
 type Claims struct {
 	Name  string `json:"name"`

--- a/backend/cmd/api/internal/auth/token.go
+++ b/backend/cmd/api/internal/auth/token.go
@@ -43,36 +43,35 @@ func getKey(token *jwt.Token) (interface{}, error) {
 		// if not already cached, request it
 		if _, ok := keys[kid]; !ok {
 			// but do it once to be thread safe
-			once.Do(func() {
-				cfg := config.GetInstance()
-				url := "https://public-keys.prod.verified-access." + cfg.Region + ".amazonaws.com/" + kid
-				req, _ := http.NewRequest("GET", url, nil)
 
-				res, err := http.DefaultClient.Do(req)
-				if err != nil {
-					log.Printf("client: error making http request: %s\n", err)
-				}
+			cfg := config.GetInstance()
+			url := "https://public-keys.prod.verified-access." + cfg.Region + ".amazonaws.com/" + kid
+			req, _ := http.NewRequest("GET", url, nil)
 
-				resBody, err := io.ReadAll(res.Body)
-				if err != nil {
-					log.Printf("client: could not read response body: %s\n", err)
-				}
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				log.Printf("client: error making http request: %s\n", err)
+			}
 
-				block, _ := pem.Decode(resBody)
-				if block == nil {
-					return // nil, errors.New("pubKey no pem data found")
-				}
+			resBody, err := io.ReadAll(res.Body)
+			if err != nil {
+				log.Printf("client: could not read response body: %s\n", err)
+			}
 
-				genericPublicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
-				if err != nil {
-					return // false, err
-				}
+			block, _ := pem.Decode(resBody)
+			if block == nil {
+				return nil, errors.Errorf("no PEM data found in public key")
+			}
 
-				pk := genericPublicKey.(*ecdsa.PublicKey)
-				// cache it!
-				keys[kid] = pk
+			genericPublicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
 
-			})
+			pk := genericPublicKey.(*ecdsa.PublicKey)
+			// cache it!
+			keys[kid] = pk
+
 		}
 
 		return keys[kid], nil


### PR DESCRIPTION
Fixes an issue where keys after the first were never cached, and since the return pulls from the cache it returned nil which caused the token validator to error