### PR TITLE
Add CloudFront custom error responses for backend outages

### DIFF
--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -176,21 +176,21 @@ resource "aws_cloudfront_distribution" "ztmf" {
   # Short TTL (10s) so CloudFront picks up a recovered origin quickly.
   custom_error_response {
     error_code            = 502
-    response_code         = 200
+    response_code         = 502
     response_page_path    = "/error.html"
     error_caching_min_ttl = 10
   }
 
   custom_error_response {
     error_code            = 503
-    response_code         = 200
+    response_code         = 503
     response_page_path    = "/error.html"
     error_caching_min_ttl = 10
   }
 
   custom_error_response {
     error_code            = 504
-    response_code         = 200
+    response_code         = 504
     response_page_path    = "/error.html"
     error_caching_min_ttl = 10
   }


### PR DESCRIPTION
## Summary

Closes #258

Serves a static error page from S3 when the API origin returns 502, 503, or 504. Instead of a raw error or broken React app, users see a branded "technical difficulties" page with a retry link.

## Changes

- `infrastructure/cloudfront.tf` — three `custom_error_response` blocks for 502/503/504
  - `response_page_path = "/error.html"` (fetched from the S3 web assets origin)
  - `response_code` preserves original status code (502/503/504) so API XHR calls receive proper error codes
  - `error_caching_min_ttl = 10` (short TTL so recovered origin is picked up quickly)

## How it works

1. API origin (ALB) returns 502/503/504 (container crash, bad deploy, etc.)
2. CloudFront intercepts the error, fetches `/error.html` from the S3 origin
3. Direct browser navigation shows the branded error page with CMS government banner and footer
4. The React SPA authLoader detects 5xx status and renders the ServerErrorPage component instead
5. CloudFront caches for 10 seconds, then re-checks the origin

## Design decisions

- `response_code` preserves the original 5xx status (NOT 200). Because `custom_error_response` is distribution-level, it intercepts errors from ALL origins including `/api/*`. If we returned 200, Axios would see a "successful" response with HTML body instead of JSON, breaking the React app error handling.
- HTTP 500 is not intercepted — those are application-level errors handled by the API itself.

## Prerequisites

The static `error.html` must exist in the S3 bucket. It is deployed by the frontend CI pipeline — see companion PR: CMS-Enterprise/ztmf-ui#335.

## Tested on dev

Scaled ECS backend to 0 desired tasks on the dev environment, confirmed the error page renders correctly.

<!-- Paste screenshot of error page here -->

## Test plan

- [x] `terraform fmt` clean
- [x] Backend unit and E2E tests pass (75/75)
- [x] Terraform deployed to dev successfully
- [x] Manual test: stopped ECS tasks, verified error page served by CloudFront
- [x] Manual test: confirmed normal operation restored after scaling backend back up