### PR TITLE
Bump Aurora engine_version to 16.11 to match deployed cluster

### DIFF
--- a/infrastructure/rds.tf
+++ b/infrastructure/rds.tf
@@ -21,7 +21,7 @@ resource "aws_rds_cluster" "ztmf" {
   cluster_identifier          = "ztmf"
   engine                      = "aurora-postgresql"
   engine_mode                 = "provisioned"
-  engine_version              = "16.8"
+  engine_version              = "16.11"
   database_name               = "ztmf"
   db_subnet_group_name        = aws_db_subnet_group.ztmf.name
   master_username             = data.aws_secretsmanager_secret_version.ztmf_db_user_current.secret_string


### PR DESCRIPTION
## Summary

- HCL pinned at 16.8 while AWS auto-applied 16.11 via maintenance window
- Every PR plan currently shows a noisy in-place change on cluster + instance engine_version that AWS no-ops on apply
- Aligning HCL to reality cleans plan output going forward; no behavioral change to running cluster

## Plan output

\`terraform plan -var-file=tfvars/dev.tfvars\` against dev: **No changes. Your infrastructure matches the configuration.**

## Test plan

- [x] Local plan against dev shows zero diff after this change
- [ ] PR auto-deploys to dev via CI; verify Aurora cluster stays healthy and engine_version stays 16.11
- [ ] After merge, future PRs no longer show the engine_version drift in plan output