### PR TITLE
feat: ability to add and edit datacalls

### DIFF
--- a/backend/cmd/api/internal/controller/datacalls.go
+++ b/backend/cmd/api/internal/controller/datacalls.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -14,6 +15,21 @@ import (
 func ListDataCalls(w http.ResponseWriter, r *http.Request) {
 	datacalls, err := model.FindDataCalls(r.Context())
 	respond(w, r, datacalls, err)
+}
+
+func GetDataCallByID(w http.ResponseWriter, r *http.Request) {
+	var datacallID int32
+	vars := mux.Vars(r)
+	if v, ok := vars["datacallid"]; !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	} else {
+		fmt.Sscan(v, &datacallID)
+	}
+
+	dc, err := model.FindDataCallByID(r.Context(), datacallID)
+
+	respond(w, r, dc, err)
 }
 
 func GetDatacallExport(w http.ResponseWriter, r *http.Request) {
@@ -57,4 +73,35 @@ func GetDatacallExport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.xlsx", strings.ReplaceAll(answers[0].DataCall, " ", "")))
 	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
 	file.Write(w)
+}
+
+func SaveDataCall(w http.ResponseWriter, r *http.Request) {
+	authdUser := auth.UserFromContext(r.Context())
+	if !authdUser.IsAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	d := &model.DataCall{}
+
+	err := getJSON(r.Body, d)
+	if err != nil {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+
+	vars := mux.Vars(r)
+	if v, ok := vars["datacallid"]; ok {
+		fmt.Sscan(v, &d.DataCallID)
+	}
+
+	err = d.Save(r.Context())
+
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	respond(w, r, d, nil)
 }

--- a/backend/cmd/api/internal/controller/functions.go
+++ b/backend/cmd/api/internal/controller/functions.go
@@ -25,7 +25,7 @@ func ListFunctions(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, functions, err)
 }
 
-func GetFunctionById(w http.ResponseWriter, r *http.Request) {
+func GetFunctionByID(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	ID, ok := vars["functionid"]
 	if !ok {

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -22,7 +22,7 @@ func ListUsers(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, users, err)
 }
 
-func GetUserById(w http.ResponseWriter, r *http.Request) {
+func GetUserByID(w http.ResponseWriter, r *http.Request) {
 	authdUser := auth.UserFromContext(r.Context())
 	if !authdUser.IsAdmin() {
 		respond(w, r, nil, ErrForbidden)

--- a/backend/cmd/api/internal/migrations/004_datacalls_new_columns.go
+++ b/backend/cmd/api/internal/migrations/004_datacalls_new_columns.go
@@ -1,0 +1,14 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"datacalls new columnds",
+		`ALTER TABLE IF EXISTS public.datacalls ADD COLUMN IF NOT EXISTS "emailsubject" varchar(100);
+		ALTER TABLE IF EXISTS public.datacalls ADD COLUMN IF NOT EXISTS "emailbody" varchar(2000);
+		ALTER TABLE IF EXISTS public.datacalls ADD COLUMN IF NOT EXISTS "emailsent" timestamp with time zone[];
+		`,
+		`ALTER TABLE IF EXISTS public.functions DROP COLUMN IF EXISTS emailsubject;
+		ALTER TABLE IF EXISTS public.functions DROP COLUMN IF EXISTS emailbody;
+		ALTER TABLE IF EXISTS public.functions DROP COLUMN IF EXISTS emailsent;
+		`)
+}

--- a/backend/cmd/api/internal/model/datacalls.go
+++ b/backend/cmd/api/internal/model/datacalls.go
@@ -9,17 +9,20 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-var dataCallColumns = []string{"datacallid", "datacall", "datecreated", "deadline"}
+var dataCallColumns = []string{"datacallid", "datacall", "datecreated", "deadline", "emailsubject", "emailbody", "emailsent"}
 
 type DataCall struct {
-	DataCallID  int32     `json:"datacallid"`
-	DataCall    string    `json:"datacall"`
-	DateCreated time.Time `json:"datecreated"`
-	Deadline    time.Time `json:"deadline"`
+	DataCallID   int32     `json:"datacallid"`
+	DataCall     string    `json:"datacall"`
+	DateCreated  time.Time `json:"datecreated"`
+	Deadline     time.Time `json:"deadline"`
+	EmailSubject *string   `json:"emailsubject"`
+	EmailBody    *string   `json:"emailbody"`
+	EmailSent    *string   `json:"emailsent"`
 }
 
 func (d *DataCall) fields() []any {
-	return []any{&d.DataCallID, &d.DataCall, &d.DateCreated, &d.Deadline}
+	return []any{&d.DataCallID, &d.DataCall, &d.DateCreated, &d.Deadline, &d.EmailSubject, &d.EmailBody, &d.EmailSent}
 }
 
 func (d *DataCall) Save(ctx context.Context) error {
@@ -37,8 +40,8 @@ func (d *DataCall) Save(ctx context.Context) error {
 	if d.DataCallID == 0 {
 		sql, boundArgs, _ = sqlBuilder.
 			Insert("datacalls").
-			Columns("datacall", "deadline").
-			Values(d.DataCall, d.Deadline).
+			Columns("datacall", "deadline", "emailsubject", "emailbody").
+			Values(d.DataCall, d.Deadline, d.EmailSubject, d.EmailBody).
 			Suffix("RETURNING " + strings.Join(dataCallColumns, ", ")).
 			ToSql()
 	} else {
@@ -46,6 +49,8 @@ func (d *DataCall) Save(ctx context.Context) error {
 			Update("datacalls").
 			Set("datacall", d.DataCall).
 			Set("deadline", d.Deadline).
+			Set("emailsubject", d.EmailSubject).
+			Set("emailbody", d.EmailBody).
 			Where("datacallid=?", d.DataCallID).
 			Suffix("RETURNING " + strings.Join(dataCallColumns, ", ")).
 			ToSql()

--- a/backend/cmd/api/internal/model/datacalls.go
+++ b/backend/cmd/api/internal/model/datacalls.go
@@ -3,20 +3,68 @@ package model
 import (
 	"context"
 	"log"
+	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 )
 
+var dataCallColumns = []string{"datacallid", "datacall", "datecreated", "deadline"}
+
 type DataCall struct {
-	DataCallID  int32   `json:"datacallid"`
-	DataCall    string  `json:"datacall"`
-	DateCreated float64 `json:"datecreated"`
-	Deadline    float64 `json:"deadline"`
+	DataCallID  int32     `json:"datacallid"`
+	DataCall    string    `json:"datacall"`
+	DateCreated time.Time `json:"datecreated"`
+	Deadline    time.Time `json:"deadline"`
+}
+
+func (d *DataCall) fields() []any {
+	return []any{&d.DataCallID, &d.DataCall, &d.DateCreated, &d.Deadline}
+}
+
+func (d *DataCall) Save(ctx context.Context) error {
+
+	var (
+		sql       string
+		boundArgs []any
+		err       error
+	)
+
+	// if valid, err := d.isValid(); !valid {
+	// 	return err
+	// }
+
+	if d.DataCallID == 0 {
+		sql, boundArgs, _ = sqlBuilder.
+			Insert("datacalls").
+			Columns("datacall", "deadline").
+			Values(d.DataCall, d.Deadline).
+			Suffix("RETURNING " + strings.Join(dataCallColumns, ", ")).
+			ToSql()
+	} else {
+		sql, boundArgs, _ = sqlBuilder.
+			Update("datacalls").
+			Set("datacall", d.DataCall).
+			Set("deadline", d.Deadline).
+			Where("datacallid=?", d.DataCallID).
+			Suffix("RETURNING " + strings.Join(dataCallColumns, ", ")).
+			ToSql()
+	}
+
+	row, err := queryRow(ctx, sql, boundArgs...)
+	if err != nil {
+		return trapError(err)
+	}
+
+	err = row.Scan(d.fields()...)
+
+	return trapError(err)
 }
 
 func FindDataCalls(ctx context.Context) ([]*DataCall, error) {
-	sqlb := sqlBuilder.Select("datacallid, datacall, EXTRACT(EPOCH FROM datecreated) as datecreated, EXTRACT(EPOCH FROM deadline) as deadline").
-		From("datacalls")
+	sqlb := sqlBuilder.Select(dataCallColumns...).
+		From("datacalls").
+		OrderBy("datecreated DESC")
 
 	sql, boundArgs, _ := sqlb.ToSql()
 	rows, err := query(ctx, sql, boundArgs...)
@@ -28,7 +76,25 @@ func FindDataCalls(ctx context.Context) ([]*DataCall, error) {
 
 	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (*DataCall, error) {
 		datacall := DataCall{}
-		err := rows.Scan(&datacall.DataCallID, &datacall.DataCall, &datacall.DateCreated, &datacall.Deadline)
+		err := row.Scan(datacall.fields()...)
 		return &datacall, trapError(err)
 	})
+}
+
+func FindDataCallByID(ctx context.Context, dataCallID int32) (*DataCall, error) {
+	sql, boundArgs, _ := sqlBuilder.
+		Select(dataCallColumns...).
+		From("datacalls").
+		Where("datacallid=?", dataCallID).
+		ToSql()
+
+	row, err := queryRow(ctx, sql, boundArgs...)
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	datacall := DataCall{}
+	err = row.Scan(datacall.fields()...)
+
+	return &datacall, err
 }

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -14,6 +14,10 @@ func Handler() http.Handler {
 	router.Use(auth.Middleware)
 
 	router.HandleFunc("/api/v1/datacalls", controller.ListDataCalls).Methods("GET")
+	router.HandleFunc("/api/v1/datacalls/{datacallid:[0-9]+}", controller.GetDataCallByID).Methods("GET")
+	router.HandleFunc("/api/v1/datacalls", controller.SaveDataCall).Methods("POST")
+	router.HandleFunc("/api/v1/datacalls/{datacallid:[0-9]+}", controller.SaveDataCall).Methods("PUT")
+
 	router.HandleFunc("/api/v1/datacalls/{datacallid:[0-9]+}/export", controller.GetDatacallExport).Methods("GET")
 
 	router.HandleFunc("/api/v1/fismasystems", controller.ListFismaSystems).Methods("GET")
@@ -29,7 +33,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/users", controller.ListUsers).Methods("GET")
 	router.HandleFunc("/api/v1/users", controller.SaveUser).Methods("POST")
 	router.HandleFunc("/api/v1/users/current", controller.GetCurrentUser).Methods("GET")
-	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.GetUserById).Methods("GET")
+	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.GetUserByID).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.SaveUser).Methods("PUT")
 
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems", controller.ListUserFismaSystems).Methods("GET")
@@ -47,7 +51,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/questions/{questionid:[0-9]+}", controller.SaveQuestion).Methods("PUT")
 
 	router.HandleFunc("/api/v1/functions", controller.ListFunctions).Methods("GET")
-	router.HandleFunc("/api/v1/functions/{functionid:[0-9]+}", controller.GetFunctionById).Methods("GET")
+	router.HandleFunc("/api/v1/functions/{functionid:[0-9]+}", controller.GetFunctionByID).Methods("GET")
 	router.HandleFunc("/api/v1/functions", controller.SaveFunction).Methods("POST")
 	router.HandleFunc("/api/v1/functions/{functionid:[0-9]+}", controller.SaveFunction).Methods("PUT")
 	return router


### PR DESCRIPTION
## Added
- routes for datacalls crud
- model.FindDataCallByID
- `dataCallColumns` as an array of column names to reduce repetition
- `(*DataCall).fields()` as a private method to reduce repetition when calling `row.Scan`
- migration to add new fields to datacalls table


## Changed
- `model.GetUserByID` and `model.GetFunctionByID` to conform to naming conventions


closes #146 