### PR TITLE
Fix Lambda deployment order issue

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -122,16 +122,24 @@ jobs:
           LAMBDA_FUNCTION="ztmf-data-sync-${ENV_LOWER}"
           LAMBDA_BUCKET="ztmf-lambda-deployments-${ENV_LOWER}"
           
-          echo "Updating Lambda function: $LAMBDA_FUNCTION"
-          echo "Using deployment package: s3://$LAMBDA_BUCKET/lambda-deployment-${{ steps.revParse.outputs.shaShort }}.zip"
+          echo "Checking if Lambda function exists: $LAMBDA_FUNCTION"
           
-          # Update Lambda function code
-          aws lambda update-function-code \
-            --function-name $LAMBDA_FUNCTION \
-            --s3-bucket $LAMBDA_BUCKET \
-            --s3-key lambda-deployment-${{ steps.revParse.outputs.shaShort }}.zip
-          
-          echo "Lambda function updated successfully"
+          # Check if Lambda function exists before trying to update
+          if aws lambda get-function --function-name $LAMBDA_FUNCTION >/dev/null 2>&1; then
+            echo "Updating existing Lambda function: $LAMBDA_FUNCTION"
+            echo "Using deployment package: s3://$LAMBDA_BUCKET/lambda-deployment-${{ steps.revParse.outputs.shaShort }}.zip"
+            
+            # Update Lambda function code
+            aws lambda update-function-code \
+              --function-name $LAMBDA_FUNCTION \
+              --s3-bucket $LAMBDA_BUCKET \
+              --s3-key lambda-deployment-${{ steps.revParse.outputs.shaShort }}.zip
+            
+            echo "Lambda function updated successfully"
+          else
+            echo "Lambda function doesn't exist yet - will be created by infrastructure workflow"
+            echo "Deployment package ready at: s3://$LAMBDA_BUCKET/lambda-deployment-${{ steps.revParse.outputs.shaShort }}.zip"
+          fi
         
       - name: AWS - SSM Put Parameter
         run: aws ssm put-parameter --name ${{ secrets.PARAMETER_NAME }} --value ${{ steps.revParse.outputs.shaShort }} --overwrite


### PR DESCRIPTION
## Problem

Backend workflow fails when trying to update Lambda function that doesn't exist yet:
```
ResourceNotFoundException: Function not found: ztmf-data-sync-prod
```

This happens because:
1. Backend workflow runs first (builds + uploads Lambda)
2. Infrastructure workflow runs second (creates Lambda function)  
3. Backend tries to update non-existent function → fails

## Solution

Make Lambda function update conditional:
- Check if function exists before attempting update
- If exists: Update with new deployment package  
- If not exists: Log message and continue (infrastructure will create it)

## Benefits

- ✅ Backend workflow succeeds regardless of Lambda function state
- ✅ Initial deployments work correctly 
- ✅ Subsequent deployments update existing functions
- ✅ No changes to infrastructure workflow needed

## Test Plan

- [x] Backend workflow succeeds when Lambda doesn't exist
- [ ] Backend workflow succeeds when Lambda exists  
- [ ] Infrastructure workflow creates Lambda with uploaded package
- [ ] Subsequent updates work normally

This resolves deployment order dependencies without changing the overall workflow structure.