### PR TITLE
Fix EventBridge cron expression syntax for quarterly scheduling

### DIFF
--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -79,8 +79,8 @@ resource "aws_cloudwatch_event_rule" "ztmf_sync_schedule" {
   name        = "ztmf-data-sync-schedule-${var.environment}"
   description = "Schedule for ZTMF data synchronization to Snowflake"
 
-  # Different schedules per environment
-  schedule_expression = var.environment == "prod" ? "cron(0 2 1 */3 * ? *)" : "cron(0 9 ? * MON *)"
+  # Different schedules per environment  
+  schedule_expression = var.environment == "prod" ? "cron(0 2 1 */3 * ?)" : "cron(0 9 ? * MON *)"
 
   tags = {
     Name        = "ZTMF Data Sync Schedule"

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -79,8 +79,8 @@ resource "aws_cloudwatch_event_rule" "ztmf_sync_schedule" {
   name        = "ztmf-data-sync-schedule-${var.environment}"
   description = "Schedule for ZTMF data synchronization to Snowflake"
 
-  # Different schedules per environment  
-  schedule_expression = var.environment == "prod" ? "cron(0 2 1 */3 * ?)" : "cron(0 9 ? * MON *)"
+  # Different schedules per environment (6-field cron format: minutes hours day month day-of-week year)
+  schedule_expression = var.environment == "prod" ? "cron(0 2 1 1,4,7,10 ? *)" : "cron(0 9 ? * MON *)"
 
   tags = {
     Name        = "ZTMF Data Sync Schedule"


### PR DESCRIPTION
## Problem

EventBridge rule creation failing in production deployment:
```
ValidationException: Parameter ScheduleExpression is not valid
```

## Root Cause

AWS EventBridge cron expressions must use explicit month values for quarterly scheduling, not `*/3` syntax.

## Solution

**Before (Invalid):**
```
cron(0 2 1 */3 * ? *)  # Invalid */3 syntax
```

**After (Correct):**
```
cron(0 2 1 1,4,7,10 ? *)  # Explicit quarterly months
```

## Schedule Details

- **Production**: 1st day of January, April, July, October at 2 AM UTC (true quarterly)
- **Development**: Every Monday at 9 AM UTC (weekly testing)

## Impact

This completes the Lambda infrastructure deployment in production where:
- ✅ Lambda function created successfully  
- ✅ S3 bucket and IAM roles deployed
- ❌ EventBridge scheduling blocked by invalid cron syntax

## Test Plan

- [x] Terraform validates locally
- [ ] EventBridge rule deploys successfully
- [ ] Quarterly scheduling works as expected