### PR TITLE
Add CFACTS auth methods sync and IdM scoring table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Single source of truth for the local API port
 API_PORT ?= 8080
 
-.PHONY: dev-setup dev-up dev-down dev-logs generate-jwt clean help test-empire-data test test-unit test-integration test-coverage test-coverage-view test-coverage-text test-e2e test-full full-stack-up full-stack-down frontend-env
+.PHONY: dev-setup dev-up dev-down dev-logs generate-jwt clean help test-empire-data test test-unit test-integration test-coverage test-coverage-view test-coverage-text test-build test-e2e test-full full-stack-up full-stack-down frontend-env
 
 # Default target
 help:
@@ -22,6 +22,7 @@ help:
 	@echo "Testing:"
 	@echo "  make test                Run all tests"
 	@echo "  make test-unit           Run unit tests only (fast)"
+	@echo "  make test-build          Build all binaries (API + Lambdas)"
 	@echo "  make test-integration    Run integration tests"
 	@echo "  make test-coverage       Run tests and generate HTML coverage report"
 	@echo "  make test-coverage-view  Open HTML coverage report in browser"
@@ -282,16 +283,30 @@ test-e2e:
 	@rm /tmp/emberfall_test_isolated.yml
 	@echo "✅ E2E tests passed!"
 
+test-build:
+	@echo "Building all binaries (API + Lambdas)..."
+	@cd backend && go build ./cmd/api/...
+	@cd backend && go build ./cmd/lambda/...
+	@cd backend && go build ./cmd/lambda-cfacts-snowflake/...
+	@cd backend && go build ./cmd/lambda-cfacts-s3/...
+	@echo "✅ All binaries build successfully"
+
 test-full:
 	@echo "Running comprehensive test suite..."
 	@echo ""
-	@echo "1/3 Running unit tests..."
+	@echo "1/4 Building all binaries (API + Lambdas)..."
+	@cd backend && go build ./cmd/api/...
+	@cd backend && go build ./cmd/lambda/...
+	@cd backend && go build ./cmd/lambda-cfacts-snowflake/...
+	@cd backend && go build ./cmd/lambda-cfacts-s3/...
+	@echo ""
+	@echo "2/4 Running unit tests..."
 	@cd backend && go test -short ./...
 	@echo ""
-	@echo "2/3 Generating coverage report..."
+	@echo "3/4 Generating coverage report..."
 	@cd backend && go test -cover ./...
 	@echo ""
-	@echo "3/3 Running Emberfall E2E tests (isolated containers)..."
+	@echo "4/4 Running Emberfall E2E tests (isolated containers)..."
 	@make test-e2e
 	@echo ""
 	@echo "✅ All tests complete"

--- a/backend/_test_data_cfacts_empire.sql
+++ b/backend/_test_data_cfacts_empire.sql
@@ -16,7 +16,9 @@ INSERT INTO public.cfacts_systems (
     group_name,
     ato_expiration_date,
     decommission_date,
-    last_modified_date
+    last_modified_date,
+    auth_methods,
+    fips_impact_level
 ) VALUES
 -- Death Star - DECOMMISSIONED (blown up at Yavin)
 (
@@ -34,7 +36,9 @@ INSERT INTO public.cfacts_systems (
     'Orbital Weapons Systems Group',
     '1977-05-25 00:00:00+00',
     '1977-05-25 00:00:00+00',
-    NOW()
+    NOW(),
+    'RACF',
+    'High'
 ),
 
 -- Executor - DECOMMISSIONED (crashed into Death Star II at Endor)
@@ -53,7 +57,9 @@ INSERT INTO public.cfacts_systems (
     'Fleet Command Systems Group',
     '1983-05-25 00:00:00+00',
     '1983-05-25 00:00:00+00',
-    NOW()
+    NOW(),
+    'IDM-Okta',
+    'High'
 ),
 
 -- Shield Generator - ACTIVE (matches ZTMF but ISSO email different)
@@ -72,7 +78,9 @@ INSERT INTO public.cfacts_systems (
     'Planetary Defense Systems Group',
     '2027-12-31 00:00:00+00',
     NULL,
-    NOW()
+    NOW(),
+    'IDM-Okta, EUA',
+    'Moderate'
 ),
 
 -- NEW SYSTEMS NOT IN ZTMF (active in CFACTS)
@@ -93,7 +101,9 @@ INSERT INTO public.cfacts_systems (
     'Starfighter Production Group',
     '2026-08-15 00:00:00+00',
     NULL,
-    NOW()
+    NOW(),
+    'IDM-Okta',
+    'Moderate'
 ),
 
 -- Star Destroyer Fleet Management
@@ -112,7 +122,9 @@ INSERT INTO public.cfacts_systems (
     'Fleet Operations Group',
     '2027-03-20 00:00:00+00',
     NULL,
-    NOW()
+    NOW(),
+    'IDM-Okta, Other (Imperial Navy Auth)',
+    'High'
 ),
 
 -- Stormtrooper Training Academy
@@ -131,7 +143,9 @@ INSERT INTO public.cfacts_systems (
     'Training and Development Group',
     '2026-11-30 00:00:00+00',
     NULL,
-    NOW()
+    NOW(),
+    'EUA',
+    'Low'
 ),
 
 -- Imperial Intelligence Network
@@ -150,7 +164,9 @@ INSERT INTO public.cfacts_systems (
     'Counter-Intelligence Group',
     '2027-06-15 00:00:00+00',
     NULL,
-    NOW()
+    NOW(),
+    'IDM-Okta',
+    'High'
 ),
 
 -- Detention Block Management (missing ISSO - data quality issue)
@@ -169,7 +185,9 @@ INSERT INTO public.cfacts_systems (
     'Detention Facility Operations Group',
     '2026-09-10 00:00:00+00',
     NULL,
-    NOW()
+    NOW(),
+    NULL,
+    'Moderate'
 ),
 
 -- RETIRED SYSTEMS
@@ -190,7 +208,9 @@ INSERT INTO public.cfacts_systems (
     'Senate Operations Group',
     '0019-01-01 00:00:00+00',
     NULL,
-    NOW()
+    NOW(),
+    NULL,
+    NULL
 ),
 
 -- Jedi Temple Archives (retired after Order 66)
@@ -209,7 +229,9 @@ INSERT INTO public.cfacts_systems (
     'Knowledge Management Group',
     '0019-01-01 00:00:00+00',
     '0019-05-04 00:00:00+00',
-    NOW()
+    NOW(),
+    NULL,
+    NULL
 ),
 
 -- Clone Army Management (retired, replaced by stormtroopers)
@@ -228,7 +250,9 @@ INSERT INTO public.cfacts_systems (
     'Clone Forces Legacy Systems Group',
     '0022-01-01 00:00:00+00',
     NULL,
-    NOW()
+    NOW(),
+    NULL,
+    NULL
 ),
 
 -- INITIATE PHASE (new systems being set up)
@@ -249,5 +273,7 @@ INSERT INTO public.cfacts_systems (
     'Advanced Weapons Research Group',
     NULL,
     NULL,
-    NOW()
+    NOW(),
+    NULL,
+    NULL
 );

--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -317,7 +317,7 @@ INSERT INTO public.scores VALUES (9030, 1001, '2024-09-01 00:00:00+00', 'Central
 
 -- CFACTS Systems (synced from CMS CFACTS via Snowflake SDL)
 -- Matches existing FISMA systems by UUID for future comparison features
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
     'DEATHSTR-1977-4A1F-8B2E-ALDERAAN404',
     'DS-1',
     'Death Star Orbital Battle Station Security Package',
@@ -334,10 +334,11 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     '1977-05-25 00:00:00+00',
     '1977-05-25 00:00:00+00',
     '1977-05-25 00:00:00+00',
+    'Imperial-SSO, Other (Retinal Scanner)',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
     'EXECUTOR-1980-5C3D-9A7B-HOTH2024',
     'SSD-EX',
     'Super Star Destroyer Executor Security Package',
@@ -354,10 +355,11 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     '2026-12-31 00:00:00+00',
     NULL,
     '2025-01-10 00:00:00+00',
+    'Imperial-SSO, Code Cylinder',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
     'ENDOR-1983-6D4E-AB8C-SHIELD999',
     'SLD-GEN',
     'Shield Generator Control Network Security Package',
@@ -374,11 +376,12 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     '2026-06-30 00:00:00+00',
     NULL,
     '2025-01-08 00:00:00+00',
+    'Imperial-LDAP',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
 -- CFACTS-only system (no matching ZTMF fismasystem) for future comparison testing
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
     'STRKLLR-2016-7E5F-BC9D-ILUM12345',
     'SK-BASE',
     'Starkiller Base Weapons Platform Security Package',
@@ -395,11 +398,12 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     '2027-01-01 00:00:00+00',
     NULL,
     '2025-01-12 00:00:00+00',
+    'Sith-MFA, Other (Kyber Crystal Auth)',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
 -- CFACTS system for Emberfall E2E tests
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
     '12345678-ABCD-4321-AFAB-123456789ABC',
     'ZTMF',
     'Zero Trust Maturity Framework Security Package',
@@ -416,12 +420,13 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     '2026-12-31 00:00:00+00',
     NULL,
     '2025-01-01 00:00:00+00',
+    'Imperial-SSO',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
 -- CFACTS system that matches fismasystem 1003 (Shield Gen) by fismauid for ISSO CFACTS access E2E tests.
 -- The join path is: cfacts_systems.fisma_uuid -> fismasystems.fismauid -> users_fismasystems.
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
     'E1D00198-36D4-4EAB-8C00-501E1D000999',
     'SLD-GEN',
     'Shield Generator Control Network CFACTS Package',
@@ -438,8 +443,18 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     '2027-12-31 00:00:00+00',
     NULL,
     '2025-01-01 00:00:00+00',
+    'Imperial-LDAP, Code Cylinder',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
+
+-- IdM Scoring lookup table for identity enrichment tooltips
+INSERT INTO public.idm_scoring (idm_name, display_name, score, reasoning) VALUES
+    ('Imperial-SSO', 'Imperial Single Sign-On (Imperial-SSO)', 3, 'Imperial Single Sign-On provides MFA via holographic verification and code cylinder backup.'),
+    ('Imperial-LDAP', 'Imperial Directory Services (Imperial-LDAP)', 2, 'Imperial LDAP directory provides basic authentication with periodic credential rotation.'),
+    ('Code Cylinder', 'Code Cylinder Hardware Token', 2, 'Physical code cylinder provides single-factor hardware authentication for secure facilities.'),
+    ('Sith-MFA', 'Sith Multi-Factor Authentication (Sith-MFA)', 4, 'Sith Multi-Factor Authentication uses Force-sensitivity detection combined with biometric and knowledge factors.'),
+    ('Single Factor (Only)', 'Single Factor Only', 1, 'Single factor authentication only - no MFA capability.')
+ON CONFLICT (idm_name) DO NOTHING;
 
 -- Reset sequences past the max explicit IDs to avoid primary key conflicts
 SELECT setval('pillars_pillarid_seq', (SELECT COALESCE(MAX(pillarid), 0) FROM public.pillars));

--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -317,7 +317,7 @@ INSERT INTO public.scores VALUES (9030, 1001, '2024-09-01 00:00:00+00', 'Central
 
 -- CFACTS Systems (synced from CMS CFACTS via Snowflake SDL)
 -- Matches existing FISMA systems by UUID for future comparison features
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, fips_impact_level, synced_at) VALUES (
     'DEATHSTR-1977-4A1F-8B2E-ALDERAAN404',
     'DS-1',
     'Death Star Orbital Battle Station Security Package',
@@ -335,10 +335,11 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     '1977-05-25 00:00:00+00',
     '1977-05-25 00:00:00+00',
     'Imperial-SSO, Other (Retinal Scanner)',
+    'High',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, fips_impact_level, synced_at) VALUES (
     'EXECUTOR-1980-5C3D-9A7B-HOTH2024',
     'SSD-EX',
     'Super Star Destroyer Executor Security Package',
@@ -356,10 +357,11 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     NULL,
     '2025-01-10 00:00:00+00',
     'Imperial-SSO, Code Cylinder',
+    'High',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, fips_impact_level, synced_at) VALUES (
     'ENDOR-1983-6D4E-AB8C-SHIELD999',
     'SLD-GEN',
     'Shield Generator Control Network Security Package',
@@ -377,11 +379,12 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     NULL,
     '2025-01-08 00:00:00+00',
     'Imperial-LDAP',
+    'Moderate',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
 -- CFACTS-only system (no matching ZTMF fismasystem) for future comparison testing
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, fips_impact_level, synced_at) VALUES (
     'STRKLLR-2016-7E5F-BC9D-ILUM12345',
     'SK-BASE',
     'Starkiller Base Weapons Platform Security Package',
@@ -399,11 +402,12 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     NULL,
     '2025-01-12 00:00:00+00',
     'Sith-MFA, Other (Kyber Crystal Auth)',
+    'High',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
 -- CFACTS system for Emberfall E2E tests
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, fips_impact_level, synced_at) VALUES (
     '12345678-ABCD-4321-AFAB-123456789ABC',
     'ZTMF',
     'Zero Trust Maturity Framework Security Package',
@@ -421,12 +425,13 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     NULL,
     '2025-01-01 00:00:00+00',
     'Imperial-SSO',
+    'High',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 
 -- CFACTS system that matches fismasystem 1003 (Shield Gen) by fismauid for ISSO CFACTS access E2E tests.
 -- The join path is: cfacts_systems.fisma_uuid -> fismasystems.fismauid -> users_fismasystems.
-INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, synced_at) VALUES (
+INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_package_name, primary_isso_name, primary_isso_email, is_active, is_retired, is_decommissioned, lifecycle_phase, component_acronym, division_name, group_acronym, group_name, ato_expiration_date, decommission_date, last_modified_date, auth_methods, fips_impact_level, synced_at) VALUES (
     'E1D00198-36D4-4EAB-8C00-501E1D000999',
     'SLD-GEN',
     'Shield Generator Control Network CFACTS Package',
@@ -444,6 +449,7 @@ INSERT INTO public.cfacts_systems (fisma_uuid, fisma_acronym, authorization_pack
     NULL,
     '2025-01-01 00:00:00+00',
     'Imperial-LDAP, Code Cylinder',
+    'Moderate',
     '2025-01-15 00:00:00+00'
 ) ON CONFLICT DO NOTHING;
 

--- a/backend/cmd/api/internal/migrations/0022cfactsauthmethods.go
+++ b/backend/cmd/api/internal/migrations/0022cfactsauthmethods.go
@@ -1,0 +1,12 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add auth_methods to cfacts_systems",
+		`
+ALTER TABLE public.cfacts_systems ADD COLUMN IF NOT EXISTS auth_methods TEXT;
+		`,
+		`
+ALTER TABLE public.cfacts_systems DROP COLUMN IF EXISTS auth_methods;
+		`)
+}

--- a/backend/cmd/api/internal/migrations/0022cfactsauthmethods.go
+++ b/backend/cmd/api/internal/migrations/0022cfactsauthmethods.go
@@ -2,11 +2,13 @@ package migrations
 
 func init() {
 	getMigrator().AppendMigration(
-		"add auth_methods to cfacts_systems",
+		"add auth_methods and fips_impact_level to cfacts_systems",
 		`
 ALTER TABLE public.cfacts_systems ADD COLUMN IF NOT EXISTS auth_methods TEXT;
+ALTER TABLE public.cfacts_systems ADD COLUMN IF NOT EXISTS fips_impact_level VARCHAR(20);
 		`,
 		`
 ALTER TABLE public.cfacts_systems DROP COLUMN IF EXISTS auth_methods;
+ALTER TABLE public.cfacts_systems DROP COLUMN IF EXISTS fips_impact_level;
 		`)
 }

--- a/backend/cmd/api/internal/migrations/0023idmscoring.go
+++ b/backend/cmd/api/internal/migrations/0023idmscoring.go
@@ -1,0 +1,27 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"create idm_scoring lookup table for identity enrichment",
+		`
+CREATE TABLE IF NOT EXISTS public.idm_scoring (
+	idm_scoring_id SERIAL PRIMARY KEY,
+	idm_name VARCHAR(100) NOT NULL,
+	display_name VARCHAR(100),
+	score INTEGER NOT NULL CHECK (score BETWEEN 1 AND 4),
+	reasoning TEXT,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	UNIQUE (idm_name)
+);
+
+COMMENT ON TABLE public.idm_scoring IS 'Lookup table for identity enrichment scoring';
+COMMENT ON COLUMN public.idm_scoring.idm_name IS 'IdM identifier used for matching';
+COMMENT ON COLUMN public.idm_scoring.display_name IS 'Friendly label for UI display';
+COMMENT ON COLUMN public.idm_scoring.score IS '1=Traditional, 2=Initial, 3=Advanced, 4=Optimal';
+COMMENT ON COLUMN public.idm_scoring.reasoning IS 'Explanation shown during data calls';
+		`,
+		`
+DROP TABLE IF EXISTS public.idm_scoring;
+		`)
+}

--- a/backend/cmd/api/internal/migrations/0023idmscoring.go
+++ b/backend/cmd/api/internal/migrations/0023idmscoring.go
@@ -7,13 +7,26 @@ func init() {
 CREATE TABLE IF NOT EXISTS public.idm_scoring (
 	idm_scoring_id SERIAL PRIMARY KEY,
 	idm_name VARCHAR(100) NOT NULL,
-	display_name VARCHAR(100),
+	display_name VARCHAR(100) NOT NULL,
 	score INTEGER NOT NULL CHECK (score BETWEEN 1 AND 4),
 	reasoning TEXT,
 	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 	UNIQUE (idm_name)
 );
+
+CREATE OR REPLACE FUNCTION update_idm_scoring_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+	NEW.updated_at = NOW();
+	RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_idm_scoring_updated_at
+	BEFORE UPDATE ON public.idm_scoring
+	FOR EACH ROW
+	EXECUTE FUNCTION update_idm_scoring_updated_at();
 
 COMMENT ON TABLE public.idm_scoring IS 'Lookup table for identity enrichment scoring';
 COMMENT ON COLUMN public.idm_scoring.idm_name IS 'IdM identifier used for matching';
@@ -22,6 +35,8 @@ COMMENT ON COLUMN public.idm_scoring.score IS '1=Traditional, 2=Initial, 3=Advan
 COMMENT ON COLUMN public.idm_scoring.reasoning IS 'Explanation shown during data calls';
 		`,
 		`
+DROP TRIGGER IF EXISTS trg_idm_scoring_updated_at ON public.idm_scoring;
+DROP FUNCTION IF EXISTS update_idm_scoring_updated_at();
 DROP TABLE IF EXISTS public.idm_scoring;
 		`)
 }

--- a/backend/cmd/lambda-cfacts-snowflake/internal/sync/sync.go
+++ b/backend/cmd/lambda-cfacts-snowflake/internal/sync/sync.go
@@ -180,6 +180,7 @@ func scanToSystem(values []any, colIdx map[string]int, rowNum int) (cfacts.Cfact
 		DivisionName:             optStr(getString("DIVISION_NAME")),
 		GroupAcronym:             optStr(getString("GROUP_ACRONYM")),
 		GroupName:                optStr(getString("GROUP_NAME")),
+		AuthMethods:             optStr(getString("AUTH_METHODS")),
 	}
 
 	var err error

--- a/backend/cmd/lambda-cfacts-snowflake/internal/sync/sync.go
+++ b/backend/cmd/lambda-cfacts-snowflake/internal/sync/sync.go
@@ -181,6 +181,7 @@ func scanToSystem(values []any, colIdx map[string]int, rowNum int) (cfacts.Cfact
 		GroupAcronym:             optStr(getString("GROUP_ACRONYM")),
 		GroupName:                optStr(getString("GROUP_NAME")),
 		AuthMethods:             optStr(getString("AUTH_METHODS")),
+		FipsImpactLevel:         optStr(getString("FIPS_IMPACT_LEVEL")),
 	}
 
 	var err error

--- a/backend/cmd/lambda-cfacts-snowflake/internal/sync/sync.go
+++ b/backend/cmd/lambda-cfacts-snowflake/internal/sync/sync.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"sort"
+
 	"github.com/CMS-Enterprise/ztmf/backend/internal/cfacts"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/export"
 )
@@ -90,6 +92,7 @@ func snowflakeColumns() []string {
 	for sfCol := range cfacts.SnowflakeColumnMap {
 		cols = append(cols, sfCol)
 	}
+	sort.Strings(cols)
 	return cols
 }
 

--- a/backend/cmd/lambda-cfacts-snowflake/main.go
+++ b/backend/cmd/lambda-cfacts-snowflake/main.go
@@ -101,6 +101,7 @@ func sendSlackNotification(ctx context.Context, event CfactsSyncEvent, rowCount 
 	result := notifications.SyncResult{
 		Environment:   config.GetInstance().Env,
 		TriggerType:   fmt.Sprintf("cfacts-snowflake/%s", event.TriggerType),
+		DryRun:        event.DryRun,
 		SuccessCount:  1 - failureCount,
 		FailureCount:  failureCount,
 		TotalRows:     rowCount,

--- a/backend/cmd/lambda/main.go
+++ b/backend/cmd/lambda/main.go
@@ -79,6 +79,8 @@ func handler(ctx context.Context, event json.RawMessage) error {
 	
 	if err != nil {
 		log.Printf("Sync failed: %v", err)
+		// Send failure notification before returning
+		sendFailureNotification(ctx, syncEvent, err)
 		return err
 	}
 	
@@ -126,6 +128,29 @@ func sendSlackNotification(ctx context.Context, event SyncEvent, result *sync.Sy
 	}
 	
 	return notifier.SendSyncNotification(ctx, notifyResult)
+}
+
+// sendFailureNotification sends a Slack notification when sync fails.
+func sendFailureNotification(ctx context.Context, event SyncEvent, syncErr error) {
+	notifier, err := notifications.NewSlackNotifier(ctx)
+	if err != nil {
+		log.Printf("Failed to initialize Slack notifier for failure notification: %v", err)
+		return
+	}
+
+	result := notifications.SyncResult{
+		Environment:   config.GetInstance().Env,
+		TriggerType:   event.TriggerType,
+		DryRun:        event.DryRun,
+		SuccessCount:  0,
+		FailureCount:  1,
+		FailedTables:  []string{"(sync initialization)"},
+		ErrorMessages: []string{syncErr.Error()},
+	}
+
+	if notifyErr := notifier.SendSyncNotification(ctx, result); notifyErr != nil {
+		log.Printf("Failed to send failure notification: %v", notifyErr)
+	}
 }
 
 func main() {

--- a/backend/cmd/lambda/main.go
+++ b/backend/cmd/lambda/main.go
@@ -116,6 +116,7 @@ func sendSlackNotification(ctx context.Context, event SyncEvent, result *sync.Sy
 	notifyResult := notifications.SyncResult{
 		Environment:   config.GetInstance().Env,
 		TriggerType:   event.TriggerType,
+		DryRun:        event.DryRun,
 		SuccessCount:  successCount,
 		FailureCount:  len(failedTables),
 		TotalRows:     result.TotalRows,

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -134,6 +134,7 @@ cfactsSystemData: &cfactsSystemData
   decommission_date: null
   last_modified_date: "2025-01-01T00:00:00Z"
   auth_methods: "Imperial-SSO"
+  fips_impact_level: "High"
   synced_at: "2025-01-15T00:00:00Z"
 
 scoreData: &scoreData

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -133,6 +133,7 @@ cfactsSystemData: &cfactsSystemData
   ato_expiration_date: "2026-12-31T00:00:00Z"
   decommission_date: null
   last_modified_date: "2025-01-01T00:00:00Z"
+  auth_methods: "Imperial-SSO"
   synced_at: "2025-01-15T00:00:00Z"
 
 scoreData: &scoreData

--- a/backend/internal/cfacts/csv.go
+++ b/backend/internal/cfacts/csv.go
@@ -105,6 +105,7 @@ func parseRecord(record []string, colIdx map[string]int, lineNum int) (CfactsSys
 	}
 
 	sys.AuthMethods = optString(get("AUTH_METHODS"))
+	sys.FipsImpactLevel = optString(get("FIPS_IMPACT_LEVEL"))
 
 	return sys, nil
 }

--- a/backend/internal/cfacts/csv.go
+++ b/backend/internal/cfacts/csv.go
@@ -104,6 +104,8 @@ func parseRecord(record []string, colIdx map[string]int, lineNum int) (CfactsSys
 		return CfactsSystem{}, err
 	}
 
+	sys.AuthMethods = optString(get("AUTH_METHODS"))
+
 	return sys, nil
 }
 

--- a/backend/internal/cfacts/model.go
+++ b/backend/internal/cfacts/model.go
@@ -21,9 +21,10 @@ type CfactsSystem struct {
 	DecommissionDate         *time.Time `json:"decommission_date"`
 	LastModifiedDate         *time.Time `json:"last_modified_date"`
 	AuthMethods              *string    `json:"auth_methods"`
+	FipsImpactLevel          *string    `json:"fips_impact_level"`
 }
 
-// cfactsColumns lists the 17 data columns in cfacts_systems (synced_at is set by DB).
+// cfactsColumns lists the 18 data columns in cfacts_systems (synced_at is set by DB).
 var cfactsColumns = []string{
 	"fisma_uuid",
 	"fisma_acronym",
@@ -42,6 +43,7 @@ var cfactsColumns = []string{
 	"decommission_date",
 	"last_modified_date",
 	"auth_methods",
+	"fips_impact_level",
 }
 
 // SnowflakeColumnMap maps uppercase Snowflake column names to CfactsSystem field names.
@@ -63,6 +65,7 @@ var SnowflakeColumnMap = map[string]string{
 	"DECOMMISSION_DATE":          "decommission_date",
 	"LAST_MODIFIED_DATE":         "last_modified_date",
 	"AUTH_METHODS":               "auth_methods",
+	"FIPS_IMPACT_LEVEL":          "fips_impact_level",
 }
 
 // values returns the ordered slice of field values for database insertion.
@@ -85,5 +88,6 @@ func (c *CfactsSystem) values() []any {
 		c.DecommissionDate,
 		c.LastModifiedDate,
 		c.AuthMethods,
+		c.FipsImpactLevel,
 	}
 }

--- a/backend/internal/cfacts/model.go
+++ b/backend/internal/cfacts/model.go
@@ -20,9 +20,10 @@ type CfactsSystem struct {
 	ATOExpirationDate        *time.Time `json:"ato_expiration_date"`
 	DecommissionDate         *time.Time `json:"decommission_date"`
 	LastModifiedDate         *time.Time `json:"last_modified_date"`
+	AuthMethods              *string    `json:"auth_methods"`
 }
 
-// cfactsColumns lists the 16 data columns in cfacts_systems (synced_at is set by DB).
+// cfactsColumns lists the 17 data columns in cfacts_systems (synced_at is set by DB).
 var cfactsColumns = []string{
 	"fisma_uuid",
 	"fisma_acronym",
@@ -40,6 +41,7 @@ var cfactsColumns = []string{
 	"ato_expiration_date",
 	"decommission_date",
 	"last_modified_date",
+	"auth_methods",
 }
 
 // SnowflakeColumnMap maps uppercase Snowflake column names to CfactsSystem field names.
@@ -60,6 +62,7 @@ var SnowflakeColumnMap = map[string]string{
 	"ATO_EXPIRATION_DATE":        "ato_expiration_date",
 	"DECOMMISSION_DATE":          "decommission_date",
 	"LAST_MODIFIED_DATE":         "last_modified_date",
+	"AUTH_METHODS":               "auth_methods",
 }
 
 // values returns the ordered slice of field values for database insertion.
@@ -81,5 +84,6 @@ func (c *CfactsSystem) values() []any {
 		c.ATOExpirationDate,
 		c.DecommissionDate,
 		c.LastModifiedDate,
+		c.AuthMethods,
 	}
 }

--- a/backend/internal/cfacts/postgres_test.go
+++ b/backend/internal/cfacts/postgres_test.go
@@ -40,7 +40,7 @@ func TestCfactsSystemValues(t *testing.T) {
 	}
 
 	vals := sys.values()
-	assert.Len(t, vals, 17)
+	assert.Len(t, vals, 18)
 	assert.Equal(t, "UUID-123", vals[0])
 	assert.Equal(t, "TEST", vals[1])
 	assert.Equal(t, &name, vals[2])
@@ -49,6 +49,7 @@ func TestCfactsSystemValues(t *testing.T) {
 	assert.Equal(t, &active, vals[5])
 	assert.Nil(t, vals[14]) // DecommissionDate
 	assert.Nil(t, vals[16]) // AuthMethods
+	assert.Nil(t, vals[17]) // FipsImpactLevel
 }
 
 func TestSyncResult(t *testing.T) {

--- a/backend/internal/cfacts/postgres_test.go
+++ b/backend/internal/cfacts/postgres_test.go
@@ -40,7 +40,7 @@ func TestCfactsSystemValues(t *testing.T) {
 	}
 
 	vals := sys.values()
-	assert.Len(t, vals, 16)
+	assert.Len(t, vals, 17)
 	assert.Equal(t, "UUID-123", vals[0])
 	assert.Equal(t, "TEST", vals[1])
 	assert.Equal(t, &name, vals[2])
@@ -48,6 +48,7 @@ func TestCfactsSystemValues(t *testing.T) {
 	assert.Equal(t, &email, vals[4])
 	assert.Equal(t, &active, vals[5])
 	assert.Nil(t, vals[14]) // DecommissionDate
+	assert.Nil(t, vals[16]) // AuthMethods
 }
 
 func TestSyncResult(t *testing.T) {

--- a/backend/internal/model/cfactssystems.go
+++ b/backend/internal/model/cfactssystems.go
@@ -25,6 +25,7 @@ var cfactsSystemColumns = []string{
 	"decommission_date",
 	"last_modified_date",
 	"auth_methods",
+	"fips_impact_level",
 	"synced_at",
 }
 
@@ -46,6 +47,7 @@ type CfactsSystem struct {
 	DecommissionDate         *time.Time `json:"decommission_date" db:"decommission_date"`
 	LastModifiedDate         *time.Time `json:"last_modified_date" db:"last_modified_date"`
 	AuthMethods              *string    `json:"auth_methods" db:"auth_methods"`
+	FipsImpactLevel          *string    `json:"fips_impact_level" db:"fips_impact_level"`
 	SyncedAt                 time.Time  `json:"synced_at" db:"synced_at"`
 }
 

--- a/backend/internal/model/cfactssystems.go
+++ b/backend/internal/model/cfactssystems.go
@@ -24,6 +24,7 @@ var cfactsSystemColumns = []string{
 	"ato_expiration_date",
 	"decommission_date",
 	"last_modified_date",
+	"auth_methods",
 	"synced_at",
 }
 
@@ -44,6 +45,7 @@ type CfactsSystem struct {
 	ATOExpirationDate        *time.Time `json:"ato_expiration_date" db:"ato_expiration_date"`
 	DecommissionDate         *time.Time `json:"decommission_date" db:"decommission_date"`
 	LastModifiedDate         *time.Time `json:"last_modified_date" db:"last_modified_date"`
+	AuthMethods              *string    `json:"auth_methods" db:"auth_methods"`
 	SyncedAt                 time.Time  `json:"synced_at" db:"synced_at"`
 }
 

--- a/backend/internal/notifications/slack.go
+++ b/backend/internal/notifications/slack.go
@@ -23,6 +23,7 @@ type SlackNotifier struct {
 type SyncResult struct {
 	Environment    string
 	TriggerType    string
+	DryRun         bool
 	SuccessCount   int
 	FailureCount   int
 	TotalRows      int64
@@ -79,10 +80,12 @@ func (s *SlackNotifier) buildSyncMessage(result SyncResult) string {
 	if result.FailureCount == 0 {
 		// Success message with environment-specific context
 		var dataMessage string
-		if result.Environment == "prod" {
+		if result.DryRun {
+			dataMessage = fmt.Sprintf("🧪 %s dry-run validation completed successfully", quarter)
+		} else if result.Environment == "prod" {
 			dataMessage = fmt.Sprintf("📅 %s data now available in Snowflake", quarter)
 		} else {
-			dataMessage = fmt.Sprintf("🧪 %s dry-run validation completed successfully", quarter)
+			dataMessage = fmt.Sprintf("📅 %s data synced to %s", quarter, strings.ToLower(result.Environment))
 		}
 
 		return fmt.Sprintf(`✅ ZTMF Data Sync SUCCESS (%s - %s)

--- a/backend/internal/notifications/slack.go
+++ b/backend/internal/notifications/slack.go
@@ -71,27 +71,36 @@ func (s *SlackNotifier) SendSyncNotification(ctx context.Context, result SyncRes
 	return s.sendToSlack(ctx, payload)
 }
 
+// getSyncLabel returns a human-readable label for the sync direction
+func getSyncLabel(triggerType string) string {
+	if strings.HasPrefix(triggerType, "cfacts-snowflake") {
+		return "CFACTS Import (SDL → ZTMF)"
+	}
+	return "Data Export (ZTMF → SDL)"
+}
+
 // buildSyncMessage creates formatted Slack message based on sync results
 func (s *SlackNotifier) buildSyncMessage(result SyncResult) string {
 	quarter := getCurrentQuarter()
 	scheduleType := getScheduleType(result.Environment)
 	envUpper := strings.ToUpper(result.Environment)
-	
+	syncLabel := getSyncLabel(result.TriggerType)
+
 	if result.FailureCount == 0 {
-		// Success message with environment-specific context
 		var dataMessage string
 		if result.DryRun {
 			dataMessage = fmt.Sprintf("🧪 %s dry-run validation completed successfully", quarter)
 		} else if result.Environment == "prod" {
-			dataMessage = fmt.Sprintf("📅 %s data now available in Snowflake", quarter)
+			dataMessage = fmt.Sprintf("📅 %s data now available", quarter)
 		} else {
 			dataMessage = fmt.Sprintf("📅 %s data synced to %s", quarter, strings.ToLower(result.Environment))
 		}
 
-		return fmt.Sprintf(`✅ ZTMF Data Sync SUCCESS (%s - %s)
+		return fmt.Sprintf(`✅ %s SUCCESS (%s - %s)
 📊 %d tables synced: %s rows
 ⏱️ Duration: %s
 %s`,
+			syncLabel,
 			envUpper,
 			scheduleType,
 			result.SuccessCount,
@@ -99,21 +108,20 @@ func (s *SlackNotifier) buildSyncMessage(result SyncResult) string {
 			formatDuration(result.Duration),
 			dataMessage)
 	} else {
-		// Failure message
 		failedTablesStr := strings.Join(result.FailedTables, ", ")
 		errorSummary := ""
 		if len(result.ErrorMessages) > 0 {
-			// Get first error for summary
 			errorSummary = result.ErrorMessages[0]
 			if len(errorSummary) > 100 {
 				errorSummary = errorSummary[:100] + "..."
 			}
 		}
-		
-		return fmt.Sprintf(`🚨 ZTMF Data Sync FAILURE (%s - %s)
+
+		return fmt.Sprintf(`🚨 %s FAILURE (%s - %s)
 ❌ %d table(s) failed: %s
 ✅ %d tables successful: %s rows
 🔧 Action Required: %s`,
+			syncLabel,
 			envUpper,
 			scheduleType,
 			result.FailureCount,

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1512,6 +1512,10 @@ components:
           type: string
           format: date-time
           nullable: true
+        auth_methods:
+          type: string
+          nullable: true
+          description: Comma-separated list of identity management systems reported in CFACTS
         synced_at:
           type: string
           format: date-time

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1516,6 +1516,10 @@ components:
           type: string
           nullable: true
           description: Comma-separated list of identity management systems reported in CFACTS
+        fips_impact_level:
+          type: string
+          nullable: true
+          description: FIPS 199 overall impact rating (High, Moderate, Low)
         synced_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- Add `auth_methods` column to `cfacts_systems` — syncs IdM system names (e.g., IDM-Okta, EUA, PIV) from CFACTS MFA metadata per FISMA system
- Create `idm_scoring` lookup table for mapping IdM names to maturity scores, display names, and reasoning text for ISSO tooltips during data calls
- Update all 5 CFACTS sync layers: model, CSV parser, Lambda scanner, API model, OpenAPI spec

## Context
First infrastructure step for SDL-enriched data calls (CMS-Enterprise/ztmf-misc#82). When an ISSO opens a data call, the `auth_methods` field tells the app which identity management systems CFACTS reports for that FISMA system. The `idm_scoring` table will power tooltip suggestions like "Your system uses IDM-Okta — suggested maturity: Initial (2)."

## Deployment notes
- **Snowflake view update required**: `VW_CFACTS_SYSTEMS_FOR_ZTMF` needs the AUTH_METHODS subquery added (SQL in `tmp/datagrip-queries/cfacts-view-with-auth.sql`, not committed)
- **SDL grant required**: `GRANT SELECT ON APP_ARCHER.PUBLIC.SEC_VW_MULTI_FACTOR_AUTHENTICATION_MFA_META TO ROLE SVC_ZEROTRUST_ROLE`
- **Manual seed**: `idm_scoring` table created empty — seed SQL in `tmp/seed-idm-scoring.sql` (not committed) for manual loading after ZT expert review

## Test plan
- [x] Unit tests pass (17 values assertion updated)
- [x] 75/75 Emberfall E2E tests pass
- [x] `make dev-setup` applies migrations cleanly
- [x] `auth_methods` column verified in dev DB
- [x] `idm_scoring` table created with correct schema
- [ ] CI pipeline passes
- [ ] Dev deployment succeeds