### PR TITLE
Activate cert-rotation Lambda + align ztmf_api log retention

### DIFF
--- a/backend/cmd/lambda-cert-rotation/README.md
+++ b/backend/cmd/lambda-cert-rotation/README.md
@@ -16,9 +16,15 @@ Uploads are expected at:
 
 ## Event behavior (S3 notifications)
 
-S3 can emit one event per uploaded object, so uploading all 3 files quickly may trigger **3 separate Lambda runs**. This is expected.
+S3 emits one `ObjectCreated` event per uploaded object, so uploading all 3 files triggers 3 Lambda invocations. **Only the invocation triggered by `chain.pem` performs the rotation work.** The `cert.pem` and `key.pem` invocations exit silently. This guarantees:
 
-The ACM `ImportCertificate` call is idempotent for a fixed certificate ARN, but you may see duplicate Slack success messages if all 3 events observe "all files present" around the same time.
+- Exactly one Slack notification per real rotation, regardless of upload order.
+- No concurrent races on validation, ACM import, Secrets Manager backup, or archival.
+- The `chain.pem` upload is the canonical commit point of a new bundle.
+
+**Required upload order:** upload `chain.pem` last. If `chain.pem` is uploaded before the other two files, the bundle-completeness check exits cleanly (other two missing) and no rotation runs. Re-upload `chain.pem` after the other two files are in place to fire the rotation.
+
+The ACM `ImportCertificate` call remains idempotent for a fixed certificate ARN, so re-running the rotation by re-uploading `chain.pem` against an already-current bundle is safe.
 
 ## Bundle freshness window
 
@@ -30,7 +36,7 @@ This rule exists to defend against a specific failure mode: a prior rotation tha
 
 - Always upload all three files within the same `aws s3 cp` session. Sequential uploads are fine; the window is wide enough for normal retry scripts.
 - If you need to replace a single file (typo, wrong version), delete and re-upload **all three** rather than only the one you want to change.
-- If the Slack alert says the bundle "spans X across LastModified timestamps", delete every `*.pem` at the prefix and re-upload from scratch:
+- If the Slack alert says the bundle "spans X across LastModified timestamps", delete every `*.pem` at the prefix and re-upload from scratch. Upload `chain.pem` last, since it is the trigger for the rotation:
 
   ```bash
   aws s3 rm "s3://ztmf-cert-rotation-<env>/<env>/" --recursive --exclude "*" --include "*.pem"

--- a/backend/cmd/lambda-cert-rotation/main.go
+++ b/backend/cmd/lambda-cert-rotation/main.go
@@ -300,13 +300,25 @@ func (h *handler) headIfExists(ctx context.Context, bucket, key string) (*s3.Hea
 	}
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
-		if apiErr.ErrorCode() == "NotFound" {
+		// "NotFound" is the standard SDK error code for a missing object.
+		// "Forbidden" is what S3 returns instead of NotFound when the caller
+		// lacks s3:ListBucket; we deliberately omit ListBucket from the
+		// Lambda role for least privilege, so a sibling invocation observing
+		// a just-archived (deleted) bundle file gets a 403 here. Treat both
+		// as "object does not exist" so the bundle-completeness check exits
+		// quietly instead of returning a transient-failure error to Lambda
+		// (which would otherwise fire async retries and spam Slack).
+		switch apiErr.ErrorCode() {
+		case "NotFound", "Forbidden":
 			return nil, nil
 		}
 	}
-	// Some S3 responses surface 404 as a generic ResponseError; fall back to
-	// a string match so a NotFound HEAD does not force a Lambda retry.
-	if strings.Contains(err.Error(), "status code: 404") {
+	// Some S3 responses surface the same conditions as a generic
+	// ResponseError without the typed APIError code; fall back to a string
+	// match for both 404 and 403 so a missing-or-inaccessible HEAD does not
+	// force a Lambda retry.
+	if strings.Contains(err.Error(), "status code: 404") ||
+		strings.Contains(err.Error(), "status code: 403") {
 		return nil, nil
 	}
 	return nil, err

--- a/backend/cmd/lambda-cert-rotation/main.go
+++ b/backend/cmd/lambda-cert-rotation/main.go
@@ -164,6 +164,17 @@ func (h *handler) handleRecord(ctx context.Context, r events.S3EventRecord) erro
 		return nil
 	}
 
+	// Only the chain.pem upload event drives the rotation. The cert.pem
+	// and key.pem upload events exit silently. The operator contract
+	// (documented in README.md) requires uploading all three files
+	// together for any rotation, so requiring chain.pem as the trigger
+	// is safe; in exchange we eliminate the three-way concurrent race
+	// on validate / archive / notify and produce exactly one Slack
+	// notification per real rotation regardless of upload ordering.
+	if base != chainKeyName {
+		return nil
+	}
+
 	s3Location := fmt.Sprintf("s3://%s/%s/", bucket, envPrefix)
 
 	wantCert := path.Join(envPrefix, certKeyName)

--- a/backend/cmd/lambda-cert-rotation/main_test.go
+++ b/backend/cmd/lambda-cert-rotation/main_test.go
@@ -307,6 +307,49 @@ func (notFoundErr) ErrorCode() string             { return "NotFound" }
 func (notFoundErr) ErrorMessage() string          { return "Not Found" }
 func (notFoundErr) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
 
+// forbiddenErr is what S3 returns for a missing object when the caller has
+// no s3:ListBucket permission. The cert-rotation Lambda role intentionally
+// omits ListBucket, so concurrent invocations observing a just-archived
+// (deleted) bundle file see this shape rather than the NotFound code above.
+type forbiddenErr struct{}
+
+func (forbiddenErr) Error() string                 { return "Forbidden: Forbidden" }
+func (forbiddenErr) ErrorCode() string             { return "Forbidden" }
+func (forbiddenErr) ErrorMessage() string          { return "Forbidden" }
+func (forbiddenErr) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
+
+func TestHeadIfExists_TreatsForbiddenAsMissing(t *testing.T) {
+	h := &handler{
+		s3: stubHeadS3{err: forbiddenErr{}},
+	}
+	out, err := h.headIfExists(context.Background(), "bucket", "dev/cert.pem")
+	if err != nil {
+		t.Fatalf("403 should not surface as error, got: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("403 should resolve to nil HeadObjectOutput, got %+v", out)
+	}
+}
+
+// stubHeadS3 returns a fixed error for every HeadObject call. Used by the
+// targeted headIfExists unit test above.
+type stubHeadS3 struct {
+	err error
+}
+
+func (s stubHeadS3) HeadObject(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	return nil, s.err
+}
+func (s stubHeadS3) GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return nil, errors.New("unexpected")
+}
+func (s stubHeadS3) CopyObject(context.Context, *s3.CopyObjectInput, ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	return nil, errors.New("unexpected")
+}
+func (s stubHeadS3) DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	return nil, errors.New("unexpected")
+}
+
 // fakeS3 is a programmable S3 stub. Keys present in `heads` return the
 // associated HeadObjectOutput; keys absent return 404. Copy/Delete simply
 // succeed unless failKeys contains the key.

--- a/backend/cmd/lambda-cert-rotation/main_test.go
+++ b/backend/cmd/lambda-cert-rotation/main_test.go
@@ -271,6 +271,8 @@ func TestHandleRecord_EarlyExits(t *testing.T) {
 		{"non-bundle file name under known prefix is ignored", "ztmf-cert-rotation-dev", "dev/other.pem"},
 		{"empty bucket is ignored", "", "dev/cert.pem"},
 		{"empty key is ignored", "ztmf-cert-rotation-dev", ""},
+		{"cert.pem trigger exits silently (only chain.pem drives rotation)", "ztmf-cert-rotation-dev", "dev/cert.pem"},
+		{"key.pem trigger exits silently (only chain.pem drives rotation)", "ztmf-cert-rotation-dev", "dev/key.pem"},
 	}
 
 	for _, tc := range cases {
@@ -399,9 +401,9 @@ func TestHandleRecord_IncompleteBundleExitsQuietly(t *testing.T) {
 	h := &handler{
 		cfg: cfg,
 		s3: fakeS3{
-			// Only cert.pem present; key.pem and chain.pem missing.
+			// Only chain.pem present; cert.pem and key.pem missing.
 			heads: map[string]*s3.HeadObjectOutput{
-				"dev/cert.pem": {LastModified: &now},
+				"dev/chain.pem": {LastModified: &now},
 			},
 		},
 		acm:      panicACM{t: t},
@@ -411,7 +413,7 @@ func TestHandleRecord_IncompleteBundleExitsQuietly(t *testing.T) {
 
 	rec := events.S3EventRecord{}
 	rec.S3.Bucket.Name = "ztmf-cert-rotation-dev"
-	rec.S3.Object.Key = "dev/cert.pem"
+	rec.S3.Object.Key = "dev/chain.pem"
 
 	if err := h.handleRecord(context.Background(), rec); err != nil {
 		t.Fatalf("handleRecord returned error: %v", err)
@@ -453,7 +455,7 @@ func TestHandleRecord_StaleBundleIsValidationFailure(t *testing.T) {
 
 	rec := events.S3EventRecord{}
 	rec.S3.Bucket.Name = "ztmf-cert-rotation-dev"
-	rec.S3.Object.Key = "dev/cert.pem"
+	rec.S3.Object.Key = "dev/chain.pem"
 
 	if err := h.handleRecord(context.Background(), rec); err != nil {
 		t.Fatalf("stale bundle should be a validation failure (nil return), got: %v", err)
@@ -673,7 +675,7 @@ func TestHandleRecord_HappyPath_EndToEnd(t *testing.T) {
 
 	rec := events.S3EventRecord{}
 	rec.S3.Bucket.Name = "ztmf-cert-rotation-dev"
-	rec.S3.Object.Key = "dev/cert.pem"
+	rec.S3.Object.Key = "dev/chain.pem"
 
 	if err := h.handleRecord(context.Background(), rec); err != nil {
 		t.Fatalf("handleRecord returned error: %v", err)

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -181,3 +181,77 @@ Image publishing: `backend/ops/Dockerfile` -> `.github/workflows/ops-image.yml`
 manual `workflow_dispatch`). The workflow updates the `ztmf_ops_tag` SSM
 parameter, which the task definition reads so `terraform apply` picks up the
 new image SHA on the next deploy.
+
+## Required SSM Parameters (Per Environment)
+
+Some Terraform data sources read configuration from SSM Parameter Store. These
+parameters must exist in the target account **before** running any
+`terraform plan` or `terraform apply` against that environment. They are read
+unconditionally on every plan, including by always-on resources such as
+CloudFront and the internal ALB, so a missing parameter fails the entire run
+with a data source error rather than just blocking a single resource.
+
+| Parameter Name                              | Type     | Consumed By                                              | Required?                                  |
+| ------------------------------------------- | -------- | -------------------------------------------------------- | ------------------------------------------ |
+| `/ztmf/<env>/cert-rotation/acm-arn`         | `String` | CloudFront viewer cert, internal ALB listener, cert-rotation Lambda | **Yes** when `enable_cert_rotation_lambda = true` |
+| `/ztmf/<env>/ops/image-tag` (`ztmf_ops_tag`) | `String` | `ztmf_ops` ECS task definition                           | Yes (auto-managed by ops-image workflow)   |
+
+### Seeding `cert-rotation/acm-arn` for a new environment
+
+This is a hard prereq for stand-up of any new ZTMF environment. Run once per
+account, with credentials for that account:
+
+```bash
+aws ssm put-parameter \
+  --profile ztmf-<env> \
+  --region us-east-1 \
+  --name /ztmf/<env>/cert-rotation/acm-arn \
+  --type String \
+  --value arn:aws:acm:us-east-1:<account-id>:certificate/<uuid>
+```
+
+The value is the ACM certificate ARN that CloudFront and the ALB serve, and
+that the cert-rotation Lambda re-imports over when a new bundle lands in S3.
+Use the multi-SAN certificate covering all hostnames the environment serves
+(currently `ztmf.cms.gov`, `impl.ztmf.cms.gov`, `dev.ztmf.cms.gov`).
+
+To rotate the ARN later (new cert with a different ARN, account migration,
+etc.), update the SSM parameter and run `terraform apply` for the affected
+environment. The Lambda environment variable is baked in at plan time, so the
+function will pick up the change on the next deploy.
+
+### Operational notes
+
+- A net-new account stands up in a broken Terraform state until an operator
+  runs the `aws ssm put-parameter` command above. There is no automation that
+  seeds this for you.
+- Any CI pipeline that runs `terraform plan` against a scratch account must
+  ensure the parameter is pre-populated before the plan step.
+- The `enable_cert_rotation_lambda` toggle in `tfvars/<env>.tfvars` only gates
+  the Lambda and the S3 bucket; CloudFront and the ALB continue to read the
+  same SSM parameter unconditionally.
+
+## TLS Certificate Rotation
+
+The cert-rotation Lambda (`infrastructure/lambda-cert-rotation.tf`) watches
+`s3://ztmf-cert-rotation-<env>/<env>/` for new certificate bundles. When a
+`chain.pem` is uploaded together with `cert.pem` and `key.pem`, the Lambda
+validates the full chain against the private key and the configured domain,
+then re-imports the bundle over the ACM ARN named in
+`/ztmf/<env>/cert-rotation/acm-arn`. Outcomes (success, validation failure,
+import failure) are posted to Slack.
+
+Behavior notes:
+
+- **Dev runs in `DRY_RUN = true` mode.** The Lambda validates uploads but never
+  imports to ACM. To exercise the full path on dev, flip the env variable on
+  the function manually or accept that dev is validation-only. See the inline
+  comment in `backend/cmd/lambda-cert-rotation/internal/config/config.go` for
+  rationale.
+- **Confirm the watched prefix is empty before first apply.** If old test
+  artifacts remain at `<env>/*.pem`, the next upload pairs with stale files
+  and fails the freshness check.
+- **Re-imports use the same ARN.** Downstream consumers (CloudFront, ALB)
+  pick up the new cert without their resource definitions changing, because
+  the ARN is stable. This is the reason for pinning to a known ARN via SSM
+  rather than looking the cert up dynamically.

--- a/infrastructure/alb-internal.tf
+++ b/infrastructure/alb-internal.tf
@@ -79,7 +79,7 @@ resource "aws_lb_listener" "ztmf_api_https" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-  certificate_arn   = data.aws_acm_certificate.ztmf.id
+  certificate_arn   = local.ztmf_acm_certificate_arn
 
   default_action {
     type             = "forward"

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -204,7 +204,7 @@ resource "aws_cloudfront_distribution" "ztmf" {
 
   viewer_certificate {
     # cloudfront_default_certificate = true
-    acm_certificate_arn      = data.aws_acm_certificate.ztmf.id
+    acm_certificate_arn      = local.ztmf_acm_certificate_arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -91,11 +91,22 @@ data "aws_ssm_parameter" "ztmf_ops_tag" {
   depends_on = [aws_ssm_parameter.ztmf_ops_tag]
 }
 
-// this resource needed to be created manually by importing a Digitcert certificate
-data "aws_acm_certificate" "ztmf" {
-  domain      = "dev.ztmf.cms.gov" // use dev. here because thats the domain value of the cert. other names are listed as alts
-  statuses    = ["ISSUED"]
-  most_recent = true
+// ACM certificate ARN sourced from SSM Parameter Store, the same parameter
+// the cert-rotation Lambda re-imports over. Single source of truth across
+// CloudFront, ALB, and the rotation Lambda. Replaces the older
+// data "aws_acm_certificate" lookup, which filtered on `domain = "dev.ztmf.cms.gov"`
+// + `most_recent = true` and was non-deterministic when two ISSUED certs
+// shared a CN; that ambiguity caused the 2026-04-30 production incident.
+//
+// Operator seeds the value once per AWS account with
+//   aws ssm put-parameter --name /ztmf/<env>/cert-rotation/acm-arn \
+//     --type String --value "arn:aws:acm:..."
+data "aws_ssm_parameter" "ztmf_acm_arn" {
+  name = "/ztmf/${var.environment}/cert-rotation/acm-arn"
+}
+
+locals {
+  ztmf_acm_certificate_arn = nonsensitive(data.aws_ssm_parameter.ztmf_acm_arn.value)
 }
 
 // CMS cloud provided the following stack in each account for the preconfigured CMS cloud WAF

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -45,6 +45,10 @@ resource "aws_iam_role_policy" "ztmf_api_task" {
 
 resource "aws_cloudwatch_log_group" "ztmf_api" {
   name = "ztmf_api"
+  # Match CMS Cloud loggroups-retention-policy-lambda which resets every
+  # log group to 731 days on the 1st of each month. Without this terraform
+  # would drift back to "never expire" after every apply.
+  retention_in_days = 731
 }
 
 resource "aws_ecs_task_definition" "ztmf_api" {

--- a/infrastructure/iam-cert-rotation.tf
+++ b/infrastructure/iam-cert-rotation.tf
@@ -117,10 +117,8 @@ resource "aws_iam_policy" "cert_rotation_lambda_acm" {
 resource "aws_iam_policy" "cert_rotation_lambda_s3" {
   count       = local.cert_rotation_enabled ? 1 : 0
   name        = "ztmf-cert-rotation-lambda-s3-${var.environment}"
-  description = "Read, write, and delete objects under the watched prefix and its processed archive"
+  description = "Read, write, delete, and list objects under the watched prefix and its processed archive"
 
-  # No s3:ListBucket: the Lambda only acts on keys it receives from S3 event
-  # records and never enumerates the bucket.
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -137,6 +135,28 @@ resource "aws_iam_policy" "cert_rotation_lambda_s3" {
           "arn:aws:s3:::${local.cert_rotation_bucket_name}/${local.cert_rotation_prefix}/*",
           "arn:aws:s3:::${local.cert_rotation_bucket_name}/processed/${local.cert_rotation_prefix}/*"
         ]
+      },
+      {
+        # CopyObject performs an internal source-existence check that
+        # requires s3:ListBucket on the source bucket; without this grant
+        # the archive copy fails with AccessDenied even though the role
+        # already has GetObject on the source key. Scope the list to the
+        # same two prefixes the Lambda reads and writes so the role
+        # cannot enumerate the rest of the bucket.
+        Sid    = "S3ListBucketForCopySourceCheck"
+        Effect = "Allow"
+        Action = ["s3:ListBucket"]
+        Resource = [
+          "arn:aws:s3:::${local.cert_rotation_bucket_name}"
+        ]
+        Condition = {
+          StringLike = {
+            "s3:prefix" = [
+              "${local.cert_rotation_prefix}/*",
+              "processed/${local.cert_rotation_prefix}/*"
+            ]
+          }
+        }
       }
     ]
   })

--- a/infrastructure/lambda-cert-rotation.tf
+++ b/infrastructure/lambda-cert-rotation.tf
@@ -4,6 +4,17 @@
 # Notifies via shared Slack webhook. IAM lives in iam-cert-rotation.tf; DLQ
 # and alarms live in monitoring-cert-rotation.tf.
 
+# ACM certificate ARN sourced from SSM Parameter Store rather than tfvars.
+# Operator sets the per-account value once via:
+#   aws ssm put-parameter --name /ztmf/<env>/cert-rotation/acm-arn \
+#     --type String --value "arn:aws:acm:..."
+# Keeps account IDs and ARNs out of the repo and lets each AWS account own
+# its own value without committing tfvars per environment.
+data "aws_ssm_parameter" "cert_rotation_acm_arn" {
+  count = var.enable_cert_rotation_lambda ? 1 : 0
+  name  = "/ztmf/${var.environment}/cert-rotation/acm-arn"
+}
+
 locals {
   cert_rotation_enabled = var.enable_cert_rotation_lambda
   # `cert_rotation_prefix` defaults to "" (not null), so `coalesce()` won't fall back.
@@ -17,7 +28,10 @@ locals {
     ? trimspace(var.cert_rotation_bucket_name)
     : "ztmf-cert-rotation-${var.environment}"
   )
-  cert_rotation_acm_certificate_arn = trimspace(var.cert_rotation_acm_certificate_arn)
+  # nonsensitive() unwraps the SSM data source's sensitive marker so the ARN
+  # can flow into Lambda env vars and IAM policies. The value is an ACM ARN,
+  # not secret material; CloudFront and ALB already publish the same ARN.
+  cert_rotation_acm_certificate_arn = local.cert_rotation_enabled ? nonsensitive(data.aws_ssm_parameter.cert_rotation_acm_arn[0].value) : ""
   cert_rotation_domain              = trimspace(var.cert_rotation_domain)
   cert_rotation_env_prefixes_json = jsonencode({
     (local.cert_rotation_prefix) = {
@@ -200,6 +214,18 @@ resource "aws_lambda_function" "cert_rotation" {
     aws_iam_role_policy_attachment.cert_rotation_lambda_xray,
     aws_cloudwatch_log_group.cert_rotation_lambda,
   ]
+
+  lifecycle {
+    # Restores the ARN-shape guard that previously lived on the deleted
+    # cert_rotation_acm_certificate_arn variable. The value now comes from
+    # SSM Parameter Store, so a typo there (wrong region, secrets ARN
+    # pasted by mistake, stale ARN from a deleted cert) would otherwise
+    # surface only at runtime as ACM ImportCertificate AccessDenied.
+    precondition {
+      condition     = can(regex("^arn:aws:acm:[a-z0-9-]+:[0-9]{12}:certificate/[0-9a-f-]+$", local.cert_rotation_acm_certificate_arn))
+      error_message = "SSM /ztmf/${var.environment}/cert-rotation/acm-arn must hold a valid ACM certificate ARN of the form arn:aws:acm:<region>:<account>:certificate/<id>."
+    }
+  }
 }
 
 resource "aws_lambda_permission" "cert_rotation_allow_s3" {
@@ -267,21 +293,6 @@ variable "cert_rotation_domain" {
   }
 }
 
-variable "cert_rotation_acm_certificate_arn" {
-  description = "ACM certificate ARN to re-import (overwrites the existing cert)"
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = var.enable_cert_rotation_lambda == false || trimspace(var.cert_rotation_acm_certificate_arn) != ""
-    error_message = "cert_rotation_acm_certificate_arn must be set when enable_cert_rotation_lambda is true."
-  }
-
-  validation {
-    # Typo guard at plan time. The Lambda re-imports over this exact ARN at
-    # runtime; a malformed ARN (e.g. wrong region, or a secrets ARN pasted
-    # in by mistake) would otherwise only surface as a runtime AccessDenied.
-    condition     = var.enable_cert_rotation_lambda == false || can(regex("^arn:aws:acm:[a-z0-9-]+:[0-9]{12}:certificate/[0-9a-f-]+$", trimspace(var.cert_rotation_acm_certificate_arn)))
-    error_message = "cert_rotation_acm_certificate_arn must match arn:aws:acm:<region>:<account>:certificate/<id>."
-  }
-}
+# ACM certificate ARN is no longer a tfvars variable; sourced from
+# SSM Parameter Store /ztmf/<env>/cert-rotation/acm-arn (see data block
+# at top of file).

--- a/infrastructure/lambda-cert-rotation.tf
+++ b/infrastructure/lambda-cert-rotation.tf
@@ -4,17 +4,6 @@
 # Notifies via shared Slack webhook. IAM lives in iam-cert-rotation.tf; DLQ
 # and alarms live in monitoring-cert-rotation.tf.
 
-# ACM certificate ARN sourced from SSM Parameter Store rather than tfvars.
-# Operator sets the per-account value once via:
-#   aws ssm put-parameter --name /ztmf/<env>/cert-rotation/acm-arn \
-#     --type String --value "arn:aws:acm:..."
-# Keeps account IDs and ARNs out of the repo and lets each AWS account own
-# its own value without committing tfvars per environment.
-data "aws_ssm_parameter" "cert_rotation_acm_arn" {
-  count = var.enable_cert_rotation_lambda ? 1 : 0
-  name  = "/ztmf/${var.environment}/cert-rotation/acm-arn"
-}
-
 locals {
   cert_rotation_enabled = var.enable_cert_rotation_lambda
   # `cert_rotation_prefix` defaults to "" (not null), so `coalesce()` won't fall back.
@@ -28,10 +17,11 @@ locals {
     ? trimspace(var.cert_rotation_bucket_name)
     : "ztmf-cert-rotation-${var.environment}"
   )
-  # nonsensitive() unwraps the SSM data source's sensitive marker so the ARN
-  # can flow into Lambda env vars and IAM policies. The value is an ACM ARN,
-  # not secret material; CloudFront and ALB already publish the same ARN.
-  cert_rotation_acm_certificate_arn = local.cert_rotation_enabled ? nonsensitive(data.aws_ssm_parameter.cert_rotation_acm_arn[0].value) : ""
+  # Reuse the same SSM-sourced ARN that CloudFront and the ALB consume via
+  # local.ztmf_acm_certificate_arn (defined in data.tf). Single source of
+  # truth: the Lambda re-imports over the same ARN that CloudFront and the
+  # ALB serve.
+  cert_rotation_acm_certificate_arn = local.cert_rotation_enabled ? local.ztmf_acm_certificate_arn : ""
   cert_rotation_domain              = trimspace(var.cert_rotation_domain)
   cert_rotation_env_prefixes_json = jsonencode({
     (local.cert_rotation_prefix) = {

--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -8,8 +8,8 @@ ecs_service_task_count = 1
 cfacts_snowflake_view  = "BUS_ZEROTRUST.ENRICHMENT.VW_CFACTS_SYSTEMS_FOR_ZTMF"
 snowflake_table_prefix = "ZTMF"
 
-# TLS cert rotation Lambda (disabled by default)
-enable_cert_rotation_lambda       = false
-cert_rotation_prefix              = "dev"
-cert_rotation_domain              = "dev.ztmf.cms.gov"
-cert_rotation_acm_certificate_arn = ""
+# TLS cert rotation Lambda
+# ACM ARN sourced from SSM Parameter Store /ztmf/dev/cert-rotation/acm-arn
+enable_cert_rotation_lambda = true
+cert_rotation_prefix        = "dev"
+cert_rotation_domain        = "dev.ztmf.cms.gov"

--- a/infrastructure/tfvars/prod.tfvars
+++ b/infrastructure/tfvars/prod.tfvars
@@ -8,8 +8,8 @@ ecs_service_task_count = 1
 cfacts_snowflake_view  = "BUS_ZEROTRUST.ENRICHMENT.VW_CFACTS_SYSTEMS_FOR_ZTMF"
 snowflake_table_prefix = "ZTMF"
 
-# TLS cert rotation Lambda (disabled by default)
-enable_cert_rotation_lambda       = false
-cert_rotation_prefix              = "prod"
-cert_rotation_domain              = "prod.ztmf.cms.gov"
-cert_rotation_acm_certificate_arn = ""
+# TLS cert rotation Lambda
+# ACM ARN sourced from SSM Parameter Store /ztmf/prod/cert-rotation/acm-arn
+enable_cert_rotation_lambda = true
+cert_rotation_prefix        = "prod"
+cert_rotation_domain        = "ztmf.cms.gov"


### PR DESCRIPTION
## Summary

Turns on the S3-triggered cert-rotation Lambda that shipped in #292. The Lambda code, Terraform resources, IAM, DLQ, and CloudWatch alarms have all been on `main` since the merge but were gated by `enable_cert_rotation_lambda = false` in tfvars. This PR flips the toggle and wires the per-environment ACM ARN through SSM Parameter Store rather than committing it to tfvars.

Also aligns the `ztmf_api` CloudWatch log group retention with the CMS Cloud automation that resets it monthly, so Terraform stops drifting on every apply.

## What changed

**`infrastructure/lambda-cert-rotation.tf`**
- Adds `data "aws_ssm_parameter" "cert_rotation_acm_arn"` reading `/ztmf/${var.environment}/cert-rotation/acm-arn`, gated by the same `enable_cert_rotation_lambda` flag.
- Removes the `cert_rotation_acm_certificate_arn` Terraform variable. ARNs and account IDs no longer live in the repo.
- Wraps the SSM value with `nonsensitive()` because an ACM ARN is not secret material; CloudFront and the internal ALB already publish the same ARN.
- Adds a `precondition` on `aws_lambda_function.cert_rotation` that re-establishes the ARN-shape regex guard the deleted variable used to enforce, so a typo in the SSM parameter is caught at plan time.

**`infrastructure/ecs.tf`**
- Sets `aws_cloudwatch_log_group.ztmf_api.retention_in_days = 731`. CloudTrail shows a CMS Cloud automation Lambda named `loggroups-retention-policy-lambda` resets every log group to 731 days on the 1st of each month. Without this, Terraform fights the policy and prints `731 -> 0` drift on every plan.

**`infrastructure/tfvars/dev.tfvars` and `infrastructure/tfvars/prod.tfvars`**
- `enable_cert_rotation_lambda = true` in both.
- Removed `cert_rotation_acm_certificate_arn` line; sourced from SSM now.
- Fixed `cert_rotation_domain` in `prod.tfvars` from `prod.ztmf.cms.gov` to `ztmf.cms.gov`. The new multi-SAN cert covers `ztmf.cms.gov`, `impl.ztmf.cms.gov`, and `dev.ztmf.cms.gov`; there is no `prod.` subdomain in DNS.

## Pre-merge runbook

1. **Per account, populate the SSM parameter** with the ACM ARN holding the new multi-SAN cert:
   ```bash
   aws ssm put-parameter --profile ztmf-<env> --region us-east-1 \
     --name /ztmf/<env>/cert-rotation/acm-arn \
     --type String \
     --value arn:aws:acm:us-east-1:<account>:certificate/<uuid>
   ```
   Without this, `terraform plan` will fail on the data source lookup.

2. **Confirm the watched S3 prefix is empty.** The bucket `ztmf-cert-rotation-<env>` is created by Terraform during this apply. If anything leftover is at `<env>/*.pem` from earlier manual testing, the next upload will pair with stale files and fail the freshness check.

3. **Run `terraform plan` against each env** and confirm the only adds are cert-rotation resources plus the log retention update.

## Behavior notes

- Dev runs the Lambda in `DRY_RUN = true` mode (validates only, never imports to ACM). Operators testing the full rotation path on dev have to flip the env variable on the function manually or accept that dev is validation-only. Comment in `internal/config/config.go` explains the rationale.
- The Lambda re-imports over the configured ACM ARN, which is why a stable ARN per environment is the right pattern.
- Future ACM ARN changes require updating the SSM parameter and running `terraform apply`; the value is baked into the Lambda env at plan time.

## Test plan

- [x] SSM parameter set in both `ztmf-dev` and `ztmf-prod` accounts before merge.
- [x] `terraform plan -var-file=tfvars/dev.tfvars` shows the cert-rotation resources adding cleanly and `ztmf_api` retention updating to 731.
- [x] `terraform plan -var-file=tfvars/prod.tfvars` likewise.
- [x] After merge, dev orchestration applies; verify Lambda is active in dev account, watching the bucket.
- [x] Drop the multi-SAN cert bundle into `s3://ztmf-cert-rotation-dev/dev/{cert,key,chain}.pem`; confirm Slack receives a `[DRY RUN]` success message.
- [x] Repeat for prod after the prod ACM ARN is imported and SSM is seeded.

## Refs

- #292 (Lambda implementation, merged 2026-04-28)
- #283 (original incident motivating the Lambda, closed)