### PR TITLE
feat: imeplemented test db population

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -68,7 +68,7 @@ jobs:
       # TODO: convert this placeholder to a series of tests via BATS
       - name: Curl
         run: |
-          auth="eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InNvbWVAb25lLmNvbSJ9.IrtPdDCxmm9Jo6-860zvUeCZGKTTzZCCKx8lNNfymjs"
+          auth="eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3QudXNlckBub3doZXJlLnh5eiJ9.zmgPiVjkLNzh4sl9uD_KAR28bd___-OlLhHsXWQNSC4"
           curl -s -H "Authorization: ${auth}" http://localhost:8080/api/v1/users/current
 
       - name: AWS - Get Credentials

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -59,8 +59,11 @@ jobs:
           DB_NAME: ztmf
           DB_USER: admin
           DB_PASS: localDev 
+          DB_POPULATE: "/src/backend/_test_data.sql"
           AUTH_HS256_SECRET: "zeroTrust"
           AUTH_HEADER_FIELD: "Authorization"
+          WORKSPACE: ${{ github.workspace }}
+
 
       # TODO: convert this placeholder to a series of tests via BATS
       - name: Curl

--- a/backend/_test_data.sql
+++ b/backend/_test_data.sql
@@ -1,0 +1,4 @@
+
+INSERT INTO public.users VALUES (DEFAULT, 'test.user@nowhere.xyz', 'Admin User', 'ADMIN') ON CONFLICT DO NOTHING;
+
+INSERT INTO public.fismasystems VALUES (DEFAULT, 'abcdefghijklmnopqrstuvwxyz', 'TEST', 'Test Environment System Test', 'test', 'test', 'test group acronym', 'test group', 'test division', 'OTHER', 'test contact', 'test@nowhere.xyz') ON CONFLICT DO NOTHING;

--- a/backend/actions-compose.yml
+++ b/backend/actions-compose.yml
@@ -24,8 +24,11 @@ services:
       - DB_NAME
       - DB_USER
       - DB_PASS
+      - DB_POPULATE
       - AUTH_HS256_SECRET
       - AUTH_HEADER_FIELD
     network_mode: host
     command:
       - "/usr/local/bin/ztmfapi"
+    volumes:
+      - ${WORKSPACE}:/src

--- a/backend/cmd/api/internal/migrations/migrations.go
+++ b/backend/cmd/api/internal/migrations/migrations.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"sync"
 
+	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 	"github.com/jackc/tern/v2/migrate"
 )
@@ -29,6 +30,16 @@ func Run() {
 		return
 	}
 	migrator = nil
+
+	cfg := config.GetInstance()
+
+	// only populate local databases to prevent accidental overwrite of higher environments
+	if cfg.Db.PopulateSql != nil && cfg.Db.Host == "localhost" {
+		err := populate(*cfg.Db.PopulateSql)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 }
 
 func getMigrator() *migrate.Migrator {

--- a/backend/cmd/api/internal/migrations/populate.go
+++ b/backend/cmd/api/internal/migrations/populate.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"context"
+	"os"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+)
+
+func populate(path string) error {
+	sql, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.TODO()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = conn.Exec(ctx, string(sql))
+	return err
+}

--- a/backend/cmd/api/internal/migrations/populate.go
+++ b/backend/cmd/api/internal/migrations/populate.go
@@ -2,12 +2,14 @@ package migrations
 
 import (
 	"context"
+	"log"
 	"os"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 )
 
 func populate(path string) error {
+	log.Printf("Populating database with %s\n", path)
 	sql, err := os.ReadFile(path)
 	if err != nil {
 		return err

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -20,12 +20,13 @@ type config struct {
 		HeaderField  string `env:"AUTH_HEADER_FIELD"`  // the header that includes encoded JWT from OIDC IDP
 	}
 	Db struct {
-		Host     string `env:"DB_ENDPOINT"`
-		Port     string `env:"DB_PORT" envDefault:"5432"`
-		Name     string `env:"DB_NAME"`
-		User     string `env:"DB_USER"`
-		Pass     string `env:"DB_PASS"`
-		SecretId string `env:"DB_SECRET_ID"`
+		Host        string  `env:"DB_ENDPOINT"`
+		Port        string  `env:"DB_PORT" envDefault:"5432"`
+		Name        string  `env:"DB_NAME"`
+		User        string  `env:"DB_USER"`
+		Pass        string  `env:"DB_PASS"`
+		SecretId    string  `env:"DB_SECRET_ID"`
+		PopulateSql *string `env:"DB_POPULATE"` // path to sql to populate test database
 	}
 }
 
@@ -49,5 +50,6 @@ func GetInstance() *config {
 			return nil
 		}
 	}
+
 	return cfg
 }


### PR DESCRIPTION
Implements mechanism to populate a test database with dummy data. If `DB_POPULATE` env var is set to a path, migrations will load that file and execute the SQL contained therein.

The backend test was also modified to include a volume to allow the docker compose container access to the test data sql file

closes #144 