### PR TITLE
fix: resolved issue where save returned error cannot find field FunctionOption

### DIFF
--- a/backend/cmd/api/internal/model/scores.go
+++ b/backend/cmd/api/internal/model/scores.go
@@ -44,7 +44,7 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			Where("scoreid=?", s.ScoreID).
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, functionoptionid, datacallid")
 	}
-	return queryRow(ctx, sqlb, pgx.RowToStructByName[Score])
+	return queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
 }
 
 func (s *Score) validate(ctx context.Context) error {


### PR DESCRIPTION
## Added
non

## Changed
- fixed issue with model function to covert DB record to Scores struct, ignoring FunctionOption field when not present