### PR TITLE
feat: ability to filter list of users via query string parameters

### DIFF
--- a/.github/workflows/orchestration-dev.yml
+++ b/.github/workflows/orchestration-dev.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   analysis:
-    if: github.event.pull_request.draft == false
     name: Analysis
     uses: ./.github/workflows/analysis.yml
     secrets: inherit

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -9,6 +9,10 @@ import (
 )
 
 func ListUsers(w http.ResponseWriter, r *http.Request) {
+	var (
+		users []*model.User
+		err   error
+	)
 	// TODO: replace the repititious admin checks with ACL
 	authdUser := model.UserFromContext(r.Context())
 	if !authdUser.IsAdmin() {
@@ -16,7 +20,11 @@ func ListUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	users, err := model.FindUsers(r.Context())
+	findUsersInput := &model.FindUsersInput{}
+	err = decoder.Decode(findUsersInput, r.URL.Query())
+	if err == nil {
+		users, err = model.FindUsers(r.Context(), findUsersInput)
+	}
 
 	respond(w, r, users, err)
 }

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -396,6 +396,51 @@ tests:
       status: 200
       headers:
         content-type: "application/json"
+  
+  # list users with invalid input should return 400
+  - url: http://localhost:8080/api/v1/users?role=adnim
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 400
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          error: "invalid input"
+          data: 
+            role: "adnim"
+  
+  # list users with partial email should return a list of users
+  - url: http://localhost:8080/api/v1/users?email=example.com
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+  
+  # list users with correct role should return a list of users
+  - url: http://localhost:8080/api/v1/users?role=ADMIN
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+  
+  # list users with partial name should return a list of users
+  - url: http://localhost:8080/api/v1/users?fullname=Test+User
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
 
   - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
     method: DELETE


### PR DESCRIPTION
## Added
- model/users `FindUsersInput` type

## Changed
- `controller.ListUsers` now hydrates `FindUsersInput` and passes to `model.FindUsers`
- `model.FindUsers` now filters based on all fields of `FindUsersInput` that are present in the request

## Usage
To filter list of users, append the following query string parameters in any order in any combination:
`?role=string&email=string&fullname=string&deleted=bool`

`role` and `deleted` will be used as an exact match
`email` and `fullname` will be used as a loose match e.g.: `email=cms.hss.gov` will return all users with that as part of their email, `fullname=bob` will return all users with "bob" anywhere in their name

closes #189