### PR TITLE
refactor: added unique constraint to datacalls.datacall

### DIFF
--- a/backend/cmd/api/internal/migrations/0013datacallsunique.go
+++ b/backend/cmd/api/internal/migrations/0013datacallsunique.go
@@ -1,0 +1,13 @@
+package migrations
+
+// new column: datacalls.completed is intended for marking a data call complete per fisma system
+// every id in the array indicates
+
+func init() {
+	getMigrator().AppendMigration(
+		"datacalls unique data call column",
+		`ALTER TABLE IF EXISTS public.datacalls DROP CONSTRAINT IF EXISTS datacall_key;
+		ALTER TABLE IF EXISTS public.datacalls ADD CONSTRAINT datacall_key UNIQUE (datacall);
+		`,
+		`ALTER TABLE IF EXISTS public.datacalls DROP CONSTRAINT IF EXISTS datacall_key;`)
+}


### PR DESCRIPTION
## Added
- migration to add unique constraint to datacalls.datacall

This will ensure that no 2 datacalls will share the same name 

## Changed
none

closes #195 