### PR TITLE
Fix EventBridge quarterly scheduling cron expression

### DIFF
--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -79,8 +79,8 @@ resource "aws_cloudwatch_event_rule" "ztmf_sync_schedule" {
   name        = "ztmf-data-sync-schedule-${var.environment}"
   description = "Schedule for ZTMF data synchronization to Snowflake"
 
-  # Different schedules per environment  
-  schedule_expression = var.environment == "prod" ? "cron(0 2 1 */3 * ?)" : "cron(0 9 ? * MON *)"
+  # Different schedules per environment (6-field cron format: minutes hours day month day-of-week year)
+  schedule_expression = var.environment == "prod" ? "cron(0 2 1 1,4,7,10 ? *)" : "cron(0 9 ? * MON *)"
 
   tags = {
     Name        = "ZTMF Data Sync Schedule"


### PR DESCRIPTION
## Problem

EventBridge rule creation failing in production deployment:
```
ValidationException: Parameter ScheduleExpression is not valid
```

## Root Cause

AWS EventBridge doesn't support `*/3` syntax for quarterly scheduling in cron expressions.

## Solution

Use explicit quarterly months instead:

**Before (Invalid):**
```
cron(0 2 1 */3 * ?)  # */3 not supported
```

**After (Correct):**
```
cron(0 2 1 1,4,7,10 ? *)  # Explicit quarterly months
```

## Schedule Details

- **Production**: January 1st, April 1st, July 1st, October 1st at 2 AM UTC
- **Development**: Every Monday at 9 AM UTC (unchanged)

## Impact

This unblocks the Lambda infrastructure deployment where:
- ✅ Lambda function created successfully
- ✅ IAM roles and monitoring deployed  
- ❌ EventBridge scheduling blocked by invalid cron syntax

## Test Plan

- [x] Terraform validates locally
- [ ] EventBridge rule deploys successfully
- [ ] Quarterly scheduling configured correctly