### PR TITLE
fix: update PostgreSQL engine version to 16.6

### DIFF
--- a/infrastructure/rds.tf
+++ b/infrastructure/rds.tf
@@ -21,7 +21,7 @@ resource "aws_rds_cluster" "ztmf" {
   cluster_identifier          = "ztmf"
   engine                      = "aurora-postgresql"
   engine_mode                 = "provisioned"
-  engine_version              = "16.1"
+  engine_version              = "16.6"
   database_name               = "ztmf"
   db_subnet_group_name        = aws_db_subnet_group.ztmf.name
   master_username             = data.aws_secretsmanager_secret_version.ztmf_db_user_current.secret_string


### PR DESCRIPTION
## Problem

AWS automatically upgraded the RDS Aurora PostgreSQL cluster from version 16.1 to 16.6 during a maintenance window. When Terraform tries to deploy, it attempts to "correct" this by downgrading back to 16.1, which AWS RDS does not allow.

**Error encountered:**
```
Error: updating RDS Cluster (ztmf): operation error RDS: ModifyDBCluster, 
https response error StatusCode: 400, RequestID: 2e33d1fc-835f-4768-9f19-6791e7028602, 
api error InvalidParameterCombination: Cannot upgrade aurora-postgresql from 16.6 to 16.1
```

## Solution

Update the Terraform configuration to match the current AWS reality by changing `engine_version` from "16.1" to "16.6" in the RDS cluster resource.

## Changes

- Updated `infrastructure/rds.tf` PostgreSQL engine version from 16.1 to 16.6
- No functional changes to the database or application
- Resolves deployment failures in CI/CD pipeline

## Testing

- [x] Verified AWS RDS cluster is currently running PostgreSQL 16.6
- [x] Confirmed this change aligns Terraform config with AWS state
- [x] No application code changes required (PostgreSQL 16.6 is backward compatible)

## Impact

- ✅ Fixes failed deployments
- ✅ Aligns infrastructure code with AWS reality  
- ✅ No downtime or application impact
- ✅ Maintains database compatibility

This is a critical infrastructure fix needed to unblock deployments.