### PR TITLE
fix: refactored secrets and error handling, exiting on password error

### DIFF
--- a/backend/cmd/api/internal/model/model.go
+++ b/backend/cmd/api/internal/model/model.go
@@ -19,7 +19,7 @@ var sqlBuilder = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
 func query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, trapError(err)
 	}
 
 	return conn.Query(ctx, sql, args...)
@@ -29,7 +29,7 @@ func query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
 func queryRow(ctx context.Context, sql string, args ...any) (pgx.Row, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, trapError(err)
 	}
 
 	row := conn.QueryRow(ctx, sql, args...)

--- a/backend/internal/db/conn.go
+++ b/backend/internal/db/conn.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"log"
 	"sync"
-	"time"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/secrets"
@@ -64,15 +63,10 @@ func getDbCreds() (*dbCreds, error) {
 		}
 	}
 
-	// if the secret was rotated, refresh it
-	if time.Now().UTC().After(*dbSecret.NextRotationDate()) {
-		err = dbSecret.Refresh()
-		if err != nil {
-			return nil, err
-		}
+	secVal, err := dbSecret.Value()
+	if err != nil {
+		return nil, err
 	}
-
-	secVal := dbSecret.Value()
 	creds := &dbCreds{}
 	err = json.Unmarshal([]byte(*secVal), creds)
 	if err != nil {


### PR DESCRIPTION
## Added
nothing new

## Changed
Refactored db and secrets packages to move refreshing into the scope of secrets.
Refactored db conn to trap errors
Refactored model errors to unwrap and exit on password errors. This is not ideal but it will kill the container, force ECS to respawn and from there pick up the latest secret. 
Added logging in an effort to gain more visibility into why this continues to happen despite best attempts and caching and rotation