### PR TITLE
feat: admins can add and edit fismasystems

### DIFF
--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -41,9 +41,9 @@ func respond(w http.ResponseWriter, r *http.Request, data any, err error) {
 		log.Printf("%#v\n", err)
 
 		status, err = sanitizeErr(err)
-		switch err.(type) {
+		switch e := err.(type) {
 		case *model.InvalidInputError:
-			res.Data = err.(*model.InvalidInputError).Data()
+			res.Data = e.Data()
 		}
 		res.Err = err.Error()
 	}

--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/model"
@@ -37,29 +38,13 @@ func respond(w http.ResponseWriter, r *http.Request, data any, err error) {
 	}
 
 	if err != nil {
-		switch {
-		case errors.Is(err, model.ErrNoData):
-			err = ErrNotFound
-			fallthrough
-		case errors.Is(err, ErrNotFound):
-			status = 404
-		case errors.Is(err, ErrForbidden):
-			status = 403
-		case errors.Is(err, &model.InvalidInputError{}),
-			errors.Is(err, model.ErrNotUnique),
-			errors.Is(err, ErrMalformed),
-			errors.Is(err, model.ErrNoReference):
-			status = 400
-		case errors.Is(err, model.ErrDbConnection):
-			err = ErrServiceUnavailable
-			status = 503
-		case errors.Is(err, model.ErrTooMuchData):
-			fallthrough
-		default:
-			status = 500
-			err = ErrServer
-		}
+		log.Printf("%#v\n", err)
 
+		status, err = sanitizeErr(err)
+		switch err.(type) {
+		case *model.InvalidInputError:
+			res.Data = err.(*model.InvalidInputError).Data()
+		}
 		res.Err = err.Error()
 	}
 
@@ -72,4 +57,37 @@ func getJSON(r io.Reader, dest any) error {
 	d := json.NewDecoder(r)
 	d.DisallowUnknownFields()
 	return d.Decode(dest)
+}
+
+func sanitizeErr(err error) (int, error) {
+	switch err.(type) {
+	case *model.InvalidInputError:
+		return 400, err
+	}
+
+	var status int
+
+	switch {
+	case errors.Is(err, model.ErrNoData):
+		err = ErrNotFound
+		fallthrough
+	case errors.Is(err, ErrNotFound):
+		status = 404
+	case errors.Is(err, ErrForbidden):
+		status = 403
+	case errors.Is(err, model.ErrNotUnique),
+		errors.Is(err, ErrMalformed),
+		errors.Is(err, model.ErrNoReference):
+		status = 400
+	case errors.Is(err, model.ErrDbConnection):
+		err = ErrServiceUnavailable
+		status = 503
+	case errors.Is(err, model.ErrTooMuchData):
+		fallthrough
+	default:
+		status = 500
+		err = ErrServer
+	}
+
+	return status, err
 }

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -50,9 +50,9 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fismasystem := &model.FismaSystem{}
+	f := &model.FismaSystem{}
 
-	err := getJSON(r.Body, fismasystem)
+	err := getJSON(r.Body, f)
 	if err != nil {
 		log.Println(err)
 		respond(w, r, nil, ErrMalformed)
@@ -61,20 +61,15 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	if v, ok := vars["fismasystemid"]; ok {
-		fmt.Sscan(v, &fismasystem.FismaSystemID)
+		fmt.Sscan(v, &f.FismaSystemID)
 	}
 
-	if fismasystem.FismaSystemID == 0 {
-		fismasystem, err = model.CreateFismaSystem(r.Context(), *fismasystem)
-	} else {
-		fismasystem, err = model.UpdateFismaSystem(r.Context(), *fismasystem)
-	}
+	err = f.Save(r.Context())
 
 	if err != nil {
-		log.Println(err)
 		respond(w, r, nil, err)
 		return
 	}
 
-	respond(w, r, fismasystem, nil)
+	respond(w, r, f, nil)
 }

--- a/backend/cmd/api/internal/migrations/002_fix_datacenter_spelling.go
+++ b/backend/cmd/api/internal/migrations/002_fix_datacenter_spelling.go
@@ -1,0 +1,8 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"ordering columns",
+		`UPDATE public.fismasystems SET datacenterenvironment='DECOMMISSIONED' where datacenterenvironment='DECOMISSIONED';`,
+		"")
+}

--- a/backend/cmd/api/internal/migrations/002_fix_datacenter_spelling.go
+++ b/backend/cmd/api/internal/migrations/002_fix_datacenter_spelling.go
@@ -2,7 +2,7 @@ package migrations
 
 func init() {
 	getMigrator().AppendMigration(
-		"ordering columns",
+		"fix mispelling",
 		`UPDATE public.fismasystems SET datacenterenvironment='DECOMMISSIONED' where datacenterenvironment='DECOMISSIONED';`,
 		"")
 }

--- a/backend/cmd/api/internal/model/errors.go
+++ b/backend/cmd/api/internal/model/errors.go
@@ -23,12 +23,12 @@ type InvalidInputError struct {
 	data map[string]string
 }
 
+func (e *InvalidInputError) Data() map[string]string {
+	return e.data
+}
+
 func (e *InvalidInputError) Error() string {
-	str := "invalid input:\n"
-	for k, v := range e.data {
-		str += "  " + k + ":" + v + "\n"
-	}
-	return str
+	return "invalid input"
 }
 
 // trapError converts db driver errors into generic model errors

--- a/backend/cmd/api/internal/model/fismasystems.go
+++ b/backend/cmd/api/internal/model/fismasystems.go
@@ -3,9 +3,12 @@ package model
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 )
+
+var fismaSystemColumns = []string{"fismasystemid", "fismauid", "fismaacronym", "fismaname", "fismasubsystem", "component", "groupacronym", "groupname", "divisionname", "datacenterenvironment", "datacallcontact", "issoemail"}
 
 type FismaSystem struct {
 	FismaSystemID         int32   `json:"fismasystemid"`
@@ -30,7 +33,9 @@ type FindFismaSystemsInput struct {
 
 func FindFismaSystems(ctx context.Context, input FindFismaSystemsInput) ([]*FismaSystem, error) {
 
-	sqlb := sqlBuilder.Select("fismasystems.fismasystemid as fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail").From("fismasystems")
+	c := []string{"fismasystems.fismasystemid as fismasystemid"}
+	c = append(c, fismaSystemColumns[1:]...)
+	sqlb := sqlBuilder.Select(c...).From("fismasystems")
 
 	if input.UserID != nil {
 		sqlb = sqlb.InnerJoin("users_fismasystems ON users_fismasystems.fismasystemid = fismasystems.fismasystemid AND users_fismasystems.userid=?", *input.UserID)
@@ -63,7 +68,7 @@ func FindFismaSystem(ctx context.Context, input FindFismaSystemsInput) (*FismaSy
 		}
 	}
 
-	sqlb := sqlBuilder.Select("fismasystems.fismasystemid as fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail").From("fismasystems")
+	sqlb := sqlBuilder.Select(fismaSystemColumns...).From("fismasystems")
 
 	sqlb = sqlb.Where("fismasystems.fismasystemid=?", input.FismaSystemID)
 	sql, boundArgs, _ := sqlb.ToSql()
@@ -81,4 +86,48 @@ func FindFismaSystem(ctx context.Context, input FindFismaSystemsInput) (*FismaSy
 	}
 
 	return &fismaSystem, nil
+}
+
+func CreateFismaSystem(ctx context.Context, f FismaSystem) (*FismaSystem, error) {
+	sqlb := sqlBuilder.
+		Insert("fismasystems").
+		Columns(fismaSystemColumns[1:]...).
+		Values(f.FismaUID, f.FismaAcronym, f.FismaName, f.FismaSubsystem, f.Component, f.Groupacronym, f.GroupName, f.DivisionName, f.DataCenterEnvironment, f.DataCallContact, f.ISSOEmail).
+		Suffix("RETURNING fismasystemid")
+
+	sql, boundArgs, _ := sqlb.ToSql()
+	row, err := queryRow(ctx, sql, boundArgs...)
+	if err != nil {
+		return nil, trapError(err)
+	}
+	err = row.Scan(&f.FismaSystemID)
+
+	return &f, trapError(err)
+}
+
+func UpdateFismaSystem(ctx context.Context, f FismaSystem) (*FismaSystem, error) {
+	sqlb := sqlBuilder.Update("fismasystems").
+		Set("fismauid", f.FismaUID).
+		Set("fismaacronym", f.FismaAcronym).
+		Set("fismaname", f.FismaName).
+		Set("fismasubsystem", f.FismaSubsystem).
+		Set("component", f.Component).
+		Set("groupacronym", f.Groupacronym).
+		Set("groupname", f.GroupName).
+		Set("divisionname", f.DivisionName).
+		Set("datacenterenvironment", f.DataCenterEnvironment).
+		Set("datacallcontact", f.DataCallContact).
+		Set("issoemail", f.ISSOEmail).
+		Where("fismasystemid=?", f.FismaSystemID).
+		Suffix("RETURNING " + strings.Join(fismaSystemColumns, ", "))
+
+	sql, boundArgs, _ := sqlb.ToSql()
+	row, err := queryRow(ctx, sql, boundArgs...)
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	err = row.Scan(&f.FismaSystemID, &f.FismaUID, &f.FismaAcronym, &f.FismaName, &f.FismaSubsystem, &f.Component, &f.Groupacronym, &f.GroupName, &f.DivisionName, &f.DataCenterEnvironment, &f.DataCallContact, &f.ISSOEmail)
+
+	return &f, trapError(err)
 }

--- a/backend/cmd/api/internal/model/validations.go
+++ b/backend/cmd/api/internal/model/validations.go
@@ -13,6 +13,17 @@ var roles = map[string]interface{}{
 	"ISSM":  nil,
 }
 
+var datacenterenvironments = map[string]interface{}{
+	"Other":          nil,
+	"SaaS":           nil,
+	"CMS-Cloud-AWS":  nil,
+	"CMSDC":          nil,
+	"CMS-Cloud-MAG":  nil,
+	"AWS":            nil,
+	"OPDC":           nil,
+	"DECOMMISSIONED": nil,
+}
+
 var rgxUUID = regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
 
 func isValidEmail(email string) bool {
@@ -27,4 +38,9 @@ func isValidRole(role string) bool {
 
 func isValidUUID(uuid string) bool {
 	return rgxUUID.MatchString(uuid)
+}
+
+func isValidDataCenterEnvironment(d string) bool {
+	_, ok := datacenterenvironments[d]
+	return ok
 }

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -17,7 +17,10 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/datacalls/{datacallid:[0-9]+}/export", controller.GetDatacallExport).Methods("GET")
 
 	router.HandleFunc("/api/v1/fismasystems", controller.ListFismaSystems).Methods("GET")
+	router.HandleFunc("/api/v1/fismasystems", controller.SaveFismaSystem).Methods("POST")
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}", controller.GetFismaSystem).Methods("GET")
+	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}", controller.SaveFismaSystem).Methods("PUT")
+
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/questions", controller.ListQuestions).Methods("GET")
 
 	router.HandleFunc("/api/v1/functions/{functionid:[0-9]+}/options", controller.ListFunctionOptions).Methods("GET")


### PR DESCRIPTION
## Added
- 2 new routes: `POST fismasystems` and `PUT fismasystems/<id>` to create and update
- `SaveFismaSystem()` function to controller
- `isValid()`, `Save()`, `insertSql()`, and `updateSql()` methods to `*model.FismaSystem`
- migration to correct spelling of datacenterenvironment ("DECOMISSIONED" -> "DECOMMISSIONED")

## Changed
- refactored handling of fismasystem columns to reduce repetition
- refactored error handling to ensure `model.InvalidInputError` is properly returned
- included list of valid datacenter environments

closes #146 