### PR TITLE
feat: creating new datacall now copies scores associated to previous datacall

### DIFF
--- a/backend/cmd/api/internal/migrations/006_scores_datacall_constraint.go
+++ b/backend/cmd/api/internal/migrations/006_scores_datacall_constraint.go
@@ -1,0 +1,10 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"scores datacallid constraint",
+		`ALTER TABLE public.scores DROP CONSTRAINT IF EXISTS scores_datacallid_fkey;
+		ALTER TABLE public.scores ADD CONSTRAINT scores_datacallid_fkey FOREIGN KEY (datacallid) REFERENCES datacalls(datacallid) ON DELETE CASCADE;
+		`,
+		``)
+}


### PR DESCRIPTION
## Added
- migration to ensure proper foreign key constraint on `scores.datacallid`
- function in `model` to find previous datacall
- function in `model` to copy scores from the previous datacall

closes #164 