### PR TITLE
implemented soft delete feature for users resource

### DIFF
--- a/backend/_test_data.sql
+++ b/backend/_test_data.sql
@@ -1,3 +1,3 @@
 
-INSERT INTO public.users VALUES (DEFAULT, 'test.user@nowhere.xyz', 'Admin User', 'ADMIN') ON CONFLICT DO NOTHING;
+INSERT INTO public.users VALUES (DEFAULT, 'test.user@nowhere.xyz', 'Admin User', 'ADMIN', DEFAULT) ON CONFLICT DO NOTHING;
 INSERT INTO public.pillars VALUES (DEFAULT, 'TEST pillar', 1);

--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -44,6 +44,12 @@ func Middleware(next http.Handler) http.Handler {
 				return
 			}
 
+			if user.Deleted {
+				log.Printf("user with email: %s was deleted but tried logging in\n", claims.Email)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+
 			ctx := model.UserToContext(r.Context(), user)
 			r = r.WithContext(ctx)
 		}

--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -38,7 +38,7 @@ func respond(w http.ResponseWriter, r *http.Request, data any, err error) {
 		Data: data,
 	}
 
-	if err == nil && data == nil {
+	if err == nil && (data == nil && status != 204) {
 		err = ErrNotFound
 	}
 

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -78,3 +78,28 @@ func SaveUser(w http.ResponseWriter, r *http.Request) {
 
 	respond(w, r, user, nil)
 }
+
+// DeleteUser handles the deletion of a user
+func DeleteUser(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.IsAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	vars := mux.Vars(r)
+	userID, ok := vars["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	err := model.DeleteUser(r.Context(), userID)
+	if err != nil {
+		log.Println(err)
+		respond(w, r, nil, err)
+		return
+	}
+
+	respond(w, r, nil, nil)
+}

--- a/backend/cmd/api/internal/migrations/008_users_soft_delete.go
+++ b/backend/cmd/api/internal/migrations/008_users_soft_delete.go
@@ -1,0 +1,9 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		// add soft delete capability
+		"users table role type",
+		`ALTER TABLE IF EXISTS public.users ADD COLUMN deleted boolean NOT NULL DEFAULT FALSE;`,
+		`ALTER TABLE IF EXISTS public.users DROP COLUMN IF EXISTS deleted;`)
+}

--- a/backend/cmd/api/internal/model/users.go
+++ b/backend/cmd/api/internal/model/users.go
@@ -112,3 +112,19 @@ func findUser(ctx context.Context, where string, args []any) (*User, error) {
 
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[User])
 }
+
+// DeleteUser marks a user as deleted in the database
+func DeleteUser(ctx context.Context, userid string) error {
+	if !isValidUUID(userid) {
+		return ErrNoData
+	}
+
+	sqlb := stmntBuilder.
+		Update("users").
+		Set("deleted", true).
+		Where("userid=?", userid).
+		Suffix("RETURNING userid")
+
+	_, err := queryRow(ctx, sqlb, pgx.RowTo[string])
+	return err
+}

--- a/backend/cmd/api/internal/model/users.go
+++ b/backend/cmd/api/internal/model/users.go
@@ -35,10 +35,12 @@ func (u *User) Save(ctx context.Context) (*User, error) {
 
 	var sqlb SqlBuilder
 
+	// deleted column is intentionally left out as it cannot be set by an update, and on create it defaults to false
+	// it must be set via explicit delete. See DeleteUser below
 	if u.UserID == "" {
 		sqlb = stmntBuilder.
 			Insert("users").
-			Columns("email", "fullname", "role", "delete").
+			Columns("email", "fullname", "role").
 			Values(u.Email, u.FullName, u.Role).
 			Suffix("RETURNING userid, email, fullname, role, deleted")
 	} else {
@@ -47,7 +49,6 @@ func (u *User) Save(ctx context.Context) (*User, error) {
 			Set("email", u.Email).
 			Set("fullname", u.FullName).
 			Set("role", u.Role).
-			Set("deleted", u.Deleted).
 			Where("userid=?", u.UserID).
 			Suffix("RETURNING userid, email, fullname, role, deleted")
 	}

--- a/backend/cmd/api/internal/model/users.go
+++ b/backend/cmd/api/internal/model/users.go
@@ -105,7 +105,7 @@ func FindUserByEmail(ctx context.Context, email string) (*User, error) {
 
 func findUser(ctx context.Context, where string, args []any) (*User, error) {
 	sqlb := stmntBuilder.
-		Select("users.userid, email, fullname, role, ARRAY_AGG(fismasystemid) AS assignedfismasystems").
+		Select("users.userid, email, fullname, role, deleted, ARRAY_AGG(fismasystemid) AS assignedfismasystems").
 		From("users").
 		LeftJoin("users_fismasystems on users_fismasystems.userid=users.userid").
 		Where(where, args...).
@@ -124,8 +124,8 @@ func DeleteUser(ctx context.Context, userid string) error {
 		Update("users").
 		Set("deleted", true).
 		Where("userid=?", userid).
-		Suffix("RETURNING userid")
+		Suffix("RETURNING userid, email, fullname, role, deleted")
 
-	_, err := queryRow(ctx, sqlb, pgx.RowTo[string])
+	_, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
 	return err
 }

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -35,6 +35,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/users/current", controller.GetCurrentUser).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.GetUserByID).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.SaveUser).Methods("PUT")
+	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.DeleteUser).Methods("DELETE")
 
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems", controller.ListUserFismaSystems).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems", controller.CreateUserFismaSystem).Methods("POST")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -391,7 +391,13 @@ tests:
       headers:
         content-type: "application/json"
 
-
+  - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
+    method: DELETE
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 204
+  
   # # Scores Endpoints
   # - id: createScore
   #   url: http://localhost:8080/api/v1/scores

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -69,6 +69,12 @@ updatedUserData: &updatedUserData
   fullname: "Updated Test User"
   role: "ISSO"
 
+deletedUserData: &deletedUserData
+  email: "updated.user@example.com"
+  fullname: "Updated Test User"
+  role: "ISSO"
+  deleted: true
+
 questionData: &questionData
   question: "How do you manage user identities?"
   notesprompt: "Provide details about your identity management approach"
@@ -397,7 +403,20 @@ tests:
       <<: *commonHeaders
     expect:
       status: 204
-  
+    
+  - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            <<: *deletedUserData
+
   # # Scores Endpoints
   # - id: createScore
   #   url: http://localhost:8080/api/v1/scores


### PR DESCRIPTION
## Added
- migration to add `delete` column to users table

## Changed
- model/users FindUsers() now returns only users where delete=false
- auth now returns http 401 unauthorized when deleted user tries to log in

closes #184 