### PR TITLE
fix: refresh secrets if within 23 hours of next rotation date

### DIFF
--- a/backend/internal/secrets/secrets.go
+++ b/backend/internal/secrets/secrets.go
@@ -22,8 +22,12 @@ type Secret struct {
 func (s *Secret) Value() (*string, error) {
 	if s.metadata.NextRotationDate != nil {
 		// if the secret was rotated, refresh it
-		// TODO: change this to check if now is after NextRotationDate-23 hours
+		// secrets manager may actually rotate many hours before the NextRotationDate
+		// time.Sub returns a time.Duration, whereas time.Add can accept a negative number as input and return time.Time
 		now := time.Now().UTC()
+		log.Println("now", now)
+		now = now.Add(time.Duration(-23) * time.Hour).UTC()
+		log.Println("now -23h", now)
 		if now.After(*s.metadata.NextRotationDate) {
 			err := s.Refresh()
 			if err != nil {

--- a/backend/internal/secrets/secrets.go
+++ b/backend/internal/secrets/secrets.go
@@ -24,10 +24,7 @@ func (s *Secret) Value() (*string, error) {
 		// if the secret was rotated, refresh it
 		// secrets manager may actually rotate many hours before the NextRotationDate
 		// time.Sub returns a time.Duration, whereas time.Add can accept a negative number as input and return time.Time
-		now := time.Now().UTC()
-		log.Println("now", now)
-		now = now.Add(time.Duration(-23) * time.Hour).UTC()
-		log.Println("now -23h", now)
+		now := time.Now().Add(time.Duration(-23) * time.Hour).UTC()
 		if now.After(*s.metadata.NextRotationDate) {
 			err := s.Refresh()
 			if err != nil {


### PR DESCRIPTION
## Added
nothing new

## Changed
- refactored secrets library to refresh secrets if they were within 23 hours of the next rotation date because secrets manager has been known to rotate secrets as much as 16 hours in advance


closes #178 