### PR TITLE
refactor:  use gorilla/schema decoder in all controllers where r.URL.Query() is needed

### DIFF
--- a/backend/cmd/api/internal/controller/events.go
+++ b/backend/cmd/api/internal/controller/events.go
@@ -8,9 +8,7 @@ import (
 
 func GetEvents(w http.ResponseWriter, r *http.Request) {
 	findEventsInput := &model.FindEventsInput{}
-
-	v := r.URL.Query()
-	err := decoder.Decode(findEventsInput, v)
+	err := decoder.Decode(findEventsInput, r.URL.Query())
 	if err != nil {
 		respond(w, r, nil, err)
 		return

--- a/backend/cmd/api/internal/controller/functions.go
+++ b/backend/cmd/api/internal/controller/functions.go
@@ -11,16 +11,16 @@ import (
 
 func ListFunctions(w http.ResponseWriter, r *http.Request) {
 
-	input := model.FindFunctionsInput{}
+	var (
+		functions []*model.Function
+		err       error
+	)
 
-	q := r.URL.Query()
-	if q.Has("questionid") {
-		var questionID int32
-		fmt.Sscan(q.Get("questionid"), &questionID)
-		input.QuestionID = &questionID
+	findFunctionsInput := model.FindFunctionsInput{}
+	err = decoder.Decode(&findFunctionsInput, r.URL.Query())
+	if err == nil {
+		functions, err = model.FindFunctions(r.Context(), findFunctionsInput)
 	}
-
-	functions, err := model.FindFunctions(r.Context(), input)
 	respond(w, r, functions, err)
 }
 

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -10,27 +10,23 @@ import (
 )
 
 func ListScores(w http.ResponseWriter, r *http.Request) {
+
+	var (
+		scores []*model.Score
+		err    error
+	)
 	user := model.UserFromContext(r.Context())
-	input := model.FindScoresInput{}
+	findScoresInput := model.FindScoresInput{}
 
 	if !user.IsAdmin() {
-		input.UserID = &user.UserID
+		findScoresInput.UserID = &user.UserID
 	}
 
-	vars := r.URL.Query()
-	if vars.Has("datacallid") {
-		var dataCallID int32
-		fmt.Sscan(vars.Get("datacallid"), &dataCallID)
-		input.DataCallID = &dataCallID
+	err = decoder.Decode(&findScoresInput, r.URL.Query())
+	if err == nil {
+		scores, err = model.FindScores(r.Context(), findScoresInput)
 	}
 
-	if vars.Has("fismasystemid") {
-		var fismaSystemID int32
-		fmt.Sscan(vars.Get("fismasystemid"), &fismaSystemID)
-		input.FismaSystemID = &fismaSystemID
-	}
-
-	scores, err := model.FindScores(r.Context(), input)
 	respond(w, r, scores, err)
 }
 
@@ -66,21 +62,22 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetScoresAggregate(w http.ResponseWriter, r *http.Request) {
+	var (
+		aggregate []*model.ScoreAggregate
+		err       error
+	)
+
 	user := model.UserFromContext(r.Context())
-	input := model.FindScoresInput{}
+	findScoresInput := model.FindScoresInput{}
 
 	if !user.IsAdmin() {
-		input.FismaSystemIDs = user.AssignedFismaSystems
+		findScoresInput.FismaSystemIDs = user.AssignedFismaSystems
 	}
 
-	vars := r.URL.Query()
-	if vars.Has("datacallid") {
-		var dataCallID int32
-		fmt.Sscan(vars.Get("datacallid"), &dataCallID)
-		input.DataCallID = &dataCallID
+	err = decoder.Decode(&findScoresInput, r.URL.Query())
+	if err == nil {
+		aggregate, err = model.FindScoresAggregate(r.Context(), findScoresInput)
 	}
-
-	aggregate, err := model.FindScoresAggregate(r.Context(), input)
 
 	respond(w, r, aggregate, err)
 }

--- a/backend/cmd/api/internal/model/answers.go
+++ b/backend/cmd/api/internal/model/answers.go
@@ -22,7 +22,7 @@ type Answer struct {
 }
 
 type FindAnswersInput struct {
-	FismaSystemIDs []*int32
+	FismaSystemIDs []*int32 `schema:"fsids"`
 	DataCallID     int32
 	UserID         *string
 }

--- a/backend/cmd/api/internal/model/functions.go
+++ b/backend/cmd/api/internal/model/functions.go
@@ -20,7 +20,7 @@ type Function struct {
 }
 
 type FindFunctionsInput struct {
-	QuestionID            *int32
+	QuestionID            *int32 `schema:"questionid"`
 	PillarID              *int32
 	DataCenterEnvironment *string
 }

--- a/backend/cmd/api/internal/model/scores.go
+++ b/backend/cmd/api/internal/model/scores.go
@@ -48,9 +48,9 @@ type ScoreAggregate struct {
 }
 
 type FindScoresInput struct {
-	FismaSystemID  *int32
+	FismaSystemID  *int32 `schema:"fismasystemid"`
 	FismaSystemIDs []*int32
-	DataCallID     *int32
+	DataCallID     *int32 `schema:"datacallid"`
 	UserID         *string
 }
 


### PR DESCRIPTION
## Added
nothing new

## Changed
Replaced complex retrieval and conversion of query string parameters with `decoder.Decode` and applied relevant `schema` tags to model input structs

closes #165 