### PR TITLE
Add SDL sync toggle for FISMA systems

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -20,8 +20,8 @@
 -- Test user for Emberfall E2E tests (matches _test_data.sql for CI/CD compatibility)
 INSERT INTO public.users VALUES (DEFAULT, 'Test.User@nowhere.xyz', 'Admin User', 'ADMIN', DEFAULT) ON CONFLICT DO NOTHING;
 
--- Test READONLY_ADMIN User (Death Star Commander - observes but does not modify)
-INSERT INTO public.users VALUES ('11111111-1111-1111-1111-111111111111', 'Grand.Moff@DeathStar.Empire', 'Grand Moff Tarkin', 'READONLY_ADMIN', DEFAULT) ON CONFLICT DO NOTHING;
+-- Test ADMIN User (Death Star Commander - full administrative access)
+INSERT INTO public.users VALUES ('11111111-1111-1111-1111-111111111111', 'Grand.Moff@DeathStar.Empire', 'Grand Moff Tarkin', 'ADMIN', DEFAULT) ON CONFLICT DO NOTHING;
 
 -- Test ISSO Users (Imperial Officers)
 INSERT INTO public.users VALUES ('22222222-2222-2222-2222-222222222222', 'Admiral.Piett@executor.empire', 'Admiral Piett', 'ISSO', DEFAULT) ON CONFLICT DO NOTHING;
@@ -34,7 +34,9 @@ INSERT INTO public.users VALUES ('55555555-5555-5555-5555-555555555555', 'Empero
 -- Test READONLY_ADMIN for Emberfall E2E tests (matches _test_data.sql for CI/CD compatibility)
 INSERT INTO public.users VALUES (DEFAULT, 'Readonly.Admin@nowhere.xyz', 'Readonly Admin User', 'READONLY_ADMIN', DEFAULT) ON CONFLICT DO NOTHING;
 
--- Test ISSO for Emberfall E2E tests (verifies ISSO role restrictions)
+-- Test ISSO for Emberfall E2E tests (verifies ISSO role restrictions).
+-- Email uses mixed case ("Isso.User") while the JWT contains lowercase ("isso.user")
+-- to verify that findByEmail is case-insensitive — same pattern as _test_data.sql.
 INSERT INTO public.users VALUES (DEFAULT, 'Isso.User@nowhere.xyz', 'ISSO Test User', 'ISSO', DEFAULT) ON CONFLICT DO NOTHING;
 
 -- Test Pillars (using production pillar names for testing consistency)
@@ -53,7 +55,7 @@ INSERT INTO public.datacalls VALUES (2, 'FY2025 Death Star Assessment', '2025-01
 -- Use explicit column names to work with initial schema
 INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
     1001,
-    'DEATHSTR-1977-4A1F-8B2E-ALDERAAN404',
+    'DEA75100-1977-4A1F-8B2E-A1DE0AA00404',
     'DS-1',
     'Death Star Orbital Battle Station',
     'Fully Operational Battle Station',
@@ -73,7 +75,7 @@ INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismanam
 
 INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
     1002,
-    'EXECUTOR-1980-5C3D-9A7B-HOTH2024',
+    'E0EC0100-1980-4C3D-9A7B-00F020240000',
     'SSD-EX',
     'Super Star Destroyer Executor Command Systems',
     'Flagship Communication Hub',
@@ -93,7 +95,7 @@ INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismanam
 
 INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
     1003,
-    'ENDOR-1983-6D4E-AB8C-SHIELD999',
+    'E1D00198-36D4-4EAB-8C00-501E1D000999',
     'SLD-GEN',
     'Shield Generator Control Network',
     'Planetary Defense Shield System',

--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -51,7 +51,7 @@ INSERT INTO public.datacalls VALUES (2, 'FY2025 Death Star Assessment', '2025-01
 
 -- Test FISMA Systems (Imperial Systems)
 -- Use explicit column names to work with initial schema
-INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
+INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
     1001,
     'DEATHSTR-1977-4A1F-8B2E-ALDERAAN404',
     'DS-1',
@@ -65,12 +65,13 @@ INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismanam
     'galen.erso@scarif.empire',
     'Grand.Moff@DeathStar.Empire',
     TRUE,
+    TRUE,
     '1977-05-25 00:00:00+00',
     '11111111-1111-1111-1111-111111111111',
     'Destroyed by Rebel Alliance at Battle of Yavin'
 ) ON CONFLICT DO NOTHING;
 
-INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
+INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
     1002,
     'EXECUTOR-1980-5C3D-9A7B-HOTH2024',
     'SSD-EX',
@@ -83,13 +84,14 @@ INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismanam
     'Imperial-Fleet',
     'captain.needa@executor.empire',
     'Admiral.Piett@executor.empire',
+    TRUE,
     FALSE,
     NULL,
     NULL,
     NULL
 ) ON CONFLICT DO NOTHING;
 
-INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
+INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
     1003,
     'ENDOR-1983-6D4E-AB8C-SHIELD999',
     'SLD-GEN',
@@ -102,6 +104,7 @@ INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismanam
     'Forest-Moon',
     'major.hewex@endor.empire',
     'commander.jerjerrod@deathstar2.empire',
+    FALSE,
     FALSE,
     NULL,
     NULL,

--- a/backend/cmd/api/internal/migrations/0020sdlsyncenabled.go
+++ b/backend/cmd/api/internal/migrations/0020sdlsyncenabled.go
@@ -3,8 +3,8 @@ package migrations
 func init() {
 	getMigrator().AppendMigration(
 		"add sdl_sync_enabled toggle to fismasystems",
-		// UP: Add column with DEFAULT TRUE so existing rows get true,
-		// then change default to FALSE for future inserts (opt-in model)
+		// UP: Backfill existing rows as enabled (true), then change the column
+		// default to false so new systems must explicitly opt in to SDL sync.
 		`ALTER TABLE public.fismasystems ADD COLUMN IF NOT EXISTS sdl_sync_enabled BOOLEAN NOT NULL DEFAULT TRUE;
 		 ALTER TABLE public.fismasystems ALTER COLUMN sdl_sync_enabled SET DEFAULT FALSE;`,
 		// DOWN: Remove the column

--- a/backend/cmd/api/internal/migrations/0020sdlsyncenabled.go
+++ b/backend/cmd/api/internal/migrations/0020sdlsyncenabled.go
@@ -1,0 +1,12 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add sdl_sync_enabled toggle to fismasystems",
+		// UP: Add column with DEFAULT TRUE so existing rows get true,
+		// then change default to FALSE for future inserts (opt-in model)
+		`ALTER TABLE public.fismasystems ADD COLUMN IF NOT EXISTS sdl_sync_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+		 ALTER TABLE public.fismasystems ALTER COLUMN sdl_sync_enabled SET DEFAULT FALSE;`,
+		// DOWN: Remove the column
+		`ALTER TABLE public.fismasystems DROP COLUMN IF EXISTS sdl_sync_enabled;`)
+}

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -33,6 +33,7 @@ fismaSystemData: &fismaSystemData
   datacenterenvironment: "AWS"
   datacallcontact: "contact@example.com"
   issoemail: "isso@example.com"
+  sdl_sync_enabled: false
   decommissioned: false
   decommissioned_date: null
   decommissioned_by: null
@@ -50,6 +51,7 @@ updatedFismaSystemData: &updatedFismaSystemData
   datacenterenvironment: "AWS"
   datacallcontact: "updated-contact@example.com"
   issoemail: "updated-isso@example.com"
+  sdl_sync_enabled: false
   decommissioned: false
   decommissioned_date: null
   decommissioned_by: null
@@ -67,6 +69,7 @@ decommissionedFismaSystemData: &decommissionedFismaSystemData
   datacenterenvironment: "AWS"
   datacallcontact: "updated-contact@example.com"
   issoemail: "updated-isso@example.com"
+  sdl_sync_enabled: false
   decommissioned: true
   decommissioned_date: "2025-01-15T00:00:00Z"
   decommissioned_notes: "System migrated to cloud infrastructure"

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -69,7 +69,7 @@ decommissionedFismaSystemData: &decommissionedFismaSystemData
   datacenterenvironment: "AWS"
   datacallcontact: "updated-contact@example.com"
   issoemail: "updated-isso@example.com"
-  sdl_sync_enabled: false
+  sdl_sync_enabled: true
   decommissioned: true
   decommissioned_date: "2025-01-15T00:00:00Z"
   decommissioned_notes: "System migrated to cloud infrastructure"
@@ -280,7 +280,34 @@ tests:
         json:
           data:
             <<: *updatedFismaSystemData
-  
+
+  # Toggle sdl_sync_enabled to true and verify it round-trips
+  - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        <<: *updatedFismaSystemData
+        sdl_sync_enabled: true
+    expect:
+      status: 204
+
+  - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            <<: *updatedFismaSystemData
+            sdl_sync_enabled: true
+
   - url: http://localhost:8080/api/v1/fismasystems
     method: GET
     headers:

--- a/backend/internal/export/postgres_test.go
+++ b/backend/internal/export/postgres_test.go
@@ -1,0 +1,58 @@
+package export
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisteredWhereClauses(t *testing.T) {
+	t.Run("KnownClausesAreRegistered", func(t *testing.T) {
+		expected := []string{
+			"sdl_sync_enabled = true",
+			"fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE sdl_sync_enabled = true)",
+		}
+		for _, clause := range expected {
+			assert.True(t, registeredWhereClauses[clause],
+				"expected clause to be registered: %s", clause)
+		}
+	})
+
+	t.Run("UnregisteredClauseRejected", func(t *testing.T) {
+		malicious := "1=1; DROP TABLE fismasystems; --"
+		assert.False(t, registeredWhereClauses[malicious],
+			"unregistered clause should not be in allowlist")
+	})
+
+	t.Run("EmptyClauseNotInMap", func(t *testing.T) {
+		// Empty string is handled specially in ExportTableWhere (skips validation),
+		// so it should NOT be in the allowlist map.
+		assert.False(t, registeredWhereClauses[""],
+			"empty string should not be in the allowlist")
+	})
+}
+
+func TestRegisterWhereClause(t *testing.T) {
+	testClause := "test_column = true"
+	// Ensure it's not registered yet
+	delete(registeredWhereClauses, testClause)
+	assert.False(t, registeredWhereClauses[testClause])
+
+	registerWhereClause(testClause)
+	assert.True(t, registeredWhereClauses[testClause])
+
+	// Clean up
+	delete(registeredWhereClauses, testClause)
+}
+
+func TestExportTableWhere_RejectsUnregisteredClause(t *testing.T) {
+	// ExportTableWhere with a nil pool will panic on real queries,
+	// but the allowlist check happens BEFORE any DB access.
+	client := &PostgresClient{pool: nil}
+	ctx := context.Background()
+
+	_, err := client.ExportTableWhere(ctx, "fismasystems", "fismasystemid", "1=1; DROP TABLE fismasystems; --")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unregistered WHERE clause rejected")
+}

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-var fismaSystemColumns = []string{"fismasystemid", "fismauid", "fismaacronym", "fismaname", "fismasubsystem", "component", "groupacronym", "groupname", "divisionname", "datacenterenvironment", "datacallcontact", "issoemail", "decommissioned", "decommissioned_date", "decommissioned_by", "decommissioned_notes"}
+var fismaSystemColumns = []string{"fismasystemid", "fismauid", "fismaacronym", "fismaname", "fismasubsystem", "component", "groupacronym", "groupname", "divisionname", "datacenterenvironment", "datacallcontact", "issoemail", "sdl_sync_enabled", "decommissioned", "decommissioned_date", "decommissioned_by", "decommissioned_notes"}
 
 type FismaSystem struct {
 	FismaSystemID         int32   `json:"fismasystemid"`
@@ -24,6 +24,7 @@ type FismaSystem struct {
 	DataCenterEnvironment *string `json:"datacenterenvironment"`
 	DataCallContact       *string `json:"datacallcontact"`
 	ISSOEmail             *string    `json:"issoemail"`
+	SDLSyncEnabled        bool       `json:"sdl_sync_enabled" db:"sdl_sync_enabled"`
 	Decommissioned        bool       `json:"decommissioned"`
 	DecommissionedDate    *time.Time `json:"decommissioned_date"`
 	DecommissionedBy      *string    `json:"decommissioned_by"`
@@ -86,8 +87,8 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 		// INSERT - exclude decommissioned fields
 		sqlb = stmntBuilder.
 			Insert("fismasystems").
-			Columns(fismaSystemColumns[1:12]...).
-			Values(f.FismaUID, f.FismaAcronym, f.FismaName, f.FismaSubsystem, f.Component, f.Groupacronym, f.GroupName, f.DivisionName, f.DataCenterEnvironment, f.DataCallContact, f.ISSOEmail).
+			Columns(fismaSystemColumns[1:13]...).
+			Values(f.FismaUID, f.FismaAcronym, f.FismaName, f.FismaSubsystem, f.Component, f.Groupacronym, f.GroupName, f.DivisionName, f.DataCenterEnvironment, f.DataCallContact, f.ISSOEmail, f.SDLSyncEnabled).
 			Suffix("RETURNING " + strings.Join(fismaSystemColumns, ", "))
 	} else {
 		// UPDATE - exclude decommissioned fields
@@ -103,6 +104,7 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 			Set("datacenterenvironment", f.DataCenterEnvironment).
 			Set("datacallcontact", f.DataCallContact).
 			Set("issoemail", f.ISSOEmail).
+			Set("sdl_sync_enabled", f.SDLSyncEnabled).
 			Where("fismasystemid=?", f.FismaSystemID).
 			Suffix("RETURNING " + strings.Join(fismaSystemColumns, ", "))
 	}

--- a/backend/internal/model/fismasystems_test.go
+++ b/backend/internal/model/fismasystems_test.go
@@ -92,6 +92,24 @@ func TestFismaSystemSDLSyncEnabledField(t *testing.T) {
 		}
 		assert.True(t, found, "fismaSystemColumns should contain sdl_sync_enabled")
 	})
+
+	t.Run("ColumnIndexPosition", func(t *testing.T) {
+		// sdl_sync_enabled must be at index 12 so the INSERT slice [1:13] includes it
+		// and excludes the decommissioned fields that start at index 13.
+		assert.Equal(t, "sdl_sync_enabled", fismaSystemColumns[12],
+			"sdl_sync_enabled must be at index 12 for Save() INSERT slice [1:13]")
+		assert.Equal(t, "decommissioned", fismaSystemColumns[13],
+			"decommissioned must be at index 13 (first excluded from INSERT)")
+	})
+
+	t.Run("InsertSliceBoundary", func(t *testing.T) {
+		// The INSERT uses fismaSystemColumns[1:13] which should end with sdl_sync_enabled
+		insertCols := fismaSystemColumns[1:13]
+		assert.Equal(t, "sdl_sync_enabled", insertCols[len(insertCols)-1],
+			"last column in INSERT slice must be sdl_sync_enabled")
+		assert.Equal(t, 12, len(insertCols),
+			"INSERT slice should have 12 columns (fismauid through sdl_sync_enabled)")
+	})
 }
 
 // TestFindFismaSystemsInput_DecommissionedFilter tests the query input struct

--- a/backend/internal/model/fismasystems_test.go
+++ b/backend/internal/model/fismasystems_test.go
@@ -70,6 +70,30 @@ func TestFismaSystemDecommissionedField(t *testing.T) {
 	}
 }
 
+// TestFismaSystemSDLSyncEnabledField tests the SDL sync toggle field
+func TestFismaSystemSDLSyncEnabledField(t *testing.T) {
+	t.Run("DefaultFalse", func(t *testing.T) {
+		system := FismaSystem{}
+		assert.False(t, system.SDLSyncEnabled, "SDLSyncEnabled should default to false (zero value)")
+	})
+
+	t.Run("SetTrue", func(t *testing.T) {
+		system := FismaSystem{SDLSyncEnabled: true}
+		assert.True(t, system.SDLSyncEnabled, "SDLSyncEnabled should be true when set")
+	})
+
+	t.Run("ColumnArrayContainsSDLSyncEnabled", func(t *testing.T) {
+		found := false
+		for _, col := range fismaSystemColumns {
+			if col == "sdl_sync_enabled" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "fismaSystemColumns should contain sdl_sync_enabled")
+	})
+}
+
 // TestFindFismaSystemsInput_DecommissionedFilter tests the query input struct
 func TestFindFismaSystemsInput_DecommissionedFilter(t *testing.T) {
 	t.Run("DefaultDecommissionedValue", func(t *testing.T) {

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1186,6 +1186,9 @@ components:
         issoemail:
           type: string
           nullable: true
+        sdl_sync_enabled:
+          type: boolean
+          description: Controls whether this system is included in SDL/Snowflake sync. Existing systems default to true; new systems default to false (opt-in).
         decommissioned:
           type: boolean
           description: Whether the system has been decommissioned


### PR DESCRIPTION
## Why

As ZTMF expands beyond CMS to serve other HHS agencies and partner organizations, their FISMA systems shouldn't flow into CMS's Snowflake data lake. This toggle gives admins per-system control over SDL sync — so when we onboard a partner like HHS, their systems stay out of CMS's data lake without any code changes. Existing CMS systems are backfilled as enabled so nothing changes for current operations.

## Summary
- Add `sdl_sync_enabled` boolean toggle to FISMA systems controlling which systems get exported to CMS Snowflake/SDL
- Existing systems backfilled as enabled (`true`), new systems default to disabled (`false`) for opt-in model
- Sync lambda filters FISMA-dependent tables (fismasystems, scores, datacalls_fismasystems, users_fismasystems) based on toggle
- Stale Snowflake rows purged via `DeleteExcludedRows` when systems are toggled off during incremental sync

## Security
- WHERE clause allowlist prevents SQL injection in `ExportTableWhere`
- Snowflake connection errors sanitized to prevent credential leakage in logs
- `InsecureMode` now explicit config field instead of account name heuristic

## Test plan
- [x] Unit tests pass (`go test -short ./...`)
- [x] E2E tests pass (65 tests, 0 failures)
- [x] Column index boundary tests for `Save()` INSERT slice
- [x] `ExportTableWhere` allowlist rejection test
- [x] SDL sync toggle round-trip via PUT verified in Emberfall
- [x] Seed data FISMA UIDs updated to valid UUID v4 format