### PR TITLE
feat: added web acl to cloudfront

### DIFF
--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -12,7 +12,9 @@ resource "aws_cloudfront_distribution" "ztmf" {
   is_ipv6_enabled     = false
   comment             = "ZTMF Scoring"
   default_root_object = "index.html"
-
+  // CMS provides a pre configured web acl, but it cant be tagged thus it can 
+  // only be found by looking to the stack outputs
+  web_acl_id = data.aws_cloudformation_stack.web_acl.outputs["SamQuickACLEnforcingV2"]
   origin {
     origin_id                = "ztmf_web_assets"
     domain_name              = aws_s3_bucket.ztmf_web_assets.bucket_regional_domain_name

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -87,3 +87,8 @@ data "aws_acm_certificate" "ztmf" {
   domain   = "dev.ztmf.cms.gov" // use dev. here because thats the domain value of the cert. other names are listed as alts
   statuses = ["ISSUED"]
 }
+
+// CMS cloud provided the following stack in each account for the preconfigured CMS cloud WAF
+data "aws_cloudformation_stack" "web_acl" {
+  name = "SamShieldAdvancedWaf"
+}


### PR DESCRIPTION
this applies the CMS cloud preconfigured WAF to the cloudfront distribution

closes #95 