### PR TITLE
feat: scores include functionoption

### DIFF
--- a/backend/cmd/api/internal/model/functionoptions.go
+++ b/backend/cmd/api/internal/model/functionoptions.go
@@ -6,6 +6,10 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+var (
+	functionOptionColumns = []string{"functionoptions.functionoptionid", "functionid", "score", "optionname", "description"}
+)
+
 type FunctionOption struct {
 	FunctionOptionID int32  `json:"functionoptionid"`
 	FunctionID       int32  `json:"functionid"`
@@ -20,7 +24,7 @@ type FindFunctionOptionsInput struct {
 
 func FindFunctionOptions(ctx context.Context, input FindFunctionOptionsInput) ([]*FunctionOption, error) {
 	sqlb := stmntBuilder.
-		Select("functionoptionid,functionid,score,optionname,description").
+		Select(functionOptionColumns...).
 		From("functionoptions")
 
 	if input.FunctionID != nil {

--- a/backend/cmd/api/internal/model/model.go
+++ b/backend/cmd/api/internal/model/model.go
@@ -21,7 +21,7 @@ type input struct {
 	m       map[string]any
 }
 
-func (i *input) includes(key string) bool {
+func (i *input) contains(key string) bool {
 	if i.m == nil {
 		i.m = map[string]any{}
 		for _, s := range i.Include {

--- a/backend/cmd/api/internal/model/model.go
+++ b/backend/cmd/api/internal/model/model.go
@@ -16,6 +16,23 @@ import (
 // uses the PostgreSQL $1,$2,... format of placeholders
 var stmntBuilder = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
 
+type input struct {
+	Include []string `schema:"include"`
+	m       map[string]any
+}
+
+func (i *input) includes(key string) bool {
+	if i.m == nil {
+		i.m = map[string]any{}
+		for _, s := range i.Include {
+			i.m[s] = nil
+		}
+	}
+
+	_, ok := i.m[key]
+	return ok
+}
+
 // SqlBuilder allows methods to receive different types like squirrel.InsertBuilder, squirrel.UpdateBuilder, etc. that all implement the ToSql method
 type SqlBuilder interface {
 	ToSql() (string, []interface{}, error)

--- a/backend/cmd/api/internal/model/scores.go
+++ b/backend/cmd/api/internal/model/scores.go
@@ -81,7 +81,7 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 		Select("scoreid, scores.fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, scores.functionoptionid, scores.datacallid").
 		From("scores")
 
-	if input.includes("functionoption") {
+	if input.contains("functionoption") {
 		sqlb = sqlb.
 			Columns(functionOptionColumns...).
 			InnerJoin("functionoptions on functionoptions.functionoptionid=scores.functionoptionid")
@@ -102,7 +102,7 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 	return query(ctx, sqlb, func(row pgx.CollectableRow) (*Score, error) {
 		score := Score{}
 		fields := []any{&score.ScoreID, &score.FismaSystemID, &score.DateCalculated, &score.Notes, &score.FunctionOptionID, &score.DataCallID}
-		if input.includes("functionoption") {
+		if input.contains("functionoption") {
 			score.FunctionOption = &FunctionOption{}
 			fields = append(fields, &score.FunctionOption.FunctionOptionID, &score.FunctionOption.FunctionID, &score.FunctionOption.Score, &score.FunctionOption.OptionName, &score.FunctionOption.Description)
 		}


### PR DESCRIPTION
## Added
- `input` type in the model which is used for embedding into `find<resource>Input` structs

## Changed
- extended the `model/FindScores` and `FindScoresInput` to allow including the `functionoption` sub resource

## Usage
```
/api/v1/scores?datacallid=<int>&fismasystemid=<int>&include=functionoption
```

Where `include` is optional and currently only supports `functionoption` as a value

closes #194 