### PR TITLE
Add impl environment for experimental branch testing

### DIFF
--- a/.github/workflows/orchestration-impl.yml
+++ b/.github/workflows/orchestration-impl.yml
@@ -1,0 +1,56 @@
+name: Orchestration IMPL
+
+on:
+  pull_request:
+    branches:
+      - impl
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  analysis:
+    name: Analysis
+    uses: ./.github/workflows/analysis.yml
+    secrets: inherit
+
+  diff:
+    if: github.event.pull_request.draft == false
+    name: Check for Changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.backend.outputs.backend }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes in backend/
+        id: backend
+        run: echo "backend=$(git --no-pager diff --name-only origin/impl backend/ | grep ".go\|.sum\|Dockerfile" | head -n 1)" >> $GITHUB_OUTPUT
+
+  backend:
+    name: Backend
+    needs:
+      - analysis
+      - diff
+    if: github.event.pull_request.draft == false && contains(needs.diff.outputs.backend, 'backend/')
+    uses: ./.github/workflows/backend.yml
+    with:
+      environment: IMPL
+    secrets: inherit
+
+  infrastructure:
+    name: Infrastructure
+    needs:
+      - analysis
+      - diff
+      - backend
+    if: ${{ github.event.pull_request.draft == false && !failure() && !cancelled() }}
+    uses: ./.github/workflows/infrastructure.yml
+    with:
+      environment: IMPL
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ backend/lambda
 CLAUDE.md
 AGENTS.md
 .claude/
+.githooks/
 
 # Test coverage files
 coverage.out

--- a/infrastructure/alb-internal.tf
+++ b/infrastructure/alb-internal.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "ztmf_alb" {
-  name        = "ztmf"
+  name        = contains(["dev", "prod"], var.environment) ? "ztmf" : "${local.name_prefix}-alb"
   description = "Allow TLS inbound traffic"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -21,7 +21,7 @@ resource "aws_security_group" "ztmf_alb" {
 }
 
 resource "aws_lb" "ztmf_api" {
-  name                       = "ztmf-api"
+  name                       = "${local.name_prefix}-api"
   internal                   = true
   load_balancer_type         = "application"
   security_groups            = [aws_security_group.ztmf_alb.id]
@@ -58,7 +58,7 @@ resource "aws_lb" "ztmf_api" {
 
 # TARGET GROUPS
 resource "aws_lb_target_group" "ztmf_rest_api" {
-  name        = "ztmf-rest-api"
+  name        = "${local.name_prefix}-rest-api"
   port        = 443
   protocol    = "HTTPS"
   target_type = "ip"

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -1,14 +1,14 @@
 resource "aws_cloudfront_origin_access_control" "cloudfront_s3_oac" {
-  name                              = "ZTMF CloudFront S3 OAC"
-  description                       = "ZTMF CloudFront S3 OAC"
+  name                              = "${upper(local.name_prefix)} CloudFront S3 OAC"
+  description                       = "${upper(local.name_prefix)} CloudFront S3 OAC"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"
 }
 
 resource "aws_cloudfront_response_headers_policy" "hsts_policy" {
-  name    = "ZTMF-HSTS-Policy"
-  comment = "HSTS policy for ZTMF"
+  name    = "${upper(local.name_prefix)}-HSTS-Policy"
+  comment = "HSTS policy for ${upper(local.name_prefix)}"
 
   security_headers_config {
     strict_transport_security {
@@ -49,7 +49,7 @@ resource "aws_cloudfront_response_headers_policy" "hsts_policy" {
 
 resource "aws_cloudfront_vpc_origin" "internal_alb" {
   vpc_origin_endpoint_config {
-    name                   = "ZTMF_API"
+    name                   = "${upper(local.name_prefix)}_API"
     arn                    = aws_lb.ztmf_api.arn
     http_port              = 80
     https_port             = 443

--- a/infrastructure/config/backend-impl.tf
+++ b/infrastructure/config/backend-impl.tf
@@ -1,0 +1,3 @@
+bucket = "ztmf-terraform-state-use1-impl"
+key    = "tfstate"
+region = "us-east-1"

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 data "aws_vpc" "ztmf" {
   filter {
     name   = "tag:Name"
-    values = ["ztmf-east-${var.environment}"]
+    values = ["ztmf-east-${local.vpc_environment}"]
   }
 }
 
@@ -72,7 +72,7 @@ data "aws_secretsmanager_secrets" "rds" {
 
   filter {
     name   = "tag-value"
-    values = ["arn:aws:rds:us-east-1:${local.account_id}:cluster:ztmf"]
+    values = ["arn:aws:rds:us-east-1:${local.account_id}:cluster:${local.name_prefix}"]
   }
 }
 
@@ -83,12 +83,14 @@ data "aws_secretsmanager_secrets" "rds" {
 # }
 
 data "aws_ssm_parameter" "ztmf_api_tag" {
-  name = "ztmf_api_tag"
+  name = "${local.name_prefix}_api_tag"
 }
 
 // this resource needed to be created manually by importing a Digitcert certificate
+// the cert's primary domain is dev.ztmf.cms.gov with other environments as SANs
+// impl.ztmf.cms.gov must be added as a SAN before deploying the impl environment
 data "aws_acm_certificate" "ztmf" {
-  domain      = "dev.ztmf.cms.gov" // use dev. here because thats the domain value of the cert. other names are listed as alts
+  domain      = "dev.ztmf.cms.gov"
   statuses    = ["ISSUED"]
   most_recent = true
 }

--- a/infrastructure/ec2.tf
+++ b/infrastructure/ec2.tf
@@ -1,32 +1,37 @@
 # this instance is only used as a bastion host to reach the database
+# only created when this environment owns its VPC (impl shares dev's bastion)
 
 resource "aws_instance" "bastion" {
+  count                       = local.is_vpc_owner ? 1 : 0
   ami                         = "ami-0f403e3180720dd7e"
-  iam_instance_profile        = aws_iam_instance_profile.ec2_bastion.name
+  iam_instance_profile        = aws_iam_instance_profile.ec2_bastion[0].name
   instance_type               = "t2.micro"
   associate_public_ip_address = false
-  vpc_security_group_ids      = [aws_security_group.ztmf_bastion.id]
+  vpc_security_group_ids      = [aws_security_group.ztmf_bastion[0].id]
   subnet_id                   = data.aws_subnets.private.ids[0]
   tags = {
-    Name = "ztmf-bastion"
+    Name = "${local.name_prefix}-bastion"
   }
 }
 
 module "ec2_bastion" {
-  name                = "ztmf_ec2_bastion"
+  count               = local.is_vpc_owner ? 1 : 0
+  name                = "${local.name_prefix}_ec2_bastion"
   source              = "./modules/role"
   principal           = { Service = "ec2.amazonaws.com" }
   managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
 }
 
 resource "aws_iam_instance_profile" "ec2_bastion" {
-  name = "ztmf_ec2_bastion"
-  role = module.ec2_bastion.role_name
-  path = "/delegatedadmin/adodeveloper/"
+  count = local.is_vpc_owner ? 1 : 0
+  name  = "${local.name_prefix}_ec2_bastion"
+  role  = module.ec2_bastion[0].role_name
+  path  = "/delegatedadmin/adodeveloper/"
 }
 
 resource "aws_security_group" "ztmf_bastion" {
-  name        = "ztmf_bastion"
+  count       = local.is_vpc_owner ? 1 : 0
+  name        = "${local.name_prefix}_bastion"
   description = "bastion host"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -36,7 +41,7 @@ resource "aws_security_group" "ztmf_bastion" {
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"
-    security_groups = [aws_security_group.ztmf_vpc_endpoints.id]
+    security_groups = [aws_security_group.ztmf_vpc_endpoints[0].id]
   }
 
   egress {

--- a/infrastructure/ecr.tf
+++ b/infrastructure/ecr.tf
@@ -1,10 +1,15 @@
+# ECR repo and scanning config are account-level resources.
+# When multiple environments share an account (dev + impl), only the VPC owner creates these.
+# Impl reuses dev's ECR repo — just pushes images with different tags.
 resource "aws_ecr_repository" "ztmf_api" {
+  count                = local.is_vpc_owner ? 1 : 0
   name                 = "ztmf/api"
   image_tag_mutability = "IMMUTABLE"
 }
 
 resource "aws_ecr_lifecycle_policy" "ztmf_api" {
-  repository = aws_ecr_repository.ztmf_api.name
+  count      = local.is_vpc_owner ? 1 : 0
+  repository = aws_ecr_repository.ztmf_api[0].name
 
   policy = <<EOF
 {
@@ -27,6 +32,7 @@ EOF
 }
 
 resource "aws_ecr_registry_scanning_configuration" "ztmf_api" {
+  count     = local.is_vpc_owner ? 1 : 0
   scan_type = "ENHANCED"
 
   rule {
@@ -36,4 +42,14 @@ resource "aws_ecr_registry_scanning_configuration" "ztmf_api" {
       filter_type = "WILDCARD"
     }
   }
+}
+
+# Data source to look up the shared ECR repo when this environment doesn't own it
+data "aws_ecr_repository" "ztmf_api" {
+  count = local.is_vpc_owner ? 0 : 1
+  name  = "ztmf/api"
+}
+
+locals {
+  ecr_repository_url = local.is_vpc_owner ? aws_ecr_repository.ztmf_api[0].repository_url : data.aws_ecr_repository.ztmf_api[0].repository_url
 }

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_cluster" "ztmf" {
-  name = "ztmf"
+  name = local.name_prefix
 
   setting {
     name  = "containerInsights"
@@ -8,14 +8,14 @@ resource "aws_ecs_cluster" "ztmf" {
 }
 
 module "api_task_execution" {
-  name                = "ztmf_api_task_execution"
+  name                = "${local.name_prefix}_api_task_execution"
   source              = "./modules/role"
   principal           = { Service = "ecs-tasks.amazonaws.com" }
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
 module "api_task" {
-  name      = "ztmf_api_task"
+  name      = "${local.name_prefix}_api_task"
   source    = "./modules/role"
   principal = { Service = "ecs-tasks.amazonaws.com" }
 }
@@ -44,13 +44,13 @@ resource "aws_iam_role_policy" "ztmf_api_task" {
 }
 
 resource "aws_cloudwatch_log_group" "ztmf_api" {
-  name = "ztmf_api"
+  name = "${local.name_prefix}_api"
 }
 
 resource "aws_ecs_task_definition" "ztmf_api" {
   execution_role_arn       = module.api_task_execution.role_arn
   task_role_arn            = module.api_task.role_arn
-  family                   = "api"
+  family                   = contains(["dev", "prod"], var.environment) ? "api" : "${local.name_prefix}-api"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 256
@@ -60,7 +60,7 @@ resource "aws_ecs_task_definition" "ztmf_api" {
       name             = "ztmfapi"
       command          = ["/usr/local/bin/ztmfapi"]
       workingDirectory = "/api"
-      image            = "${aws_ecr_repository.ztmf_api.repository_url}:${data.aws_ssm_parameter.ztmf_api_tag.insecure_value}"
+      image            = "${local.ecr_repository_url}:${data.aws_ssm_parameter.ztmf_api_tag.insecure_value}"
       essential        = true
       portMappings     = [{ containerPort = 443 }]
 
@@ -125,7 +125,7 @@ resource "aws_ecs_task_definition" "ztmf_api" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          "awslogs-group"         = "ztmf_api"
+          "awslogs-group"         = "${local.name_prefix}_api"
           "awslogs-region"        = "us-east-1"
           "awslogs-stream-prefix" = "api"
         }
@@ -135,7 +135,7 @@ resource "aws_ecs_task_definition" "ztmf_api" {
 }
 
 resource "aws_security_group" "ztmf_api_task" {
-  name        = "ztmf-api-task"
+  name        = "${local.name_prefix}-api-task"
   description = "Allow TLS inbound traffic"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -172,7 +172,7 @@ resource "aws_security_group" "ztmf_api_task" {
 }
 
 resource "aws_ecs_service" "ztmf_api" {
-  name            = "ztmf-api"
+  name            = "${local.name_prefix}-api"
   cluster         = aws_ecs_cluster.ztmf.id
   task_definition = aws_ecs_task_definition.ztmf_api.arn
   launch_type     = "FARGATE"

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -7,6 +7,20 @@ locals {
 
   domain_name = "${var.domain_name_prefix}ztmf.cms.gov"
 
+  // Resource name prefix: "ztmf" for dev/prod (preserves existing names), "ztmf-impl" for impl, etc.
+  // This allows multiple environments to coexist in the same AWS account without name collisions.
+  name_prefix = contains(["dev", "prod"], var.environment) ? "ztmf" : "ztmf-${var.environment}"
+
+  // Which VPC to use — impl shares the dev VPC, everything else uses its own
+  vpc_environment = var.vpc_environment != "" ? var.vpc_environment : var.environment
+
+  // Whether this environment owns its VPC (controls VPC endpoint creation, bastion, etc.)
+  // When sharing a VPC, these resources already exist from the owning environment.
+  is_vpc_owner = local.vpc_environment == var.environment
+
+  // Secret name prefix: shared secrets use "ztmf" for dev/prod, "ztmf_impl" for impl
+  secret_prefix = contains(["dev", "prod"], var.environment) ? "ztmf" : "ztmf_${var.environment}"
+
   // simplify referencing of json object fields for aws_verifiedaccess_trust_provider.ztmf_idmokta.oidc_options
   // technically only one of the fields was a true secret (client_secret), but since we have the space here
   //  we can use it to simplify code instead of placing all the other fields in TF vars

--- a/infrastructure/moved.tf
+++ b/infrastructure/moved.tf
@@ -1,0 +1,67 @@
+# Terraform moved blocks to handle refactoring without destroying resources.
+# These tell Terraform that resources have been renamed/re-indexed, not deleted.
+# Safe to remove these blocks after both dev and prod have been applied once.
+
+# Snowflake secret was conditional per-environment, now unified.
+# Terraform does not allow two moved blocks targeting the same destination,
+# even if only one source exists in state. We use the dev block here since
+# dev deploys first (on PR). For the first prod apply, run:
+#   terraform state mv 'aws_secretsmanager_secret.ztmf_snowflake_prod[0]' aws_secretsmanager_secret.ztmf_snowflake
+moved {
+  from = aws_secretsmanager_secret.ztmf_snowflake_dev[0]
+  to   = aws_secretsmanager_secret.ztmf_snowflake
+}
+
+# Bastion resources moved to count-based for VPC sharing support
+moved {
+  from = module.ec2_bastion
+  to   = module.ec2_bastion[0]
+}
+
+moved {
+  from = aws_iam_instance_profile.ec2_bastion
+  to   = aws_iam_instance_profile.ec2_bastion[0]
+}
+
+moved {
+  from = aws_instance.bastion
+  to   = aws_instance.bastion[0]
+}
+
+moved {
+  from = aws_security_group.ztmf_bastion
+  to   = aws_security_group.ztmf_bastion[0]
+}
+
+# VPC endpoint resources moved to count-based for VPC sharing support
+moved {
+  from = aws_security_group.ztmf_vpc_endpoints
+  to   = aws_security_group.ztmf_vpc_endpoints[0]
+}
+
+# GitHub OIDC resources moved to count-based for account sharing support
+moved {
+  from = aws_iam_openid_connect_provider.github_actions
+  to   = aws_iam_openid_connect_provider.github_actions[0]
+}
+
+moved {
+  from = module.github_actions
+  to   = module.github_actions[0]
+}
+
+# ECR resources moved to count-based for account sharing support
+moved {
+  from = aws_ecr_repository.ztmf_api
+  to   = aws_ecr_repository.ztmf_api[0]
+}
+
+moved {
+  from = aws_ecr_lifecycle_policy.ztmf_api
+  to   = aws_ecr_lifecycle_policy.ztmf_api[0]
+}
+
+moved {
+  from = aws_ecr_registry_scanning_configuration.ztmf_api
+  to   = aws_ecr_registry_scanning_configuration.ztmf_api[0]
+}

--- a/infrastructure/oidc.tf
+++ b/infrastructure/oidc.tf
@@ -1,4 +1,7 @@
+# GitHub OIDC provider is an account-level singleton (one per URL per account).
+# Only the VPC owner creates it — impl shares dev's provider and role.
 resource "aws_iam_openid_connect_provider" "github_actions" {
+  count          = local.is_vpc_owner ? 1 : 0
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
   thumbprint_list = [
@@ -8,9 +11,10 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
 }
 
 module "github_actions" {
+  count     = local.is_vpc_owner ? 1 : 0
   name      = "ztmf_github_actions"
   source    = "./modules/role"
-  principal = { Federated = aws_iam_openid_connect_provider.github_actions.arn }
+  principal = { Federated = aws_iam_openid_connect_provider.github_actions[0].arn }
   managed_policy_arns = [
     "arn:aws:iam::${local.account_id}:policy/CMSApprovedAWSServices",
     "arn:aws:iam::${local.account_id}:policy/ADO-Restriction-Policy",

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -29,7 +29,20 @@ output "lambda_function_arn" {
 
 # Store test events as SSM parameters for team reference
 resource "aws_ssm_parameter" "lambda_test_events" {
-  for_each = var.environment == "dev" ? {
+  for_each = var.environment == "prod" ? {
+    "prod-dry-run-validation" = jsonencode({
+      trigger_type = "manual"
+      dry_run      = true
+      tables       = ["users", "scores"]
+      full_refresh = false
+    })
+    "prod-manual-full-sync" = jsonencode({
+      trigger_type = "manual"
+      dry_run      = false
+      tables       = []
+      full_refresh = true
+    })
+    } : {
     "dry-run-single-table" = jsonencode({
       trigger_type = "manual"
       dry_run      = true
@@ -47,19 +60,6 @@ resource "aws_ssm_parameter" "lambda_test_events" {
       dry_run      = false
       tables       = ["users"]
       full_refresh = false
-    })
-    } : {
-    "prod-dry-run-validation" = jsonencode({
-      trigger_type = "manual"
-      dry_run      = true
-      tables       = ["users", "scores"]
-      full_refresh = false
-    })
-    "prod-manual-full-sync" = jsonencode({
-      trigger_type = "manual"
-      dry_run      = false
-      tables       = []
-      full_refresh = true
     })
   }
 

--- a/infrastructure/rds.tf
+++ b/infrastructure/rds.tf
@@ -1,10 +1,10 @@
 resource "aws_db_subnet_group" "ztmf" {
-  name       = "ztmf"
+  name       = local.name_prefix
   subnet_ids = data.aws_subnets.private.ids
 }
 
 resource "aws_security_group" "ztmf_db" {
-  name        = "ztmf_db"
+  name        = "${local.name_prefix}_db"
   description = "Allow postgresql inbound traffic"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -18,7 +18,7 @@ resource "aws_security_group" "ztmf_db" {
 }
 
 resource "aws_rds_cluster" "ztmf" {
-  cluster_identifier          = "ztmf"
+  cluster_identifier          = local.name_prefix
   engine                      = "aurora-postgresql"
   engine_mode                 = "provisioned"
   engine_version              = "16.8"
@@ -29,8 +29,8 @@ resource "aws_rds_cluster" "ztmf" {
   storage_encrypted           = true
 
   serverlessv2_scaling_configuration {
-    max_capacity = 1.0
-    min_capacity = 0.5
+    max_capacity = var.aurora_max_capacity
+    min_capacity = var.aurora_min_capacity
   }
   vpc_security_group_ids = [aws_security_group.ztmf_db.id]
 }

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "allow_s3_access_from_cloudfront" {
 }
 
 resource "aws_s3_bucket" "ztmf_logs" {
-  bucket = "ztmf-logs-${local.account_id}-use1"
+  bucket = "${local.name_prefix}-logs-${local.account_id}-use1"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "ztmf_logs" {

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -1,75 +1,61 @@
+# OIDC configuration for ALB authentication (each environment has its own Okta app)
 resource "aws_secretsmanager_secret" "ztmf_va_trust_provider" {
-  name = "ztmf_va_trust_provider"
+  name = "${local.secret_prefix}_va_trust_provider"
 }
 
 # cert and key are the TLS digicert certificate purchased by Elizabeth S.
-# initially we tried to use them on the Fargate container but decided to 
+# initially we tried to use them on the Fargate container but decided to
 # simplify things by just generating self-signed certs during container builds
 # leaving them here so they arent stored locally in case we need the value again
 resource "aws_secretsmanager_secret" "ztmf_tls_cert" {
-  name = "ztmf_tls_cert"
+  name = "${local.secret_prefix}_tls_cert"
 }
 
 resource "aws_secretsmanager_secret" "ztmf_tls_key" {
-  name = "ztmf_tls_key"
+  name = "${local.secret_prefix}_tls_key"
 }
 
 # DB user is only used to create the DB, its value is then copied into the RDS-managed auto-rotated secret
 resource "aws_secretsmanager_secret" "ztmf_db_user" {
-  name = "ztmf_db_user"
+  name = "${local.secret_prefix}_db_user"
 }
 
 # host, port, and credentials for logging in to CMS SMTP service
 resource "aws_secretsmanager_secret" "ztmf_smtp" {
-  name = "ztmf_smtp"
+  name = "${local.secret_prefix}_smtp"
 }
 
 # CA certs for validating TLS connection to SMTP service
 resource "aws_secretsmanager_secret" "ztmf_smtp_ca_root" {
-  name = "ztmf_smtp_ca_root"
+  name = "${local.secret_prefix}_smtp_ca_root"
 }
 
 resource "aws_secretsmanager_secret" "ztmf_smtp_intermediate" {
-  name = "ztmf_smtp_intermediate"
+  name = "${local.secret_prefix}_smtp_intermediate"
 }
 
-# Snowflake credentials for data sync Lambda function (dev environment)
-resource "aws_secretsmanager_secret" "ztmf_snowflake_dev" {
-  count = var.environment == "dev" ? 1 : 0
-  name  = "ztmf_snowflake_dev"
+# Snowflake credentials for data sync Lambda function
+resource "aws_secretsmanager_secret" "ztmf_snowflake" {
+  name = "ztmf_snowflake_${var.environment}"
 
-  description = "Snowflake credentials for ZTMF data sync in dev environment"
+  description = "Snowflake credentials for ZTMF data sync in ${var.environment} environment"
 
   tags = {
-    Name        = "ZTMF Snowflake Dev Credentials"
-    Environment = "dev"
+    Name        = "ZTMF Snowflake ${title(var.environment)} Credentials"
+    Environment = var.environment
     Purpose     = "Lambda data sync"
   }
 }
 
-# Snowflake credentials for data sync Lambda function (prod environment)
-resource "aws_secretsmanager_secret" "ztmf_snowflake_prod" {
-  count = var.environment == "prod" ? 1 : 0
-  name  = "ztmf_snowflake_prod"
-
-  description = "Snowflake credentials for ZTMF data sync in prod environment"
-
-  tags = {
-    Name        = "ZTMF Snowflake Prod Credentials"
-    Environment = "prod"
-    Purpose     = "Lambda data sync"
-  }
-}
-
-# Slack webhook URL for data sync alerts (shared across environments)
+# Slack webhook URL for data sync alerts
 resource "aws_secretsmanager_secret" "ztmf_slack_webhook" {
-  name = "ztmf_slack_webhook"
+  name = "${local.secret_prefix}_slack_webhook"
 
   description = "Slack webhook URL for ZTMF data sync alerts and notifications"
 
   tags = {
     Name        = "ZTMF Slack Webhook"
-    Environment = "shared"
+    Environment = var.environment
     Purpose     = "Data sync notifications"
   }
 }

--- a/infrastructure/tfvars/impl.tfvars
+++ b/infrastructure/tfvars/impl.tfvars
@@ -1,0 +1,12 @@
+# ZTMF impl environment — lives in the dev AWS account alongside dev
+# Shares dev VPC (ztmf-east-dev) but has its own RDS, ECS, ALB, CloudFront, etc.
+environment            = "impl"
+domain_name_prefix     = "impl."
+ecs_service_task_count = 1
+aurora_min_capacity    = 0.5
+aurora_max_capacity    = 0.5
+vpc_environment        = "dev" # share dev's VPC since there is no ztmf-east-impl
+
+# CFACTS / Snowflake sync configuration
+cfacts_snowflake_view  = "BUS_ZEROTRUST.PRIVATE.VW_CFACTS_SYSTEMS_FOR_ZTMF"
+snowflake_table_prefix = "ZTMF"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -7,9 +7,27 @@ variable "domain_name_prefix" {
   default = ""
 }
 
+variable "vpc_environment" {
+  description = "Which environment's VPC to use (e.g. impl shares dev's VPC). Empty string means use own environment."
+  type        = string
+  default     = ""
+}
+
 variable "ecs_service_task_count" {
   type    = number
   default = 1
+}
+
+variable "aurora_min_capacity" {
+  description = "Aurora Serverless v2 minimum ACU (0.5 is the AWS minimum)"
+  type        = number
+  default     = 0.5
+}
+
+variable "aurora_max_capacity" {
+  description = "Aurora Serverless v2 maximum ACU"
+  type        = number
+  default     = 1.0
 }
 
 variable "cfacts_snowflake_view" {

--- a/infrastructure/vpc.tf
+++ b/infrastructure/vpc.tf
@@ -1,7 +1,10 @@
-# CMS already provides a VPC, we just need some endpoints in it
+# CMS already provides a VPC, we just need some endpoints in it.
+# VPC endpoints are per-VPC singletons — only the VPC owner creates them.
+# Environments sharing a VPC (e.g. impl sharing dev's) skip endpoint creation.
 
 resource "aws_security_group" "ztmf_vpc_endpoints" {
-  name        = "ztmf_vpc_endpoints"
+  count       = local.is_vpc_owner ? 1 : 0
+  name        = "${local.name_prefix}_vpc_endpoints"
   description = "Allow HTTP(S) traffic from private subnets"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -23,12 +26,12 @@ resource "aws_security_group" "ztmf_vpc_endpoints" {
 }
 
 resource "aws_vpc_endpoint" "ztmf" {
-  for_each            = toset(["ec2", "logs", "ecr.api", "ecr.dkr", "secretsmanager", "ssm", "ec2messages", "ssmmessages", "s3"])
+  for_each            = local.is_vpc_owner ? toset(["ec2", "logs", "ecr.api", "ecr.dkr", "secretsmanager", "ssm", "ec2messages", "ssmmessages", "s3"]) : toset([])
   vpc_id              = data.aws_vpc.ztmf.id
   service_name        = "com.amazonaws.us-east-1.${each.value}"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = data.aws_subnets.private.ids
-  security_group_ids  = [aws_security_group.ztmf_vpc_endpoints.id]
+  security_group_ids  = [aws_security_group.ztmf_vpc_endpoints[0].id]
   private_dns_enabled = true
   dns_options { private_dns_only_for_inbound_resolver_endpoint = false }
 }


### PR DESCRIPTION
## Summary

- Adds `impl` environment that coexists with `dev` in the same AWS account (451245779631)
- Impl shares dev's VPC, VPC endpoints, bastion, ECR repo, and GitHub OIDC provider
- All other resources (ECS, RDS, ALB, CloudFront, Secrets, Lambdas) are fully isolated
- CI triggers on PRs to `impl` branch, completely independent of dev/prod pipelines
- Aurora pinned to 0.5 ACU minimum (~$70-75/mo total for the environment)

## Prerequisites before deploying impl

- [ ] Create S3 bucket `ztmf-terraform-state-use1-impl` in dev account
- [ ] Create SSM parameter `ztmf-impl_api_tag` with an initial image tag
- [ ] Add `impl.ztmf.cms.gov` as SAN on the DigiCert ACM certificate
- [ ] Create new Okta app for impl, store creds in `ztmf_impl_va_trust_provider` secret
- [ ] Create GitHub environment `IMPL` with ROLEARN, ECR_REPO_URL, PARAMETER_NAME secrets
- [ ] DNS CNAME `impl.ztmf.cms.gov` → impl CloudFront distribution
- [ ] Create `impl` branch from `main`
- [ ] For first prod apply: `terraform state mv 'aws_secretsmanager_secret.ztmf_snowflake_prod[0]' aws_secretsmanager_secret.ztmf_snowflake`

## Dev impact

Terraform plan against dev shows **0 to add, 1 to change, 0 to destroy** (only a Slack webhook tag update). All other changes are state moves via `moved.tf` blocks.

## Test plan

- [x] `terraform validate` passes
- [x] `terraform plan` against dev shows no destructive changes
- [x] All 75 Emberfall E2E tests pass
- [ ] Verify no CI triggers on this draft PR