### PR TITLE
refactor: replace /whoami with /users/current

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Go Report Card](https://goreportcard.com/badge/github.com/CMS-Enterprise/ztmf/backend)](https://goreportcard.com/report/github.com/CMS-Enterprise/ztmf/backend) [![Backend](https://github.com/CMS-Enterprise/ztmf/actions/workflows/backend.yml/badge.svg)](https://github.com/CMS-Enterprise/ztmf/actions/workflows/backend.yml) [![Infrastructure](https://github.com/CMS-Enterprise/ztmf/actions/workflows/infrastructure.yml/badge.svg)](https://github.com/CMS-Enterprise/ztmf/actions/workflows/infrastructure.yml)
 # Zero Trust Maturity Framework (ZTMF) Scoring
 
 

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -1,41 +1,12 @@
 package controller
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/model"
 	"github.com/gorilla/mux"
 )
-
-func GetUser(ctx context.Context, userid string) (*model.User, error) {
-	user := auth.UserFromContext(ctx)
-
-	if !user.IsAdmin() && user.UserID != userid {
-		return nil, nil
-	}
-	return model.FindUserByID(ctx, userid)
-}
-
-func GetUserByEmail(w http.ResponseWriter, r *http.Request) {
-	authdUser := auth.UserFromContext(r.Context())
-	vars := mux.Vars(r)
-	email, ok := vars["email"]
-	if !ok {
-		respond(w, nil, &InvalidInputError{"email", nil})
-		return
-	}
-
-	if !authdUser.IsAdmin() && email != authdUser.Email {
-		respond(w, nil, &ForbiddenError{})
-		return
-	}
-
-	user, err := model.FindUserByEmail(r.Context(), email)
-
-	respond(w, user, err)
-}
 
 func GetUserById(w http.ResponseWriter, r *http.Request) {
 	authdUser := auth.UserFromContext(r.Context())
@@ -54,5 +25,10 @@ func GetUserById(w http.ResponseWriter, r *http.Request) {
 	user, err := model.FindUserByID(r.Context(), ID)
 
 	respond(w, user, err)
+}
 
+func GetCurrentUser(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	respond(w, user, nil)
 }

--- a/backend/cmd/api/internal/controller/whoami.go
+++ b/backend/cmd/api/internal/controller/whoami.go
@@ -1,8 +1,0 @@
-package controller
-
-import "net/http"
-
-func WhoAmI(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/jwt")
-	w.Write([]byte(r.Header[http.CanonicalHeaderKey("authorization")][0]))
-}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -20,13 +20,12 @@ func Handler() http.Handler {
 
 	router.HandleFunc("/api/v1/functions/{functionid}/options", controller.ListFunctionOptions).Methods("GET")
 
-	router.HandleFunc("/api/v1/users/{email:[a-zA-Z0-9.]+@[a-zA-Z0-9.]+}", controller.GetUserByEmail).Methods("GET")
+	router.HandleFunc("/api/v1/users/current", controller.GetCurrentUser).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:[a-zA-Z0-9\\-]+}", controller.GetUserById).Methods("GET")
 
 	router.HandleFunc("/api/v1/scores", controller.ListScores).Queries("datacallid", "{datacallid:[0-9]+}", "fismasystemid", "{fismasystemid:[0-9]+}").Methods("GET")
 	router.HandleFunc("/api/v1/scores", controller.SaveScore).Methods("POST")
 	router.HandleFunc("/api/v1/scores/{scoreid}", controller.SaveScore).Methods("PUT")
 
-	router.HandleFunc("/whoami", controller.WhoAmI).Methods("GET")
 	return router
 }

--- a/infrastructure/alb-public.tf
+++ b/infrastructure/alb-public.tf
@@ -93,10 +93,10 @@ resource "aws_lb_listener_rule" "login" {
   }
 
   action {
-    type             = "redirect"
+    type = "redirect"
     redirect {
       status_code = "HTTP_302"
-      path = "/"
+      path        = "/"
     }
   }
 
@@ -144,7 +144,8 @@ resource "aws_lb_listener_rule" "api" {
   condition {
     path_pattern {
       values = [
-        "/api/*"
+        "/api/*",
+        "/whoami"
       ]
     }
   }

--- a/infrastructure/alb-public.tf
+++ b/infrastructure/alb-public.tf
@@ -145,7 +145,6 @@ resource "aws_lb_listener_rule" "api" {
     path_pattern {
       values = [
         "/api/*",
-        "/whoami"
       ]
     }
   }

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -116,6 +116,27 @@ resource "aws_cloudfront_distribution" "ztmf" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  ordered_cache_behavior {
+    path_pattern     = "/whoami"
+    allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+    cached_methods   = ["HEAD", "GET", "OPTIONS"]
+    target_origin_id = "ztmf_rest_api"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "whitelist"

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -116,27 +116,6 @@ resource "aws_cloudfront_distribution" "ztmf" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  ordered_cache_behavior {
-    path_pattern     = "/whoami"
-    allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
-    cached_methods   = ["HEAD", "GET", "OPTIONS"]
-    target_origin_id = "ztmf_rest_api"
-
-    forwarded_values {
-      query_string = true
-      headers      = ["*"]
-      cookies {
-        forward = "all"
-      }
-    }
-
-    min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
   restrictions {
     geo_restriction {
       restriction_type = "whitelist"


### PR DESCRIPTION
`/whoami` was returning a JWT from which the email was then used to call `/users/<email>`
The issues with this were that
- because OIDC auth is handled by the ALB, which acts as a "Backend for Frontend" token handler, the client should only be concerned with the token handler session cookie and never receive a JWT
- /whoami is not RESTful in that it was not returning a resource

`/users/current` DOES return a resource, the object of a single user which is identified by way of the token which is forwarded to the api by the token handler mapped to the session cookie