### PR TITLE
Reorder Snowflake session init to set role first

### DIFF
--- a/backend/internal/export/snowflake.go
+++ b/backend/internal/export/snowflake.go
@@ -517,38 +517,39 @@ func (c *SnowflakeClient) TestConnection(ctx context.Context) error {
 	return nil
 }
 
-// initializeSession sets up the Snowflake session with proper context
+// initializeSession sets up the Snowflake session with proper context.
+// Role is set first because it determines access to warehouse/database/schema.
 func (c *SnowflakeClient) initializeSession(ctx context.Context) error {
 	// Validate and sanitize inputs to prevent SQL injection
 	if err := c.validateSessionIdentifiers(); err != nil {
 		return fmt.Errorf("invalid session parameters: %w", err)
 	}
-	
-	// Execute session commands with validated inputs
-	if c.cfg.Warehouse != "" {
-		if err := c.executeSessionCommand(ctx, "USE WAREHOUSE", c.cfg.Warehouse); err != nil {
-			return err
-		}
-	}
-	
-	if c.cfg.Database != "" {
-		if err := c.executeSessionCommand(ctx, "USE DATABASE", c.cfg.Database); err != nil {
-			return err
-		}
-	}
-	
-	if c.cfg.Schema != "" {
-		if err := c.executeSessionCommand(ctx, "USE SCHEMA", c.cfg.Schema); err != nil {
-			return err
-		}
-	}
-	
+
+	// Set role FIRST — it determines permissions for subsequent USE commands
 	if c.cfg.Role != "" {
 		if err := c.executeSessionCommand(ctx, "USE ROLE", c.cfg.Role); err != nil {
 			return err
 		}
 	}
-	
+
+	if c.cfg.Warehouse != "" {
+		if err := c.executeSessionCommand(ctx, "USE WAREHOUSE", c.cfg.Warehouse); err != nil {
+			return err
+		}
+	}
+
+	if c.cfg.Database != "" {
+		if err := c.executeSessionCommand(ctx, "USE DATABASE", c.cfg.Database); err != nil {
+			return err
+		}
+	}
+
+	if c.cfg.Schema != "" {
+		if err := c.executeSessionCommand(ctx, "USE SCHEMA", c.cfg.Schema); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Moves `USE ROLE` to run before `USE WAREHOUSE`, `USE DATABASE`, and `USE SCHEMA` during Snowflake session initialization

## Context

Found this while debugging the CFACTS sync lambda returning 0 rows from SDL. The 0 rows ended up being a grants issue on SDL's side (service account role can't read the underlying tables behind the view), but while looking at the connection code I noticed we were setting the role last.

Not causing any issues today, but in Snowflake the role determines what warehouses/databases/schemas you have access to, so its better practice to set it first. That way if the default role can't access a warehouse but the target role can, we don't fail on `USE WAREHOUSE` before we've even switched roles.

Small change, no functional impact on current behavior — just the right order of operations.

## Test plan

- [ ] CI passes
- [ ] Existing export lambda still works (same code path)