### PR TITLE
Providing a platform flag for the backend

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - 54321:5432
   api:
+    platform: "linux/amd64"
     depends_on:
       - postgre
     build: ./backend


### PR DESCRIPTION
## Summary

Adding a platform flag in compose file for Apple Silicon users to run when building and running docker container.

Closes #119 
## Added

None

## Changed

compose.yml to have the platform flag

## Deprecated

None

## Removed

None