### PR TITLE
508 compliance: restore user + reactivate system endpoints

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -28,6 +28,11 @@ INSERT INTO public.users VALUES (DEFAULT, 'Readonly.Admin@nowhere.xyz', 'Readonl
 -- Fixed UUID so we can assign to fismasystems for CFACTS access testing.
 INSERT INTO public.users VALUES ('66666666-6666-6666-6666-666666666666', 'Isso.User@nowhere.xyz', 'ISSO Test User', 'ISSO', DEFAULT) ON CONFLICT DO NOTHING;
 
+-- Pre-deleted user fixture for RestoreUser tests.
+-- UUID is v4-conforming (4 at position 14, 8 at position 19) so it satisfies
+-- isValidUUID's strict regex when used as a path param.
+INSERT INTO public.users VALUES ('77777777-7777-4777-8777-777777777777', 'Captain.Needa@executor.empire', 'Captain Needa', 'ISSO', TRUE) ON CONFLICT DO NOTHING;
+
 -- Test Pillars (using production pillar names for testing consistency)
 INSERT INTO public.pillars VALUES (1, 'Devices', 0) ON CONFLICT DO NOTHING;
 INSERT INTO public.pillars VALUES (2, 'Applications', 0) ON CONFLICT DO NOTHING;
@@ -100,6 +105,27 @@ INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismanam
     NULL,
     NULL,
     NULL
+) ON CONFLICT DO NOTHING;
+
+-- Pre-decommissioned fixture for ReactivateFismaSystem tests
+INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes) VALUES (
+    1004,
+    'BC1B3100-1980-4D5E-AB8C-D1FE0BB00808',
+    'SD-TYR',
+    'Star Destroyer Tyrant',
+    'Imperial Class Destroyer',
+    'IMPNAVY-(FLEET)',
+    'STARCOM',
+    'Imperial Starfleet Command',
+    'Naval Operations Division',
+    'Imperial-Fleet',
+    'admiral.ozzel@executor.empire',
+    'Captain.Needa@executor.empire',
+    FALSE,
+    TRUE,
+    '1980-05-21 00:00:00+00',
+    '11111111-1111-1111-1111-111111111111',
+    'Decommissioned to provide a reactivation test target'
 ) ON CONFLICT DO NOTHING;
 
 -- User-System Assignments (Officers assigned to their systems)

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -95,6 +95,24 @@ func TestSaveUser_ISSOForbidden(t *testing.T) {
 
 // --- DeleteUser ---
 
+func TestRestoreUser_ReadonlyAdminForbidden(t *testing.T) {
+	r := httptest.NewRequest("PUT", "/api/v1/users/11111111-1111-1111-1111-111111111111/restore", nil)
+	r = withUser(r, readonlyAdmin)
+	w := httptest.NewRecorder()
+
+	RestoreUser(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestRestoreUser_ISSOForbidden(t *testing.T) {
+	r := httptest.NewRequest("PUT", "/api/v1/users/11111111-1111-1111-1111-111111111111/restore", nil)
+	r = withUser(r, issoUser)
+	w := httptest.NewRecorder()
+
+	RestoreUser(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 func TestDeleteUser_ReadonlyAdminForbidden(t *testing.T) {
 	r := httptest.NewRequest("DELETE", "/api/v1/users/11111111-1111-1111-1111-111111111111", nil)
 	r = withUser(r, readonlyAdmin)
@@ -284,6 +302,24 @@ func TestDeleteFismaSystem_ReadonlyAdminForbidden(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	DeleteFismaSystem(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestReactivateFismaSystem_ReadonlyAdminForbidden(t *testing.T) {
+	r := httptest.NewRequest("PUT", "/api/v1/fismasystems/1/reactivate", nil)
+	r = withUser(r, readonlyAdmin)
+	w := httptest.NewRecorder()
+
+	ReactivateFismaSystem(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestReactivateFismaSystem_ISSOForbidden(t *testing.T) {
+	r := httptest.NewRequest("PUT", "/api/v1/fismasystems/1/reactivate", nil)
+	r = withUser(r, issoUser)
+	w := httptest.NewRecorder()
+
+	ReactivateFismaSystem(w, r)
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 

--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -21,6 +21,16 @@ type response struct {
 	Err  string `json:"error,omitempty"`
 }
 
+// respondOK writes an HTTP 200 with the JSON-wrapped data payload. Use for
+// PUT-as-action endpoints (restore, reactivate) that return the updated entity
+// rather than 204; respond() reserves PUT for in-place updates that drop the
+// body.
+func respondOK(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response{Data: data})
+}
+
 func respond(w http.ResponseWriter, r *http.Request, data any, err error) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -147,3 +147,52 @@ func DeleteFismaSystem(w http.ResponseWriter, r *http.Request) {
 
 	respond(w, r, system, nil)
 }
+
+// ReactivateRequest contains optional parameters for reactivating a system
+type ReactivateRequest struct {
+	Notes *string `json:"notes,omitempty"`
+}
+
+// ReactivateFismaSystem clears the decommissioned flag and stamps reactivation
+// audit columns (admin only).
+func ReactivateFismaSystem(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.IsAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	vars := mux.Vars(r)
+	fismaSystemIDStr, ok := vars["fismasystemid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	var fismaSystemID int32
+	fmt.Sscan(fismaSystemIDStr, &fismaSystemID)
+
+	var req ReactivateRequest
+	if r.ContentLength > 0 {
+		if err := getJSON(r.Body, &req); err != nil {
+			log.Println(err)
+			respond(w, r, nil, ErrMalformed)
+			return
+		}
+	}
+
+	input := model.ReactivateInput{
+		FismaSystemID: fismaSystemID,
+		UserID:        authdUser.UserID,
+		Notes:         req.Notes,
+	}
+
+	system, err := model.ReactivateFismaSystem(r.Context(), input)
+	if err != nil {
+		log.Println(err)
+		respond(w, r, nil, err)
+		return
+	}
+
+	respondOK(w, system)
+}

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -111,3 +111,28 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 
 	respond(w, r, nil, nil)
 }
+
+// RestoreUser clears the deleted flag on a soft-deleted user (admin only).
+func RestoreUser(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.IsAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	vars := mux.Vars(r)
+	userID, ok := vars["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	user, err := model.RestoreUser(r.Context(), userID)
+	if err != nil {
+		log.Println(err)
+		respond(w, r, nil, err)
+		return
+	}
+
+	respondOK(w, user)
+}

--- a/backend/cmd/api/internal/migrations/0025reactivatefismasystems.go
+++ b/backend/cmd/api/internal/migrations/0025reactivatefismasystems.go
@@ -1,0 +1,45 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add fismasystems reactivation audit columns",
+		`
+-- Drop incorrectly typed columns if they exist from a failed prior migration attempt.
+-- CASCADE on every column for consistency, even though only reactivated_by has a
+-- dependent FK; safer if a future migration adds dependent objects on the others.
+ALTER TABLE IF EXISTS public.fismasystems
+    DROP COLUMN IF EXISTS reactivated_by CASCADE,
+    DROP COLUMN IF EXISTS reactivated_date CASCADE,
+    DROP COLUMN IF EXISTS reactivation_notes CASCADE;
+
+-- Add reactivation audit columns
+ALTER TABLE IF EXISTS public.fismasystems
+    ADD COLUMN reactivated_by UUID,
+    ADD COLUMN reactivated_date TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN reactivation_notes TEXT;
+
+-- Foreign key to users so reactivator history survives user soft-deletes
+ALTER TABLE IF EXISTS public.fismasystems
+    ADD CONSTRAINT fk_reactivated_by
+    FOREIGN KEY (reactivated_by)
+    REFERENCES users(userid)
+    ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_fismasystems_reactivated_by
+    ON public.fismasystems(reactivated_by)
+    WHERE reactivated_by IS NOT NULL;
+
+COMMENT ON COLUMN public.fismasystems.reactivated_by IS 'User ID who reactivated the system after decommission';
+COMMENT ON COLUMN public.fismasystems.reactivated_date IS 'Timestamp the system was reactivated';
+COMMENT ON COLUMN public.fismasystems.reactivation_notes IS 'Reason or notes for reactivation';
+        `,
+		`
+ALTER TABLE IF EXISTS public.fismasystems
+    DROP CONSTRAINT IF EXISTS fk_reactivated_by,
+    DROP COLUMN IF EXISTS reactivated_by,
+    DROP COLUMN IF EXISTS reactivated_date,
+    DROP COLUMN IF EXISTS reactivation_notes;
+
+DROP INDEX IF EXISTS idx_fismasystems_reactivated_by;
+        `)
+}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -30,6 +30,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}", controller.GetFismaSystem).Methods("GET")
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}", controller.SaveFismaSystem).Methods("PUT")
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}", controller.DeleteFismaSystem).Methods("DELETE")
+	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/reactivate", controller.ReactivateFismaSystem).Methods("PUT")
 	// returns a list of data calls that this fisma system has marked complete
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/datacalls", controller.ListFismaSystemDataCalls).Methods("GET")
 
@@ -44,6 +45,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.GetUserByID).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.SaveUser).Methods("PUT")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.DeleteUser).Methods("DELETE")
+	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/restore", controller.RestoreUser).Methods("PUT")
 
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems", controller.ListUserFismaSystems).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems", controller.CreateUserFismaSystem).Methods("POST")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -74,6 +74,19 @@ decommissionedFismaSystemData: &decommissionedFismaSystemData
   decommissioned_date: "2025-01-15T00:00:00Z"
   decommissioned_notes: "System migrated to cloud infrastructure"
 
+# Reactivation flips decommissioned back to false but preserves the prior
+# decommission audit columns for history. reactivated_date is server-stamped
+# via NOW(), so it is not asserted here.
+reactivatedFismaSystemData: &reactivatedFismaSystemData
+  fismauid: "12345678-ABCD-4321-AFAB-123456789ABC"
+  fismaacronym: "ZTMF-UPD"
+  fismaname: "Updated Zero Trust Maturity Framework"
+  sdl_sync_enabled: true
+  decommissioned: false
+  decommissioned_date: "2025-01-15T00:00:00Z"
+  decommissioned_notes: "System migrated to cloud infrastructure"
+  reactivation_notes: "Brought back online for follow-on work"
+
 functionData: &functionData
   function: "Identity Management"
   description: "Manage user identities and access"
@@ -103,6 +116,12 @@ deletedUserData: &deletedUserData
   fullname: "Updated Test User"
   role: "ISSO"
   deleted: true
+
+restoredUserData: &restoredUserData
+  email: "updated.user@example.com"
+  fullname: "Updated Test User"
+  role: "ISSO"
+  deleted: false
 
 questionData: &questionData
   question: "How do you manage user identities?"
@@ -412,6 +431,43 @@ tests:
           data:
             <<: *decommissionedFismaSystemData
 
+  # Reactivate the decommissioned system (508 compliance restore path).
+  # reactivated_by/reactivated_date are not asserted here because Emberfall does
+  # not substitute {{...}} templates inside body matchers (URLs only). Same
+  # reason decommissioned_by is omitted from decommissionedFismaSystemData.
+  # Coverage of those fields lives in unit tests + manual smoke.
+  - id: reactivateFismaSystem
+    url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}/reactivate"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        notes: "Brought back online for follow-on work"
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            <<: *reactivatedFismaSystemData
+
+  # Verify reactivated system reflects the cleared decommissioned flag on read
+  - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            <<: *reactivatedFismaSystemData
+
 
   # Functions Endpoints
   - id: createFunction
@@ -617,6 +673,35 @@ tests:
         json:
           data:
             <<: *deletedUserData
+
+  # Restore the deleted user (508 compliance recovery path)
+  - id: restoreUser
+    url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}/restore"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            <<: *restoredUserData
+
+  # Verify restored user shows deleted=false on read
+  - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            <<: *restoredUserData
 
   # # Scores Endpoints
   # - id: createScore
@@ -953,6 +1038,26 @@ tests:
     expect:
       status: 403
 
+  # READONLY_ADMIN gets 403 on PUT /api/v1/users/{id}/restore (write blocked)
+  - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}/restore"
+    method: PUT
+    headers:
+      <<: *readonlyAdminHeaders
+    expect:
+      status: 403
+
+  # READONLY_ADMIN gets 403 on PUT /api/v1/fismasystems/{id}/reactivate (write blocked)
+  - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}/reactivate"
+    method: PUT
+    headers:
+      <<: *readonlyAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        notes: "should be blocked"
+    expect:
+      status: 403
+
   # READONLY_ADMIN gets 403 on POST /api/v1/massemails (write blocked)
   - url: http://localhost:8080/api/v1/massemails
     method: POST
@@ -1093,6 +1198,26 @@ tests:
         email: "blocked@example.com"
         fullname: "Blocked User"
         role: "ISSO"
+    expect:
+      status: 403
+
+  # ISSO gets 403 on PUT /api/v1/users/{id}/restore (write blocked)
+  - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}/restore"
+    method: PUT
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 403
+
+  # ISSO gets 403 on PUT /api/v1/fismasystems/{id}/reactivate (write blocked)
+  - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}/reactivate"
+    method: PUT
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        notes: "should be blocked"
     expect:
       status: 403
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/schema v1.4.1
-	github.com/jackc/pgx/v5 v5.9.1
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jackc/tern/v2 v2.3.6
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
 	github.com/snowflakedb/gosnowflake v1.19.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -130,8 +130,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
-github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackc/tern/v2 v2.3.6 h1:sqBIZ/CBtfMLz7zdUof0N6cVUBRVGBZ7S+F2OdCp9XU=

--- a/backend/internal/model/errors.go
+++ b/backend/internal/model/errors.go
@@ -49,16 +49,22 @@ func trapError(e error) error {
 		return ErrTooMuchData
 	}
 
-	e = errors.Unwrap(e)
-	// switch is the only way to check against custom error types
-	switch err := e.(type) {
-	case *pgconn.PgError:
-		switch err.Code {
+	// errors.As walks the wrap chain so we catch *pgconn.PgError whether pgx
+	// returns it directly or wrapped through one or more layers. errors.Unwrap
+	// alone strips a single layer and returns nil for unwrapped errors, which
+	// silently dropped 23505/23503 into the "unknown error" path.
+	var pgErr *pgconn.PgError
+	if errors.As(e, &pgErr) {
+		switch pgErr.Code {
 		case "23505":
 			// unique_violation encountered when a column is meant to contain unique values
 			// and a non-unique value is being added via insert or update
-			text := strings.Split(err.Detail, "=")
-			return fmt.Errorf("%w : %s", ErrNotUnique, text[1])
+			text := strings.Split(pgErr.Detail, "=")
+			detail := pgErr.Detail
+			if len(text) > 1 {
+				detail = text[1]
+			}
+			return fmt.Errorf("%w : %s", ErrNotUnique, detail)
 
 		case "23503":
 			// foreign_key_violation encountered when adding a record to a table with a foreign key
@@ -68,7 +74,7 @@ func trapError(e error) error {
 		case "28P01":
 			// failed to connect, password authentication failed
 			// TODO refactor DB secret caching/refreshing to avoid needing this!
-			log.Fatal(err.Error())
+			log.Fatal(pgErr.Error())
 		}
 	}
 

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -2,14 +2,16 @@ package model
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 	"github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
 )
 
-var fismaSystemColumns = []string{"fismasystemid", "fismauid", "fismaacronym", "fismaname", "fismasubsystem", "component", "groupacronym", "groupname", "divisionname", "datacenterenvironment", "datacallcontact", "issoemail", "sdl_sync_enabled", "decommissioned", "decommissioned_date", "decommissioned_by", "decommissioned_notes"}
+var fismaSystemColumns = []string{"fismasystemid", "fismauid", "fismaacronym", "fismaname", "fismasubsystem", "component", "groupacronym", "groupname", "divisionname", "datacenterenvironment", "datacallcontact", "issoemail", "sdl_sync_enabled", "decommissioned", "decommissioned_date", "decommissioned_by", "decommissioned_notes", "reactivated_by", "reactivated_date", "reactivation_notes"}
 
 type FismaSystem struct {
 	FismaSystemID         int32   `json:"fismasystemid"`
@@ -29,6 +31,9 @@ type FismaSystem struct {
 	DecommissionedDate    *time.Time `json:"decommissioned_date"`
 	DecommissionedBy      *string    `json:"decommissioned_by"`
 	DecommissionedNotes   *string    `json:"decommissioned_notes"`
+	ReactivatedBy         *string    `json:"reactivated_by"`
+	ReactivatedDate       *time.Time `json:"reactivated_date"`
+	ReactivationNotes     *string    `json:"reactivation_notes"`
 }
 
 type FindFismaSystemsInput struct {
@@ -199,6 +204,97 @@ func UpdateDecommissionMetadata(ctx context.Context, input DecommissionInput) er
 
 	_, err := queryRow(ctx, sqlb, pgx.RowToAddrOfStructByName[FismaSystem])
 	return err
+}
+
+// ReactivateInput contains parameters for reactivating a decommissioned system
+type ReactivateInput struct {
+	FismaSystemID int32
+	UserID        string
+	Notes         *string
+}
+
+// ReactivateFismaSystem clears the decommissioned flag and stamps the
+// reactivation audit columns. Existing decommissioned_* columns are preserved
+// so the prior decommission record remains queryable for history.
+//
+// Uses a transaction with SELECT FOR UPDATE so the not-found vs already-active
+// distinction is decided atomically with the row lock held. Records the audit
+// event manually because the transactional path bypasses queryRow's automatic
+// recordEvent hook.
+func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSystem, error) {
+	if !isValidIntID(input.FismaSystemID) {
+		return nil, ErrNoData
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return nil, trapError(err)
+	}
+	defer tx.Rollback(ctx)
+
+	var decommissioned bool
+	err = tx.QueryRow(ctx,
+		"SELECT decommissioned FROM fismasystems WHERE fismasystemid=$1 FOR UPDATE",
+		input.FismaSystemID,
+	).Scan(&decommissioned)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNoData
+	}
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	if !decommissioned {
+		return nil, &InvalidInputError{
+			data: map[string]any{"decommissioned": "system is already active"},
+		}
+	}
+
+	sqlb := stmntBuilder.
+		Update("fismasystems").
+		Set("decommissioned", false).
+		Set("reactivated_by", input.UserID).
+		Set("reactivated_date", squirrel.Expr("NOW()"))
+
+	if input.Notes != nil {
+		sqlb = sqlb.Set("reactivation_notes", *input.Notes)
+	}
+
+	sqlb = sqlb.Where("fismasystemid=?", input.FismaSystemID).
+		Suffix("RETURNING " + strings.Join(fismaSystemColumns, ", "))
+
+	sql, args, err := sqlb.ToSql()
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, trapError(err)
+	}
+	system, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[FismaSystem])
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	if actor := UserFromContext(ctx); actor != nil {
+		if _, err := tx.Exec(ctx,
+			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
+			actor.UserID, "updated", "fismasystems", system,
+		); err != nil {
+			return nil, trapError(err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, trapError(err)
+	}
+	return &system, nil
 }
 
 func (f *FismaSystem) validate() error {

--- a/backend/internal/model/fismasystems_test.go
+++ b/backend/internal/model/fismasystems_test.go
@@ -253,6 +253,41 @@ func TestDeleteFismaSystem_WithCustomDate(t *testing.T) {
 	})
 }
 
+// TestReactivateFismaSystem covers the input validation paths that don't
+// require a live database. End-to-end happy-path coverage lives in Emberfall.
+func TestReactivateFismaSystem(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("InvalidID", func(t *testing.T) {
+		_, err := ReactivateFismaSystem(ctx, ReactivateInput{
+			FismaSystemID: 0,
+			UserID:        "11111111-1111-1111-1111-111111111111",
+		})
+		assert.Equal(t, ErrNoData, err)
+	})
+}
+
+// TestFismaSystemReactivationFields confirms the struct exposes the new
+// audit fields and that the column array stays in the expected positions.
+func TestFismaSystemReactivationFields(t *testing.T) {
+	now := time.Now()
+	user := "11111111-1111-1111-1111-111111111111"
+	notes := "back in service"
+	system := FismaSystem{
+		ReactivatedBy:     &user,
+		ReactivatedDate:   &now,
+		ReactivationNotes: &notes,
+	}
+
+	assert.Equal(t, &user, system.ReactivatedBy)
+	assert.Equal(t, &now, system.ReactivatedDate)
+	assert.Equal(t, &notes, system.ReactivationNotes)
+
+	assert.Equal(t, "reactivated_by", fismaSystemColumns[17])
+	assert.Equal(t, "reactivated_date", fismaSystemColumns[18])
+	assert.Equal(t, "reactivation_notes", fismaSystemColumns[19])
+}
+
 // Helper function for creating string pointers
 func stringPtr(s string) *string {
 	return &s

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -49,10 +49,11 @@ func (u *User) Save(ctx context.Context) (*User, error) {
 	}
 
 	var sqlb SqlBuilder
+	creating := u.UserID == ""
 
 	// deleted column is intentionally left out as it cannot be set by an update, and on create it defaults to false
 	// it must be set via explicit delete. See DeleteUser below
-	if u.UserID == "" {
+	if creating {
 		sqlb = stmntBuilder.
 			Insert("users").
 			Columns("email", "fullname", "role").
@@ -68,7 +69,21 @@ func (u *User) Save(ctx context.Context) (*User, error) {
 			Suffix("RETURNING userid, email, fullname, role, deleted")
 	}
 
-	return queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
+	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
+	if err != nil && creating && errors.Is(err, ErrNotUnique) {
+		// Translate the bare unique-violation into a state-aware hint so the
+		// UI can guide the admin to the right recovery path. The email index
+		// is case-insensitive, so use FindUserByEmail (which also lowercases)
+		// to detect whether the conflict is with an active or soft-deleted user.
+		if existing, findErr := FindUserByEmail(ctx, u.Email); findErr == nil && existing != nil {
+			msg := "a user with this email already exists"
+			if existing.Deleted {
+				msg = "a user with this email exists in a deleted state; toggle Show Deleted and use Restore instead of creating a new record"
+			}
+			return nil, &InvalidInputError{data: map[string]any{"email": msg}}
+		}
+	}
+	return saved, err
 }
 
 func (u *User) validate() error {

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -2,8 +2,10 @@ package model
 
 import (
 	"context"
+	"errors"
 	"strings"
 
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -178,4 +180,67 @@ func DeleteUser(ctx context.Context, userid string) error {
 
 	_, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
 	return err
+}
+
+// RestoreUser clears the soft-delete flag on a user and returns the restored
+// record. Uses a transaction with SELECT FOR UPDATE so the not-found vs
+// already-active distinction is decided atomically with the row lock held.
+// Records the audit event manually because the transactional path bypasses
+// queryRow's automatic recordEvent hook.
+func RestoreUser(ctx context.Context, userid string) (*User, error) {
+	if !isValidUUID(userid) {
+		return nil, ErrNoData
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return nil, trapError(err)
+	}
+	defer tx.Rollback(ctx)
+
+	var deleted bool
+	err = tx.QueryRow(ctx,
+		"SELECT deleted FROM users WHERE userid=$1 FOR UPDATE",
+		userid,
+	).Scan(&deleted)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNoData
+	}
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	if !deleted {
+		return nil, &InvalidInputError{
+			data: map[string]any{"deleted": "user is already active"},
+		}
+	}
+
+	var restored User
+	err = tx.QueryRow(ctx,
+		"UPDATE users SET deleted=false WHERE userid=$1 RETURNING userid, email, fullname, role, deleted",
+		userid,
+	).Scan(&restored.UserID, &restored.Email, &restored.FullName, &restored.Role, &restored.Deleted)
+	if err != nil {
+		return nil, trapError(err)
+	}
+
+	if actor := UserFromContext(ctx); actor != nil {
+		if _, err := tx.Exec(ctx,
+			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
+			actor.UserID, "updated", "users", restored,
+		); err != nil {
+			return nil, trapError(err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, trapError(err)
+	}
+	return &restored, nil
 }

--- a/backend/internal/model/users_test.go
+++ b/backend/internal/model/users_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,6 +75,22 @@ func TestUser_IsAssignedFismaSystem(t *testing.T) {
 
 	empty := &User{}
 	assert.False(t, empty.IsAssignedFismaSystem(100))
+}
+
+// TestRestoreUser covers the input validation paths that don't require a
+// live database. End-to-end happy-path coverage lives in Emberfall.
+func TestRestoreUser(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("InvalidUUID", func(t *testing.T) {
+		_, err := RestoreUser(ctx, "not-a-uuid")
+		assert.Equal(t, ErrNoData, err)
+	})
+
+	t.Run("EmptyUUID", func(t *testing.T) {
+		_, err := RestoreUser(ctx, "")
+		assert.Equal(t, ErrNoData, err)
+	})
 }
 
 func TestUser_Validate(t *testing.T) {

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -377,6 +377,48 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  /fismasystems/{fismasystemid}/reactivate:
+    put:
+      summary: Reactivate a decommissioned FISMA system
+      description: Clears the decommissioned flag on a FISMA system and stamps reactivation audit columns (Admin only). Decommission audit columns are preserved for history.
+      operationId: reactivateFismaSystem
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: fismasystemid
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notes:
+                  type: string
+                  description: Reason or notes for reactivation
+      responses:
+        '200':
+          description: FISMA system reactivated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/FismaSystem'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /fismasystems/{fismasystemid}/datacalls:
     get:
       summary: List completed data calls for a FISMA system
@@ -624,6 +666,38 @@ paths:
       responses:
         '204':
           description: User deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /users/{userid}/restore:
+    put:
+      summary: Restore a soft-deleted user
+      description: Clears the deleted flag on a user (Admin only). Audit history is captured automatically in the events table.
+      operationId: restoreUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userid
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+'
+      responses:
+        '200':
+          description: User restored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1293,6 +1367,19 @@ components:
           type: string
           nullable: true
           description: Notes about why the system was decommissioned
+        reactivated_by:
+          type: string
+          nullable: true
+          description: User ID of the admin who reactivated the system after decommission
+        reactivated_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Date the system was last reactivated
+        reactivation_notes:
+          type: string
+          nullable: true
+          description: Notes about why the system was reactivated
       required:
         - fismauid
         - fismaacronym


### PR DESCRIPTION
## Summary

Stage 1 of issue #281 (508 compliance for destructive actions). Adds two admin-only endpoints so soft-deleted users and decommissioned FISMA systems can be recovered through the API instead of direct database access.

- `PUT /api/v1/users/{userid}/restore` clears the deleted flag and returns the updated user (HTTP 200).
- `PUT /api/v1/fismasystems/{fismasystemid}/reactivate` clears the decommissioned flag, stamps `reactivated_by`/`reactivated_date`/`reactivation_notes`, and preserves the prior `decommissioned_*` audit columns so the decommission record remains queryable.

Both endpoints reject READONLY_ADMIN and ISSO with 403, return 404 for unknown ids, and return 400 with `InvalidInputError` when the target is already in the requested state.

Folded in dependabot PR #296: `jackc/pgx/v5` 5.9.1 -> 5.9.2 (resolves GHSA-j88v-2chj-qfwx, SQL injection via dollar-quoted placeholder confusion in the simple protocol). One PR, one approval.

Fixes #281
Closes #296

## Implementation notes

- Migration 0025 adds `reactivated_by` (UUID FK to `users` with `ON DELETE SET NULL`), `reactivated_date` (TIMESTAMPTZ), and `reactivation_notes` (TEXT) to `fismasystems` plus a partial index on `reactivated_by`.
- Both model functions use `SELECT FOR UPDATE` inside a transaction so the not-found vs already-active decision is atomic. Audit events are recorded explicitly because the transactional path bypasses the `queryRow` auto-event hook.
- New `respondOK` helper in `controller.go` writes 200 with body for PUT-as-action endpoints. The existing `respond` function still returns 204 for in-place PUT updates and is left untouched to avoid changing the contract on `SaveUser`, `SaveFismaSystem`, etc.
- OpenAPI spec extended with both paths and three new fields on the `FismaSystem` schema.
- Fixture additions in `_test_data_empire.sql`: a pre-deleted user (Captain Needa) and a pre-decommissioned fismasystem (Star Destroyer Tyrant, id 1004) for unit-test and dev smoke coverage. Captain Needa uses a v4-conforming UUID so the existing `isValidUUID` regex accepts it as a path parameter.

## Stage 2 (separate branch)

The audit in #281 listed four ztmf-ui surfaces that depend on these endpoints. Stage 2 covers them on the next branch:

1. Confirmation dialog before Delete User.
2. Confirmation dialog before Unassign System.
3. Show-deleted-users toggle and Restore action in `UserTable`.
4. Reactivate UI on decommissioned systems (and remove the "cannot be undone" copy in the existing decommission dialog).

## Test plan

- [x] `make dev-setup` resolves cleanly with the new migration applied; `\d fismasystems` shows the three new columns and the FK
- [x] `go build ./...` clean against all backend binaries
- [x] `make test-e2e` passes 84/0/0 against the isolated `compose-test.yml` stack (port 8090). Includes the new positive flows and READONLY_ADMIN/ISSO 403 negatives for both endpoints
- [x] Manual smoke from `localhost:3000`:
  - Restore Captain Needa: 200 with `deleted: false`
  - Replay: 400 `{"deleted": "user is already active"}`
  - Bogus UUID: 404
  - Reactivate fismasystem 1004: 200 with `decommissioned: false`, `reactivated_*` populated, decommission audit preserved
  - Replay: 400 `{"decommissioned": "system is already active"}`
  - Bogus id: 404
  - READONLY_ADMIN and ISSO tokens: 403 on all four PUTs
  - `events` table contains rows for both updates against the admin's UserID
- [ ] CI green on the PR (analysis/snyk/lint/backend smoke)
- [ ] Dev auto-deploy completes; spot-check from the dev environment before stage 2 merges
