### PR TITLE
Implement MERGE/upsert for faster Snowflake sync without TRUNCATE

### DIFF
--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_event_target" "ztmf_sync_lambda" {
   input = jsonencode({
     trigger_type = "scheduled"
     tables       = [] # Empty means sync all tables
-    full_refresh = true
+    full_refresh = false # Use MERGE/upsert for better performance
     dry_run      = var.environment != "prod"
   })
 }


### PR DESCRIPTION
## Problem

Current Lambda sync using TRUNCATE + INSERT has issues:
- **Performance**: TRUNCATE operations hang for 5+ minutes
- **Timeouts**: Lambda hitting 15-minute limit due to slow TRUNCATE
- **Permissions**: Requires TRUNCATE permissions causing access control errors

## Solution: MERGE/Upsert Operations

Implement Snowflake MERGE statements for efficient incremental sync:

### **MERGE Approach:**
1. **Stage data** in temporary table
2. **MERGE with target** table using primary keys
3. **UPDATE existing** records + **INSERT new** records
4. **Single operation** replaces TRUNCATE + INSERT

### **Benefits:**
- ✅ **Faster**: No table locking delays from TRUNCATE
- ✅ **No permission issues**: Only needs INSERT/UPDATE (not DELETE/TRUNCATE)
- ✅ **Incremental**: Updates changed records, inserts new ones
- ✅ **Atomic**: Single transaction for all changes
- ✅ **Scalable**: Handles large datasets efficiently

## Implementation

### **Table Configuration:**
Added primary key mapping for all 10 ZTMF tables:
- Single key: `users` (userid), `scores` (scoreid), etc.
- Composite key: `users_fismasystems` (userid, fismasystemid)

### **Sync Logic:**
- **Incremental sync** (`full_refresh: false`): Uses MERGE (recommended)
- **Full refresh** (`full_refresh: true`): Still uses TRUNCATE + INSERT (if needed)
- **Default scheduled**: Changed to incremental for better performance

### **MERGE SQL Example:**
```sql
MERGE INTO ZTMF_USERS AS target
USING TEMP_TABLE AS source  
ON target.USERID = source.USERID
WHEN MATCHED THEN UPDATE SET fullname = source.fullname, email = source.email
WHEN NOT MATCHED THEN INSERT (userid, fullname, email) VALUES (source.userid, source.fullname, source.email)
```

## Test Plan

- [x] Lambda compiles successfully
- [ ] MERGE operations complete faster than TRUNCATE
- [ ] Incremental sync handles all 10 tables within timeout
- [ ] Data integrity maintained (updates + inserts work correctly)

This eliminates the timeout and permission issues while providing better performance for quarterly data sync operations.