### PR TITLE
Add impl environment alongside dev/prod in shared dev account

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -203,6 +203,33 @@ jobs:
           done
         
       - name: AWS - SSM Put Parameter
-        run: aws ssm put-parameter --name ${{ secrets.PARAMETER_NAME }} --value ${{ steps.revParse.outputs.shaShort }} --overwrite
+        # Guard against IMPL environment misconfiguration: if PARAMETER_NAME
+        # is copy-pasted from DEV (ztmf_api_tag) into IMPL, every impl CI
+        # run silently overwrites dev's image pointer and dev's next apply
+        # deploys the impl image. Assert per-env expected value before put.
+        env:
+          ENV: ${{ inputs.environment }}
+          PARAMETER_NAME: ${{ secrets.PARAMETER_NAME }}
+        run: |
+          set -e
+          ENV_LOWER=$(echo "$ENV" | tr '[:upper:]' '[:lower:]')
+          case "$ENV_LOWER" in
+            dev|prod)
+              EXPECTED="ztmf_api_tag"
+              ;;
+            impl)
+              EXPECTED="ztmf-impl_api_tag"
+              ;;
+            *)
+              echo "Unrecognized environment: $ENV" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$PARAMETER_NAME" != "$EXPECTED" ]; then
+            echo "PARAMETER_NAME mismatch for $ENV: got '$PARAMETER_NAME', expected '$EXPECTED'." >&2
+            echo "Fix the GitHub repo Environment '$ENV' secret PARAMETER_NAME." >&2
+            exit 1
+          fi
+          aws ssm put-parameter --name "$PARAMETER_NAME" --value "${{ steps.revParse.outputs.shaShort }}" --overwrite
 
       # Deployment of the latest image will happen with terraform apply during infrastructure deploy

--- a/.github/workflows/orchestration-impl.yml
+++ b/.github/workflows/orchestration-impl.yml
@@ -4,10 +4,17 @@
 #   ECR_REPO_URL               = 451245779631.dkr.ecr.us-east-1.amazonaws.com/ztmf/api
 #                                (impl shares dev's ECR repo; same URL as DEV environment)
 #   PARAMETER_NAME             = ztmf-impl_api_tag
-#                                (NOT ztmf_api_tag — that is dev's. backend.yml asserts this.)
+#                                (NOT ztmf_api_tag - that is dev's. backend.yml asserts this.)
 #   BUCKET_NAME                = <impl S3 web assets bucket: impl.ztmf.cms.gov>
 #   CLOUDFRONT_DISTRIBUTION_ID = <impl CloudFront distribution ID, post first apply>
 #   SNYK_TOKEN                 = <Snyk API token, can be the same as DEV>
+#
+# Trigger model:
+#   - push to `impl`: deploys to the impl environment. impl is a long-lived
+#     environment branch; direct pushes are the intended deploy mechanism,
+#     mirroring how merges to main drive prod. PR-on-impl is also accepted
+#     so contributors can preview infra/CI changes before merging into the
+#     impl branch.
 name: Orchestration IMPL
 
 on:
@@ -29,11 +36,36 @@ jobs:
     uses: ./.github/workflows/analysis.yml
     secrets: inherit
 
+  diff:
+    name: Check for Changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.backend.outputs.backend }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes in backend/
+        id: backend
+        # On push events the diff is HEAD~1..HEAD; on pull_request events
+        # the runner checks out the merge ref and we compare against the
+        # base branch (`impl`) the same way orchestration-dev does.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.base_ref }}"
+          else
+            BASE_REF="HEAD~1"
+          fi
+          echo "backend=$(git --no-pager diff --name-only "$BASE_REF" backend/ | grep -E '\.go$|\.sum$|Dockerfile' | head -n 1)" >> $GITHUB_OUTPUT
+
   backend:
     name: Backend
     needs:
       - analysis
-    if: ${{ !failure() && !cancelled() }}
+      - diff
+    if: ${{ contains(needs.diff.outputs.backend, 'backend/') && !failure() && !cancelled() }}
     uses: ./.github/workflows/backend.yml
     with:
       environment: IMPL
@@ -43,6 +75,7 @@ jobs:
     name: Infrastructure
     needs:
       - analysis
+      - diff
       - backend
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/infrastructure.yml

--- a/.github/workflows/orchestration-impl.yml
+++ b/.github/workflows/orchestration-impl.yml
@@ -10,11 +10,24 @@
 #   SNYK_TOKEN                 = <Snyk API token, can be the same as DEV>
 #
 # Trigger model:
-#   - push to `impl`: deploys to the impl environment. impl is a long-lived
-#     environment branch; direct pushes are the intended deploy mechanism,
-#     mirroring how merges to main drive prod. PR-on-impl is also accepted
-#     so contributors can preview infra/CI changes before merging into the
-#     impl branch.
+#   - pull_request to `impl`: runs Analysis only (lint, security scan, unit
+#     tests). No backend image push, no terraform apply. Gives the PR author
+#     CI feedback without racing other open PRs for shared impl state.
+#   - push to `impl`: runs the full pipeline (analysis -> diff -> backend ->
+#     infrastructure) and deploys. Squash-merge from feature/impl-* into
+#     impl is the intended trigger; the resulting single commit on impl
+#     produces one ordered deploy per merged PR.
+#
+# Required GitHub branch protection on `impl` (configure in Settings -> Branches):
+#   - Require pull request before merging
+#   - Require Analysis status check to pass
+#   - Require linear history (forces squash or rebase merge)
+#   - Require branches up to date before merging
+#   - Required approving reviews: 1
+#   - Allow administrators to bypass (for emergency hotfixes)
+#   - Disallow force pushes and deletions
+# Repo merge policy (Settings -> General -> Pull Requests):
+#   - Allow squash merging only; disable merge commits and rebase merging
 name: Orchestration IMPL
 
 on:
@@ -65,7 +78,9 @@ jobs:
     needs:
       - analysis
       - diff
-    if: ${{ contains(needs.diff.outputs.backend, 'backend/') && !failure() && !cancelled() }}
+    # Deploy steps only run on push (post-merge). PRs get Analysis feedback
+    # without burning a deploy slot or racing other open PRs.
+    if: ${{ github.event_name == 'push' && contains(needs.diff.outputs.backend, 'backend/') && !failure() && !cancelled() }}
     uses: ./.github/workflows/backend.yml
     with:
       environment: IMPL
@@ -77,7 +92,7 @@ jobs:
       - analysis
       - diff
       - backend
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ github.event_name == 'push' && !failure() && !cancelled() }}
     uses: ./.github/workflows/infrastructure.yml
     with:
       environment: IMPL

--- a/.github/workflows/orchestration-impl.yml
+++ b/.github/workflows/orchestration-impl.yml
@@ -1,0 +1,51 @@
+# Required GitHub repo Environment "IMPL" secrets (Settings -> Environments -> IMPL):
+#   ROLEARN                    = arn:aws:iam::451245779631:role/<github-actions-role>
+#                                (the dev account GitHub OIDC role; impl shares dev's account)
+#   ECR_REPO_URL               = 451245779631.dkr.ecr.us-east-1.amazonaws.com/ztmf/api
+#                                (impl shares dev's ECR repo; same URL as DEV environment)
+#   PARAMETER_NAME             = ztmf-impl_api_tag
+#                                (NOT ztmf_api_tag — that is dev's. backend.yml asserts this.)
+#   BUCKET_NAME                = <impl S3 web assets bucket: impl.ztmf.cms.gov>
+#   CLOUDFRONT_DISTRIBUTION_ID = <impl CloudFront distribution ID, post first apply>
+#   SNYK_TOKEN                 = <Snyk API token, can be the same as DEV>
+name: Orchestration IMPL
+
+on:
+  push:
+    branches:
+      - impl
+  pull_request:
+    branches:
+      - impl
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  analysis:
+    name: Analysis
+    uses: ./.github/workflows/analysis.yml
+    secrets: inherit
+
+  backend:
+    name: Backend
+    needs:
+      - analysis
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/backend.yml
+    with:
+      environment: IMPL
+    secrets: inherit
+
+  infrastructure:
+    name: Infrastructure
+    needs:
+      - analysis
+      - backend
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/infrastructure.yml
+    with:
+      environment: IMPL
+    secrets: inherit

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-push hook: Run full test suite (unit + E2E) before pushing to remote.
+# Pre-push hook: Run lint and full test suite before pushing to remote.
 # Prevents broken code from reaching GitHub and wasting CI compute.
 #
 # Skip with: git push --no-verify (use sparingly)
@@ -7,6 +7,47 @@
 set -e
 
 echo "Running pre-push checks..."
+
+# --- Infrastructure lint -----------------------------------------------------
+# Run terraform fmt and tflint when any infrastructure/*.tf file is part of
+# the push range. CI's Analysis job runs the same checks; catching them here
+# saves a round-trip and keeps embarrassing fmt/lint diffs out of PRs.
+
+INFRA_CHANGED=""
+# Prefer the actual push range when available (after the upstream is set).
+if git rev-parse --quiet --verify '@{push}' >/dev/null 2>&1; then
+    INFRA_CHANGED=$(git diff --name-only '@{push}' HEAD 2>/dev/null | grep -E '^infrastructure/.*\.tf$' || true)
+fi
+# Fallback for first-push branches: compare against origin/main.
+if [ -z "$INFRA_CHANGED" ] && git rev-parse --quiet --verify origin/main >/dev/null 2>&1; then
+    INFRA_CHANGED=$(git diff --name-only origin/main HEAD 2>/dev/null | grep -E '^infrastructure/.*\.tf$' || true)
+fi
+
+if [ -n "$INFRA_CHANGED" ]; then
+    echo "→ Infrastructure changes detected; running terraform fmt + tflint..."
+
+    if command -v terraform >/dev/null 2>&1; then
+        if ! terraform fmt -check -recursive infrastructure/ >/dev/null 2>&1; then
+            echo "❌ terraform fmt: unformatted files. Run: terraform fmt -recursive infrastructure/"
+            exit 1
+        fi
+        echo "✓ terraform fmt clean"
+    else
+        echo "⚠️  terraform CLI not installed; skipping fmt check"
+    fi
+
+    if command -v tflint >/dev/null 2>&1; then
+        if ! tflint --chdir=infrastructure/ -f compact; then
+            echo "❌ tflint found issues. Fix above, or git push --no-verify (sparingly)."
+            exit 1
+        fi
+        echo "✓ tflint clean"
+    else
+        echo "⚠️  tflint not installed; skipping. Install: https://github.com/terraform-linters/tflint"
+    fi
+fi
+
+# --- Full test suite ---------------------------------------------------------
 echo "→ Running full test suite (unit + E2E)..."
 
 # Source dev.compose.env so tests that read DB_* env (e.g. controller tests

--- a/infrastructure/alb-internal.tf
+++ b/infrastructure/alb-internal.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "ztmf_alb" {
-  name        = "ztmf"
+  name        = local.ztmf_alb_sg_name
   description = "Allow TLS inbound traffic"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -21,7 +21,7 @@ resource "aws_security_group" "ztmf_alb" {
 }
 
 resource "aws_lb" "ztmf_api" {
-  name                       = "ztmf-api"
+  name                       = local.ztmf_api_name
   internal                   = true
   load_balancer_type         = "application"
   security_groups            = [aws_security_group.ztmf_alb.id]
@@ -58,7 +58,7 @@ resource "aws_lb" "ztmf_api" {
 
 # TARGET GROUPS
 resource "aws_lb_target_group" "ztmf_rest_api" {
-  name        = "ztmf-rest-api"
+  name        = local.ztmf_rest_api_tg
   port        = 443
   protocol    = "HTTPS"
   target_type = "ip"

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudfront_origin_access_control" "cloudfront_s3_oac" {
-  name                              = "ZTMF CloudFront S3 OAC"
+  name                              = "ZTMF CloudFront S3 OAC${local.name_suffix}"
   description                       = "ZTMF CloudFront S3 OAC"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
@@ -7,7 +7,7 @@ resource "aws_cloudfront_origin_access_control" "cloudfront_s3_oac" {
 }
 
 resource "aws_cloudfront_response_headers_policy" "hsts_policy" {
-  name    = "ZTMF-HSTS-Policy"
+  name    = "ZTMF-HSTS-Policy${local.name_suffix}"
   comment = "HSTS policy for ZTMF"
 
   security_headers_config {
@@ -49,7 +49,7 @@ resource "aws_cloudfront_response_headers_policy" "hsts_policy" {
 
 resource "aws_cloudfront_vpc_origin" "internal_alb" {
   vpc_origin_endpoint_config {
-    name                   = "ZTMF_API"
+    name                   = "ZTMF_API${local.underscore_sfx}"
     arn                    = aws_lb.ztmf_api.arn
     http_port              = 80
     https_port             = 443

--- a/infrastructure/config/backend-impl.tf
+++ b/infrastructure/config/backend-impl.tf
@@ -1,0 +1,3 @@
+bucket = "ztmf-terraform-state-use1-impl"
+key    = "tfstate"
+region = "us-east-1"

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -110,6 +110,11 @@ data "aws_secretsmanager_secret" "ztmf_smtp_intermediate" {
   name  = "ztmf_smtp_intermediate"
 }
 
+data "aws_secretsmanager_secret" "ztmf_slack_webhook" {
+  count = local.manage_account_singletons ? 0 : 1
+  name  = "ztmf_slack_webhook"
+}
+
 data "aws_security_group" "ztmf_vpc_endpoints" {
   count  = local.manage_vpc_endpoints ? 0 : 1
   name   = "ztmf_vpc_endpoints"

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -51,25 +51,20 @@ data "aws_ec2_managed_prefix_list" "shared_services" {
   name = "cmscloud-shared-services"
 }
 
-// dev/prod resolve to the resource managed in secrets.tf; impl resolves to
-// the operator-seeded `ztmf_va_trust_provider_impl` secret via the data
-// source below.
-data "aws_secretsmanager_secret" "ztmf_va_trust_provider_impl" {
-  count = local.manage_account_singletons ? 0 : 1
-  name  = "ztmf_va_trust_provider_impl"
+data "aws_secretsmanager_secret" "ztmf_va_trust_provider" {
+  arn = aws_secretsmanager_secret.ztmf_va_trust_provider.arn
 }
 
 data "aws_secretsmanager_secret_version" "ztmf_va_trust_provider_current" {
-  secret_id = local.va_trust_provider_secret_id
+  secret_id = data.aws_secretsmanager_secret.ztmf_va_trust_provider.id
 }
 
-data "aws_secretsmanager_secret" "ztmf_db_user_impl" {
-  count = local.manage_account_singletons ? 0 : 1
-  name  = "ztmf_db_user_impl"
+data "aws_secretsmanager_secret" "ztmf_db_user" {
+  arn = aws_secretsmanager_secret.ztmf_db_user.arn
 }
 
 data "aws_secretsmanager_secret_version" "ztmf_db_user_current" {
-  secret_id = local.db_user_secret_id
+  secret_id = data.aws_secretsmanager_secret.ztmf_db_user.id
 }
 
 data "aws_secretsmanager_secrets" "rds" {

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -4,8 +4,11 @@ data "aws_region" "current" {}
 
 data "aws_vpc" "ztmf" {
   filter {
-    name   = "tag:Name"
-    values = ["ztmf-east-${var.environment}"]
+    name = "tag:Name"
+    // impl rides on dev's CMS-provisioned VPC; CMS Cloud has not issued a
+    // separate ztmf-east-impl VPC. Resource-name suffix in locals keeps every
+    // VPC-scoped resource (SGs, target groups, ALB) from colliding with dev.
+    values = ["ztmf-east-${var.environment == "impl" ? "dev" : var.environment}"]
   }
 }
 
@@ -36,7 +39,7 @@ data "aws_subnet" "private" {
 
 #   filter {
 #     name   = "tag:use"
-#     values = ["public"]
+#     values = ["private"]
 #   }
 # }
 
@@ -48,20 +51,25 @@ data "aws_ec2_managed_prefix_list" "shared_services" {
   name = "cmscloud-shared-services"
 }
 
-data "aws_secretsmanager_secret" "ztmf_va_trust_provider" {
-  arn = aws_secretsmanager_secret.ztmf_va_trust_provider.arn
+// dev/prod resolve to the resource managed in secrets.tf; impl resolves to
+// the operator-seeded `ztmf_va_trust_provider_impl` secret via the data
+// source below.
+data "aws_secretsmanager_secret" "ztmf_va_trust_provider_impl" {
+  count = local.manage_account_singletons ? 0 : 1
+  name  = "ztmf_va_trust_provider_impl"
 }
 
 data "aws_secretsmanager_secret_version" "ztmf_va_trust_provider_current" {
-  secret_id = data.aws_secretsmanager_secret.ztmf_va_trust_provider.id
+  secret_id = local.va_trust_provider_secret_id
 }
 
-data "aws_secretsmanager_secret" "ztmf_db_user" {
-  arn = aws_secretsmanager_secret.ztmf_db_user.arn
+data "aws_secretsmanager_secret" "ztmf_db_user_impl" {
+  count = local.manage_account_singletons ? 0 : 1
+  name  = "ztmf_db_user_impl"
 }
 
 data "aws_secretsmanager_secret_version" "ztmf_db_user_current" {
-  secret_id = data.aws_secretsmanager_secret.ztmf_db_user.id
+  secret_id = local.db_user_secret_id
 }
 
 data "aws_secretsmanager_secrets" "rds" {
@@ -71,9 +79,46 @@ data "aws_secretsmanager_secrets" "rds" {
   }
 
   filter {
-    name   = "tag-value"
-    values = ["arn:aws:rds:us-east-1:${local.account_id}:cluster:ztmf"]
+    name = "tag-value"
+    // Impl runs its own Aurora cluster ztmf-impl in the dev account; use the
+    // env-suffixed cluster identifier so the RDS-managed master password
+    // secret resolves to the right cluster's secret.
+    values = ["arn:aws:rds:us-east-1:${local.account_id}:cluster:${local.ztmf_name}"]
   }
+}
+
+# Account-singletons that impl reuses from dev's state.
+# count = 1 only when this env doesn't manage them as resources, i.e. impl.
+
+data "aws_ecr_repository" "ztmf_api" {
+  count = local.manage_account_singletons ? 0 : 1
+  name  = "ztmf/api"
+}
+
+data "aws_ecr_repository" "ztmf_ops" {
+  count = local.manage_account_singletons ? 0 : 1
+  name  = "ztmf/ops"
+}
+
+data "aws_secretsmanager_secret" "ztmf_smtp" {
+  count = local.manage_account_singletons ? 0 : 1
+  name  = "ztmf_smtp"
+}
+
+data "aws_secretsmanager_secret" "ztmf_smtp_ca_root" {
+  count = local.manage_account_singletons ? 0 : 1
+  name  = "ztmf_smtp_ca_root"
+}
+
+data "aws_secretsmanager_secret" "ztmf_smtp_intermediate" {
+  count = local.manage_account_singletons ? 0 : 1
+  name  = "ztmf_smtp_intermediate"
+}
+
+data "aws_security_group" "ztmf_vpc_endpoints" {
+  count  = local.manage_vpc_endpoints ? 0 : 1
+  name   = "ztmf_vpc_endpoints"
+  vpc_id = data.aws_vpc.ztmf.id
 }
 
 # data "aws_network_interface" "s3" {
@@ -83,7 +128,9 @@ data "aws_secretsmanager_secrets" "rds" {
 # }
 
 data "aws_ssm_parameter" "ztmf_api_tag" {
-  name = "ztmf_api_tag"
+  // dev/prod use the historical ztmf_api_tag parameter name; impl uses a
+  // namespaced parameter to avoid sharing the dev image-tag pointer.
+  name = local.manage_account_singletons ? "ztmf_api_tag" : "ztmf-impl_api_tag"
 }
 
 data "aws_ssm_parameter" "ztmf_ops_tag" {

--- a/infrastructure/ecr.tf
+++ b/infrastructure/ecr.tf
@@ -1,10 +1,14 @@
+// ECR repos are account-scoped singletons. Created in dev/prod; impl reuses
+// dev's via data.aws_ecr_repository.* so the same image can deploy across envs.
 resource "aws_ecr_repository" "ztmf_api" {
+  count                = local.manage_account_singletons ? 1 : 0
   name                 = "ztmf/api"
   image_tag_mutability = "IMMUTABLE"
 }
 
 resource "aws_ecr_lifecycle_policy" "ztmf_api" {
-  repository = aws_ecr_repository.ztmf_api.name
+  count      = local.manage_account_singletons ? 1 : 0
+  repository = aws_ecr_repository.ztmf_api[0].name
 
   policy = <<EOF
 {
@@ -27,6 +31,7 @@ EOF
 }
 
 resource "aws_ecr_registry_scanning_configuration" "ztmf_api" {
+  count     = local.manage_account_singletons ? 1 : 0
   scan_type = "ENHANCED"
 
   rule {
@@ -39,12 +44,14 @@ resource "aws_ecr_registry_scanning_configuration" "ztmf_api" {
 }
 
 resource "aws_ecr_repository" "ztmf_ops" {
+  count                = local.manage_account_singletons ? 1 : 0
   name                 = "ztmf/ops"
   image_tag_mutability = "IMMUTABLE"
 }
 
 resource "aws_ecr_lifecycle_policy" "ztmf_ops" {
-  repository = aws_ecr_repository.ztmf_ops.name
+  count      = local.manage_account_singletons ? 1 : 0
+  repository = aws_ecr_repository.ztmf_ops[0].name
 
   policy = <<EOF
 {

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_cluster" "ztmf" {
-  name = "ztmf"
+  name = local.ztmf_name
 
   setting {
     name  = "containerInsights"
@@ -8,14 +8,14 @@ resource "aws_ecs_cluster" "ztmf" {
 }
 
 module "api_task_execution" {
-  name                = "ztmf_api_task_execution"
+  name                = "ztmf_api_task_execution${local.underscore_sfx}"
   source              = "./modules/role"
   principal           = { Service = "ecs-tasks.amazonaws.com" }
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
 module "api_task" {
-  name      = "ztmf_api_task"
+  name      = "ztmf_api_task${local.underscore_sfx}"
   source    = "./modules/role"
   principal = { Service = "ecs-tasks.amazonaws.com" }
 }
@@ -34,9 +34,9 @@ resource "aws_iam_role_policy" "ztmf_api_task" {
         Effect = "Allow"
         Resource = [
           local.db_cred_secret,
-          aws_secretsmanager_secret.ztmf_smtp.arn,
-          aws_secretsmanager_secret.ztmf_smtp_ca_root.arn,
-          aws_secretsmanager_secret.ztmf_smtp_intermediate.arn,
+          local.smtp_secret_arn,
+          local.smtp_ca_root_arn,
+          local.smtp_intermediate_arn,
         ]
       },
     ]
@@ -44,7 +44,7 @@ resource "aws_iam_role_policy" "ztmf_api_task" {
 }
 
 resource "aws_cloudwatch_log_group" "ztmf_api" {
-  name = "ztmf_api"
+  name = local.ztmf_api_log_group
   # Match CMS Cloud loggroups-retention-policy-lambda which resets every
   # log group to 731 days on the 1st of each month. Without this terraform
   # would drift back to "never expire" after every apply.
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_log_group" "ztmf_api" {
 resource "aws_ecs_task_definition" "ztmf_api" {
   execution_role_arn       = module.api_task_execution.role_arn
   task_role_arn            = module.api_task.role_arn
-  family                   = "api"
+  family                   = "api${local.name_suffix}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 256
@@ -64,13 +64,13 @@ resource "aws_ecs_task_definition" "ztmf_api" {
       name             = "ztmfapi"
       command          = ["/usr/local/bin/ztmfapi"]
       workingDirectory = "/api"
-      image            = "${aws_ecr_repository.ztmf_api.repository_url}:${data.aws_ssm_parameter.ztmf_api_tag.insecure_value}"
+      image            = "${local.ecr_api_repo_url}:${data.aws_ssm_parameter.ztmf_api_tag.insecure_value}"
       essential        = true
       portMappings     = [{ containerPort = 443 }]
 
       environment = [
         {
-          name  = "ENVIRONMENT" // only for logging, application code should not depend on any particular value 
+          name  = "ENVIRONMENT" // only for logging, application code should not depend on any particular value
           value = var.environment
         },
         {
@@ -115,21 +115,21 @@ resource "aws_ecs_task_definition" "ztmf_api" {
         },
         {
           name  = "SMTP_CONFIG_SECRET_ID"
-          value = aws_secretsmanager_secret.ztmf_smtp.arn
+          value = local.smtp_secret_arn
         },
         {
           name  = "SMTP_CA_ROOT_SECRET_ID"
-          value = aws_secretsmanager_secret.ztmf_smtp_ca_root.arn
+          value = local.smtp_ca_root_arn
         },
         {
           name  = "SMTP_CA_INT_SECRET_ID"
-          value = aws_secretsmanager_secret.ztmf_smtp_intermediate.arn
+          value = local.smtp_intermediate_arn
         }
       ]
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          "awslogs-group"         = "ztmf_api"
+          "awslogs-group"         = aws_cloudwatch_log_group.ztmf_api.name
           "awslogs-region"        = "us-east-1"
           "awslogs-stream-prefix" = "api"
         }
@@ -139,7 +139,7 @@ resource "aws_ecs_task_definition" "ztmf_api" {
 }
 
 resource "aws_security_group" "ztmf_api_task" {
-  name        = "ztmf-api-task"
+  name        = local.ztmf_api_task_sg
   description = "Allow TLS inbound traffic"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -176,7 +176,7 @@ resource "aws_security_group" "ztmf_api_task" {
 }
 
 resource "aws_ecs_service" "ztmf_api" {
-  name            = "ztmf-api"
+  name            = local.ztmf_api_name
   cluster         = aws_ecs_cluster.ztmf.id
   task_definition = aws_ecs_task_definition.ztmf_api.arn
   launch_type     = "FARGATE"
@@ -202,14 +202,14 @@ resource "aws_ecs_service" "ztmf_api" {
 # operator session ends. Image built from backend/ops/Dockerfile.
 
 module "ops_task_execution" {
-  name                = "ztmf_ops_task_execution"
+  name                = "ztmf_ops_task_execution${local.underscore_sfx}"
   source              = "./modules/role"
   principal           = { Service = "ecs-tasks.amazonaws.com" }
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
 module "ops_task" {
-  name      = "ztmf_ops_task"
+  name      = "ztmf_ops_task${local.underscore_sfx}"
   source    = "./modules/role"
   principal = { Service = "ecs-tasks.amazonaws.com" }
 }
@@ -243,12 +243,12 @@ resource "aws_iam_role_policy" "ztmf_ops_task" {
 }
 
 resource "aws_cloudwatch_log_group" "ztmf_ops" {
-  name              = "ztmf_ops"
+  name              = local.ztmf_ops_log_group
   retention_in_days = 30
 }
 
 resource "aws_ssm_parameter" "ztmf_ops_tag" {
-  name  = "ztmf_ops_tag"
+  name  = "ztmf_ops_tag${local.underscore_sfx}"
   type  = "String"
   tier  = "Standard"
   value = "bootstrap"
@@ -261,7 +261,7 @@ resource "aws_ssm_parameter" "ztmf_ops_tag" {
 resource "aws_ecs_task_definition" "ztmf_ops" {
   execution_role_arn       = module.ops_task_execution.role_arn
   task_role_arn            = module.ops_task.role_arn
-  family                   = "ops"
+  family                   = "ops${local.name_suffix}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 256
@@ -269,7 +269,7 @@ resource "aws_ecs_task_definition" "ztmf_ops" {
   container_definitions = jsonencode([
     {
       name      = "ztmfops"
-      image     = "${aws_ecr_repository.ztmf_ops.repository_url}:${data.aws_ssm_parameter.ztmf_ops_tag.insecure_value}"
+      image     = "${local.ecr_ops_repo_url}:${data.aws_ssm_parameter.ztmf_ops_tag.insecure_value}"
       essential = true
 
       environment = [
@@ -294,16 +294,20 @@ resource "aws_ecs_task_definition" "ztmf_ops" {
 }
 
 resource "aws_security_group" "ztmf_ops_task" {
-  name        = "ztmf_ops_task"
+  name        = local.ztmf_ops_task_sg
   description = "on-demand ops task: ECS Exec + Aurora access"
   vpc_id      = data.aws_vpc.ztmf.id
 
   egress {
-    description     = "HTTPS to VPC endpoints (ECR, SSM, Secrets Manager, CloudWatch)"
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    security_groups = [aws_security_group.ztmf_vpc_endpoints.id]
+    description = "HTTPS to VPC endpoints (ECR, SSM, Secrets Manager, CloudWatch)"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    security_groups = [
+      local.manage_vpc_endpoints
+      ? aws_security_group.ztmf_vpc_endpoints[0].id
+      : data.aws_security_group.ztmf_vpc_endpoints[0].id
+    ]
   }
 
   egress {
@@ -314,4 +318,3 @@ resource "aws_security_group" "ztmf_ops_task" {
     security_groups = [aws_security_group.ztmf_db.id]
   }
 }
-

--- a/infrastructure/iam-cert-rotation.tf
+++ b/infrastructure/iam-cert-rotation.tf
@@ -72,7 +72,7 @@ resource "aws_iam_policy" "cert_rotation_lambda_secrets" {
           "secretsmanager:DescribeSecret"
         ]
         Resource = [
-          aws_secretsmanager_secret.ztmf_slack_webhook.arn
+          local.slack_webhook_arn
         ]
       },
       {

--- a/infrastructure/iam-cfacts.tf
+++ b/infrastructure/iam-cfacts.tf
@@ -62,7 +62,7 @@ resource "aws_iam_policy" "cfacts_sync_lambda_secrets" {
         Resource = [
           local.db_cred_secret,
           "arn:aws:secretsmanager:${data.aws_region.current.id}:*:secret:ztmf_snowflake_${var.environment}*",
-          aws_secretsmanager_secret.ztmf_slack_webhook.arn
+          local.slack_webhook_arn
         ]
       }
     ]

--- a/infrastructure/iam-kion.tf
+++ b/infrastructure/iam-kion.tf
@@ -87,7 +87,7 @@ resource "aws_iam_policy" "ztmf_kion_key_rotate_secrets" {
           "secretsmanager:DescribeSecret"
         ]
         Resource = [
-          aws_secretsmanager_secret.ztmf_slack_webhook.arn
+          local.slack_webhook_arn
         ]
       }
     ]

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -61,7 +61,7 @@ resource "aws_iam_policy" "ztmf_sync_lambda_secrets" {
         Resource = [
           local.db_cred_secret,
           "arn:aws:secretsmanager:${data.aws_region.current.id}:*:secret:ztmf_snowflake_${var.environment}*",
-          aws_secretsmanager_secret.ztmf_slack_webhook.arn
+          local.slack_webhook_arn
         ]
       }
     ]

--- a/infrastructure/lambda-cert-rotation.tf
+++ b/infrastructure/lambda-cert-rotation.tf
@@ -169,7 +169,7 @@ resource "aws_lambda_function" "cert_rotation" {
       ENV_PREFIXES_JSON = local.cert_rotation_env_prefixes_json
       ARCHIVE_PREFIX    = "processed"
       DRY_RUN           = var.environment != "prod" ? "true" : "false"
-      SLACK_SECRET_ID   = aws_secretsmanager_secret.ztmf_slack_webhook.name
+      SLACK_SECRET_ID   = local.slack_webhook_name
     }
   }
 

--- a/infrastructure/lambda-cfacts.tf
+++ b/infrastructure/lambda-cfacts.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "cfacts_snowflake_sync" {
       DB_ENDPOINT           = aws_rds_cluster.ztmf.endpoint
       DB_PORT               = "5432"
       DB_NAME               = "ztmf"
-      SLACK_SECRET_ID       = aws_secretsmanager_secret.ztmf_slack_webhook.name
+      SLACK_SECRET_ID       = local.slack_webhook_name
       CFACTS_SNOWFLAKE_VIEW = var.cfacts_snowflake_view
     }
   }
@@ -145,7 +145,7 @@ resource "aws_lambda_function" "cfacts_s3_sync" {
       DB_ENDPOINT     = aws_rds_cluster.ztmf.endpoint
       DB_PORT         = "5432"
       DB_NAME         = "ztmf"
-      SLACK_SECRET_ID = aws_secretsmanager_secret.ztmf_slack_webhook.name
+      SLACK_SECRET_ID = local.slack_webhook_name
     }
   }
 

--- a/infrastructure/lambda-cfacts.tf
+++ b/infrastructure/lambda-cfacts.tf
@@ -76,11 +76,12 @@ resource "aws_lambda_function" "cfacts_snowflake_sync" {
   ]
 }
 
-# EventBridge rule - daily at 3AM UTC (initially disabled)
+# EventBridge rule - daily at 3AM UTC.
+# Impl has no Snowflake account; lambda exists for parity but is never fired.
 resource "aws_cloudwatch_event_rule" "cfacts_snowflake_schedule" {
   name        = "ztmf-cfacts-snowflake-schedule-${var.environment}"
   description = "Daily schedule for CFACTS Snowflake sync to PostgreSQL"
-  state       = "ENABLED"
+  state       = local.enable_snowflake_sync ? "ENABLED" : "DISABLED"
 
   schedule_expression = "cron(0 3 * * ? *)"
 

--- a/infrastructure/lambda-kion.tf
+++ b/infrastructure/lambda-kion.tf
@@ -28,7 +28,7 @@ resource "aws_lambda_function" "ztmf_kion_key_rotate" {
     variables = {
       ENVIRONMENT       = var.environment
       KION_SECRET_ID    = "ztmf_kion_${var.environment}"
-      SLACK_SECRET_ID   = aws_secretsmanager_secret.ztmf_slack_webhook.name
+      SLACK_SECRET_ID   = local.slack_webhook_name
       ROTATE_AFTER_DAYS = "4"
     }
   }

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -83,6 +83,8 @@ resource "aws_cloudwatch_event_rule" "ztmf_sync_schedule" {
 
   # Different schedules per environment (6-field cron format: minutes hours day month day-of-week year)
   schedule_expression = var.environment == "prod" ? "cron(0 2 1 1,4,7,10 ? *)" : "cron(0 9 ? * MON *)"
+  # Impl has no Snowflake account; lambda exists for parity but is never fired.
+  state = local.enable_snowflake_sync ? "ENABLED" : "DISABLED"
 
   tags = {
     Name        = "ZTMF Data Sync Schedule"

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "ztmf_sync" {
       DB_ENDPOINT            = aws_rds_cluster.ztmf.endpoint
       DB_PORT                = "5432"
       DB_NAME                = "ztmf"
-      SLACK_SECRET_ID        = aws_secretsmanager_secret.ztmf_slack_webhook.name
+      SLACK_SECRET_ID        = local.slack_webhook_name
       SNOWFLAKE_TABLE_PREFIX = var.snowflake_table_prefix
     }
   }

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -53,4 +53,7 @@ locals {
   smtp_secret_arn       = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp[0].arn : data.aws_secretsmanager_secret.ztmf_smtp[0].arn
   smtp_ca_root_arn      = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp_ca_root[0].arn : data.aws_secretsmanager_secret.ztmf_smtp_ca_root[0].arn
   smtp_intermediate_arn = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp_intermediate[0].arn : data.aws_secretsmanager_secret.ztmf_smtp_intermediate[0].arn
+
+  slack_webhook_arn  = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_slack_webhook[0].arn : data.aws_secretsmanager_secret.ztmf_slack_webhook[0].arn
+  slack_webhook_name = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_slack_webhook[0].name : data.aws_secretsmanager_secret.ztmf_slack_webhook[0].name
 }

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -39,11 +39,11 @@ locals {
   // impl reuses them rather than racing dev's state for ownership.
   manage_vpc_endpoints = var.environment != "impl"
 
-  // Snowflake/Kion sync are dev/prod-only for impl v1. Snowflake credentials
-  // and Kion API keys require SDL/Kion coordination not yet done for impl.
-  // CFACTS S3 sync (S3-trigger only, no external service dep) stays on for impl.
+  // Snowflake sync is dev/prod-only for impl v1. Snowflake credentials require
+  // SDL coordination not yet done for impl. CFACTS S3 sync (S3-trigger only,
+  // no external service dep) stays on for impl. Kion is gated separately via
+  // var.kion_rotate_schedule_enabled in tfvars.
   enable_snowflake_sync = contains(["dev", "prod"], var.environment)
-  enable_kion_rotation  = contains(["dev", "prod"], var.environment)
 
   // Reference shims: pick the resource for dev/prod, the data source for impl.
   // Keeps every other file's reference site identical regardless of env.

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -53,7 +53,4 @@ locals {
   smtp_secret_arn       = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp[0].arn : data.aws_secretsmanager_secret.ztmf_smtp[0].arn
   smtp_ca_root_arn      = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp_ca_root[0].arn : data.aws_secretsmanager_secret.ztmf_smtp_ca_root[0].arn
   smtp_intermediate_arn = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp_intermediate[0].arn : data.aws_secretsmanager_secret.ztmf_smtp_intermediate[0].arn
-
-  va_trust_provider_secret_id = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_va_trust_provider[0].id : data.aws_secretsmanager_secret.ztmf_va_trust_provider_impl[0].id
-  db_user_secret_id           = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_db_user[0].id : data.aws_secretsmanager_secret.ztmf_db_user_impl[0].id
 }

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -11,4 +11,49 @@ locals {
   // technically only one of the fields was a true secret (client_secret), but since we have the space here
   //  we can use it to simplify code instead of placing all the other fields in TF vars
   oidc_options = jsondecode(data.aws_secretsmanager_secret_version.ztmf_va_trust_provider_current.secret_string)
+
+  // impl shares the dev AWS account and dev VPC; per-env suffix renames every
+  // VPC- and account-scoped resource that would otherwise collide with dev's.
+  // dev/prod render an empty suffix so existing AWS object names (and the
+  // terraform state addresses that bind to them) stay literal.
+  name_suffix    = var.environment == "impl" ? "-impl" : ""
+  underscore_sfx = var.environment == "impl" ? "_impl" : ""
+
+  ztmf_name          = "ztmf${local.name_suffix}"
+  ztmf_api_name      = "ztmf-api${local.name_suffix}"
+  ztmf_rest_api_tg   = "ztmf-rest-api${local.name_suffix}"
+  ztmf_db_sg_name    = "ztmf_db${local.underscore_sfx}"
+  ztmf_api_log_group = "ztmf_api${local.underscore_sfx}"
+  ztmf_ops_log_group = "ztmf_ops${local.underscore_sfx}"
+  ztmf_vpce_sg_name  = "ztmf_vpc_endpoints${local.underscore_sfx}"
+  ztmf_alb_sg_name   = "ztmf${local.name_suffix}"
+  ztmf_api_task_sg   = "ztmf-api-task${local.name_suffix}"
+  ztmf_ops_task_sg   = "ztmf_ops_task${local.underscore_sfx}"
+
+  // True account-level singletons (ECR repos, OIDC provider, shared SMTP/TLS
+  // secrets, account-shared S3 log bucket). Created in dev/prod, reused by
+  // impl via data sources so two states never own the same physical resource.
+  manage_account_singletons = var.environment != "impl"
+
+  // dev's VPC already owns the 9 interface endpoints listed in vpc.tf.
+  // impl reuses them rather than racing dev's state for ownership.
+  manage_vpc_endpoints = var.environment != "impl"
+
+  // Snowflake/Kion sync are dev/prod-only for impl v1. Snowflake credentials
+  // and Kion API keys require SDL/Kion coordination not yet done for impl.
+  // CFACTS S3 sync (S3-trigger only, no external service dep) stays on for impl.
+  enable_snowflake_sync = contains(["dev", "prod"], var.environment)
+  enable_kion_rotation  = contains(["dev", "prod"], var.environment)
+
+  // Reference shims: pick the resource for dev/prod, the data source for impl.
+  // Keeps every other file's reference site identical regardless of env.
+  ecr_api_repo_url = local.manage_account_singletons ? aws_ecr_repository.ztmf_api[0].repository_url : data.aws_ecr_repository.ztmf_api[0].repository_url
+  ecr_ops_repo_url = local.manage_account_singletons ? aws_ecr_repository.ztmf_ops[0].repository_url : data.aws_ecr_repository.ztmf_ops[0].repository_url
+
+  smtp_secret_arn       = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp[0].arn : data.aws_secretsmanager_secret.ztmf_smtp[0].arn
+  smtp_ca_root_arn      = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp_ca_root[0].arn : data.aws_secretsmanager_secret.ztmf_smtp_ca_root[0].arn
+  smtp_intermediate_arn = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_smtp_intermediate[0].arn : data.aws_secretsmanager_secret.ztmf_smtp_intermediate[0].arn
+
+  va_trust_provider_secret_id = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_va_trust_provider[0].id : data.aws_secretsmanager_secret.ztmf_va_trust_provider_impl[0].id
+  db_user_secret_id           = local.manage_account_singletons ? aws_secretsmanager_secret.ztmf_db_user[0].id : data.aws_secretsmanager_secret.ztmf_db_user_impl[0].id
 }

--- a/infrastructure/moved.tf
+++ b/infrastructure/moved.tf
@@ -69,16 +69,6 @@ moved {
 }
 
 moved {
-  from = aws_secretsmanager_secret.ztmf_va_trust_provider
-  to   = aws_secretsmanager_secret.ztmf_va_trust_provider[0]
-}
-
-moved {
-  from = aws_secretsmanager_secret.ztmf_db_user
-  to   = aws_secretsmanager_secret.ztmf_db_user[0]
-}
-
-moved {
   from = aws_s3_bucket.ztmf_logs
   to   = aws_s3_bucket.ztmf_logs[0]
 }

--- a/infrastructure/moved.tf
+++ b/infrastructure/moved.tf
@@ -1,0 +1,94 @@
+// Address shifts caused by adding `count` to account-singleton resources so
+// impl can reuse dev's existing copies via data sources. Without these blocks,
+// `terraform plan` against dev/prod state would propose destroy + recreate.
+// With them, the plan is a state-only "moved" no-op.
+
+moved {
+  from = aws_ecr_repository.ztmf_api
+  to   = aws_ecr_repository.ztmf_api[0]
+}
+
+moved {
+  from = aws_ecr_lifecycle_policy.ztmf_api
+  to   = aws_ecr_lifecycle_policy.ztmf_api[0]
+}
+
+moved {
+  from = aws_ecr_registry_scanning_configuration.ztmf_api
+  to   = aws_ecr_registry_scanning_configuration.ztmf_api[0]
+}
+
+moved {
+  from = aws_ecr_repository.ztmf_ops
+  to   = aws_ecr_repository.ztmf_ops[0]
+}
+
+moved {
+  from = aws_ecr_lifecycle_policy.ztmf_ops
+  to   = aws_ecr_lifecycle_policy.ztmf_ops[0]
+}
+
+moved {
+  from = aws_iam_openid_connect_provider.github_actions
+  to   = aws_iam_openid_connect_provider.github_actions[0]
+}
+
+moved {
+  from = module.github_actions
+  to   = module.github_actions[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.ztmf_smtp
+  to   = aws_secretsmanager_secret.ztmf_smtp[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.ztmf_smtp_ca_root
+  to   = aws_secretsmanager_secret.ztmf_smtp_ca_root[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.ztmf_smtp_intermediate
+  to   = aws_secretsmanager_secret.ztmf_smtp_intermediate[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.ztmf_tls_cert
+  to   = aws_secretsmanager_secret.ztmf_tls_cert[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.ztmf_tls_key
+  to   = aws_secretsmanager_secret.ztmf_tls_key[0]
+}
+
+moved {
+  from = aws_security_group.ztmf_vpc_endpoints
+  to   = aws_security_group.ztmf_vpc_endpoints[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.ztmf_va_trust_provider
+  to   = aws_secretsmanager_secret.ztmf_va_trust_provider[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.ztmf_db_user
+  to   = aws_secretsmanager_secret.ztmf_db_user[0]
+}
+
+moved {
+  from = aws_s3_bucket.ztmf_logs
+  to   = aws_s3_bucket.ztmf_logs[0]
+}
+
+moved {
+  from = aws_s3_bucket_server_side_encryption_configuration.ztmf_logs
+  to   = aws_s3_bucket_server_side_encryption_configuration.ztmf_logs[0]
+}
+
+moved {
+  from = aws_s3_bucket_policy.ztmf_logs_access
+  to   = aws_s3_bucket_policy.ztmf_logs_access[0]
+}

--- a/infrastructure/moved.tf
+++ b/infrastructure/moved.tf
@@ -64,6 +64,11 @@ moved {
 }
 
 moved {
+  from = aws_secretsmanager_secret.ztmf_slack_webhook
+  to   = aws_secretsmanager_secret.ztmf_slack_webhook[0]
+}
+
+moved {
   from = aws_security_group.ztmf_vpc_endpoints
   to   = aws_security_group.ztmf_vpc_endpoints[0]
 }

--- a/infrastructure/oidc.tf
+++ b/infrastructure/oidc.tf
@@ -1,5 +1,7 @@
 // GitHub OIDC provider is account-scoped (one per token URL). Created in
-// dev/prod; impl reuses dev's via data source.
+// dev/prod; impl reuses dev's existing provider implicitly through CI's
+// configure-aws-credentials action (which trusts the provider by URL, not
+// by terraform-tracked ARN). No data source needed here.
 resource "aws_iam_openid_connect_provider" "github_actions" {
   count          = local.manage_account_singletons ? 1 : 0
   url            = "https://token.actions.githubusercontent.com"
@@ -8,11 +10,6 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
     "6938fd4d98bab03faadb97b34396831e3780aea1",
     "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
   ]
-}
-
-data "aws_iam_openid_connect_provider" "github_actions" {
-  count = local.manage_account_singletons ? 0 : 1
-  url   = "https://token.actions.githubusercontent.com"
 }
 
 // GitHub Actions deploy role. Account-scoped IAM role; impl shares dev's role

--- a/infrastructure/oidc.tf
+++ b/infrastructure/oidc.tf
@@ -1,4 +1,7 @@
+// GitHub OIDC provider is account-scoped (one per token URL). Created in
+// dev/prod; impl reuses dev's via data source.
 resource "aws_iam_openid_connect_provider" "github_actions" {
+  count          = local.manage_account_singletons ? 1 : 0
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
   thumbprint_list = [
@@ -7,10 +10,18 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
   ]
 }
 
+data "aws_iam_openid_connect_provider" "github_actions" {
+  count = local.manage_account_singletons ? 0 : 1
+  url   = "https://token.actions.githubusercontent.com"
+}
+
+// GitHub Actions deploy role. Account-scoped IAM role; impl shares dev's role
+// (same role assumes via OIDC for impl branch deploys via env-routed secrets).
 module "github_actions" {
+  count     = local.manage_account_singletons ? 1 : 0
   name      = "ztmf_github_actions"
   source    = "./modules/role"
-  principal = { Federated = aws_iam_openid_connect_provider.github_actions.arn }
+  principal = { Federated = aws_iam_openid_connect_provider.github_actions[0].arn }
   managed_policy_arns = [
     "arn:aws:iam::${local.account_id}:policy/CMSApprovedAWSServices",
     "arn:aws:iam::${local.account_id}:policy/ADO-Restriction-Policy",

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -27,6 +27,29 @@ output "lambda_function_arn" {
   sensitive   = false
 }
 
+# CloudFront distribution domain - the CNAME target for the env's
+# domain_name (dev.ztmf.cms.gov, impl.ztmf.cms.gov, ztmf.cms.gov).
+# Hand this value to the DNS team to create the CNAME record.
+output "cloudfront_distribution_domain" {
+  description = "CloudFront distribution domain name; CNAME target for the env's public domain (dev.ztmf.cms.gov / impl.ztmf.cms.gov / ztmf.cms.gov)"
+  value       = aws_cloudfront_distribution.ztmf.domain_name
+  sensitive   = false
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID; populate the env's CLOUDFRONT_DISTRIBUTION_ID GitHub secret with this"
+  value       = aws_cloudfront_distribution.ztmf.id
+  sensitive   = false
+}
+
+# Internal ALB DNS - not normally needed for external DNS, but useful
+# for debugging direct ALB access from inside the VPC.
+output "alb_dns_name" {
+  description = "Internal ALB DNS name (private; only resolvable from inside the VPC)"
+  value       = aws_lb.ztmf_api.dns_name
+  sensitive   = false
+}
+
 # Store test events as SSM parameters for team reference
 resource "aws_ssm_parameter" "lambda_test_events" {
   for_each = var.environment == "dev" ? {

--- a/infrastructure/rds.tf
+++ b/infrastructure/rds.tf
@@ -1,10 +1,10 @@
 resource "aws_db_subnet_group" "ztmf" {
-  name       = "ztmf"
+  name       = local.ztmf_name
   subnet_ids = data.aws_subnets.private.ids
 }
 
 resource "aws_security_group" "ztmf_db" {
-  name        = "ztmf_db"
+  name        = local.ztmf_db_sg_name
   description = "Allow postgresql inbound traffic"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -18,7 +18,7 @@ resource "aws_security_group" "ztmf_db" {
 }
 
 resource "aws_rds_cluster" "ztmf" {
-  cluster_identifier          = "ztmf"
+  cluster_identifier          = local.ztmf_name
   engine                      = "aurora-postgresql"
   engine_mode                 = "provisioned"
   engine_version              = "16.8"

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -56,12 +56,16 @@ data "aws_iam_policy_document" "allow_s3_access_from_cloudfront" {
   }
 }
 
+// Account-shared ALB access log bucket. Account ID-keyed name; impl skips
+// creation since dev's bucket already exists in the same account.
 resource "aws_s3_bucket" "ztmf_logs" {
+  count  = local.manage_account_singletons ? 1 : 0
   bucket = "ztmf-logs-${local.account_id}-use1"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "ztmf_logs" {
-  bucket = aws_s3_bucket.ztmf_logs.id
+  count  = local.manage_account_singletons ? 1 : 0
+  bucket = aws_s3_bucket.ztmf_logs[0].id
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
@@ -70,7 +74,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "ztmf_logs" {
 }
 
 resource "aws_s3_bucket_policy" "ztmf_logs_access" {
-  bucket = aws_s3_bucket.ztmf_logs.id
+  count  = local.manage_account_singletons ? 1 : 0
+  bucket = aws_s3_bucket.ztmf_logs[0].id
   policy = data.aws_iam_policy_document.ztmf_logs_access.json
 }
 
@@ -88,7 +93,7 @@ data "aws_iam_policy_document" "ztmf_logs_access" {
     ]
 
     resources = [
-      "${aws_s3_bucket.ztmf_logs.arn}/rest-api-alb/*"
+      "arn:aws:s3:::ztmf-logs-${local.account_id}-use1/rest-api-alb/*"
     ]
   }
 
@@ -106,8 +111,8 @@ data "aws_iam_policy_document" "ztmf_logs_access" {
     ]
 
     resources = [
-      aws_s3_bucket.ztmf_logs.arn,
-      "${aws_s3_bucket.ztmf_logs.arn}/*",
+      "arn:aws:s3:::ztmf-logs-${local.account_id}-use1",
+      "arn:aws:s3:::ztmf-logs-${local.account_id}-use1/*",
     ]
 
 

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -1,11 +1,11 @@
-// Per-env OIDC config for ALB authenticate-oidc actions. dev/prod manage
-// the secret here; impl reads `ztmf_va_trust_provider_impl` via data source
-// so the operator can pre-seed valid OIDC JSON before first apply (the
-// secret_version data source below would otherwise fail on an empty
-// terraform-created placeholder, blocking every plan).
+// Per-env OIDC config for ALB authenticate-oidc actions. Suffix-renamed for
+// impl so the dev account holds two distinct secrets (ztmf_va_trust_provider
+// for dev, ztmf_va_trust_provider_impl for impl) without state collision.
+// First apply for any env: terraform creates the empty secret; operator
+// seeds the OIDC JSON; re-apply consumes it via the data source below.
+// Same two-phase bootstrap dev went through.
 resource "aws_secretsmanager_secret" "ztmf_va_trust_provider" {
-  count = local.manage_account_singletons ? 1 : 0
-  name  = "ztmf_va_trust_provider"
+  name = "ztmf_va_trust_provider${local.underscore_sfx}"
 }
 
 # cert and key are the TLS digicert certificate purchased by Elizabeth S.
@@ -25,14 +25,15 @@ resource "aws_secretsmanager_secret" "ztmf_tls_key" {
   name  = "ztmf_tls_key"
 }
 
-# DB user is only used to create the DB, its value is then copied into the RDS-managed auto-rotated secret.
-# dev/prod manage here; impl reads `ztmf_db_user_impl` via data source so the
-# operator can pre-seed the DB master username before first apply (the RDS
-# cluster references this value via secret_version, which fails on an empty
-# placeholder).
+# DB user holds the master_username for the Aurora cluster. The password
+# itself is auto-generated and auto-rotated by RDS via
+# manage_master_user_password=true on the cluster, so this secret is touched
+# once at bootstrap and never again.
+# Suffix-renamed for impl: each env's Aurora cluster has its own seeded
+# username. First apply for any env: terraform creates the empty secret;
+# operator seeds a username string; re-apply creates the cluster.
 resource "aws_secretsmanager_secret" "ztmf_db_user" {
-  count = local.manage_account_singletons ? 1 : 0
-  name  = "ztmf_db_user"
+  name = "ztmf_db_user${local.underscore_sfx}"
 }
 
 # host, port, and credentials for logging in to CMS SMTP service.

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -119,9 +119,13 @@ resource "aws_secretsmanager_secret" "ztmf_slack_webhook" {
 
   description = "Slack webhook URL for ZTMF data sync alerts and notifications"
 
+  # Tag tracks which env the webhook belongs to. dev/prod historically
+  # tagged this "shared" because there was a single webhook secret pre-impl;
+  # preserving that value avoids a no-op tag diff on dev/prod state. impl's
+  # new secret gets tagged accurately.
   tags = {
     Name        = "ZTMF Slack Webhook"
-    Environment = "shared"
+    Environment = local.manage_account_singletons ? "shared" : var.environment
     Purpose     = "Data sync notifications"
   }
 }

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -111,21 +111,19 @@ resource "aws_secretsmanager_secret" "ztmf_kion_prod" {
   }
 }
 
-# Slack webhook URL for data sync alerts.
-# Suffix-renamed for impl so impl alerts route to a separate channel without
-# noising dev/prod incident response.
+# Slack webhook URL for data sync alerts. Account-singleton: impl reuses
+# dev's webhook via the data source in data.tf. Single channel covers both
+# environments since the alert source already includes ENVIRONMENT in the
+# message payload.
 resource "aws_secretsmanager_secret" "ztmf_slack_webhook" {
-  name = "ztmf_slack_webhook${local.underscore_sfx}"
+  count = local.manage_account_singletons ? 1 : 0
+  name  = "ztmf_slack_webhook"
 
   description = "Slack webhook URL for ZTMF data sync alerts and notifications"
 
-  # Tag tracks which env the webhook belongs to. dev/prod historically
-  # tagged this "shared" because there was a single webhook secret pre-impl;
-  # preserving that value avoids a no-op tag diff on dev/prod state. impl's
-  # new secret gets tagged accurately.
   tags = {
     Name        = "ZTMF Slack Webhook"
-    Environment = local.manage_account_singletons ? "shared" : var.environment
+    Environment = "shared"
     Purpose     = "Data sync notifications"
   }
 }

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -1,36 +1,56 @@
+// Per-env OIDC config for ALB authenticate-oidc actions. dev/prod manage
+// the secret here; impl reads `ztmf_va_trust_provider_impl` via data source
+// so the operator can pre-seed valid OIDC JSON before first apply (the
+// secret_version data source below would otherwise fail on an empty
+// terraform-created placeholder, blocking every plan).
 resource "aws_secretsmanager_secret" "ztmf_va_trust_provider" {
-  name = "ztmf_va_trust_provider"
+  count = local.manage_account_singletons ? 1 : 0
+  name  = "ztmf_va_trust_provider"
 }
 
 # cert and key are the TLS digicert certificate purchased by Elizabeth S.
-# initially we tried to use them on the Fargate container but decided to 
+# initially we tried to use them on the Fargate container but decided to
 # simplify things by just generating self-signed certs during container builds
 # leaving them here so they arent stored locally in case we need the value again
+#
+# Account-singletons; impl reuses dev's via data sources rather than racing
+# state ownership.
 resource "aws_secretsmanager_secret" "ztmf_tls_cert" {
-  name = "ztmf_tls_cert"
+  count = local.manage_account_singletons ? 1 : 0
+  name  = "ztmf_tls_cert"
 }
 
 resource "aws_secretsmanager_secret" "ztmf_tls_key" {
-  name = "ztmf_tls_key"
+  count = local.manage_account_singletons ? 1 : 0
+  name  = "ztmf_tls_key"
 }
 
-# DB user is only used to create the DB, its value is then copied into the RDS-managed auto-rotated secret
+# DB user is only used to create the DB, its value is then copied into the RDS-managed auto-rotated secret.
+# dev/prod manage here; impl reads `ztmf_db_user_impl` via data source so the
+# operator can pre-seed the DB master username before first apply (the RDS
+# cluster references this value via secret_version, which fails on an empty
+# placeholder).
 resource "aws_secretsmanager_secret" "ztmf_db_user" {
-  name = "ztmf_db_user"
+  count = local.manage_account_singletons ? 1 : 0
+  name  = "ztmf_db_user"
 }
 
-# host, port, and credentials for logging in to CMS SMTP service
+# host, port, and credentials for logging in to CMS SMTP service.
+# Account-singleton; impl reuses dev's CMS SMTP credentials.
 resource "aws_secretsmanager_secret" "ztmf_smtp" {
-  name = "ztmf_smtp"
+  count = local.manage_account_singletons ? 1 : 0
+  name  = "ztmf_smtp"
 }
 
-# CA certs for validating TLS connection to SMTP service
+# CA certs for validating TLS connection to SMTP service. Account-singletons.
 resource "aws_secretsmanager_secret" "ztmf_smtp_ca_root" {
-  name = "ztmf_smtp_ca_root"
+  count = local.manage_account_singletons ? 1 : 0
+  name  = "ztmf_smtp_ca_root"
 }
 
 resource "aws_secretsmanager_secret" "ztmf_smtp_intermediate" {
-  name = "ztmf_smtp_intermediate"
+  count = local.manage_account_singletons ? 1 : 0
+  name  = "ztmf_smtp_intermediate"
 }
 
 # Snowflake credentials for data sync Lambda function (dev environment)
@@ -90,9 +110,11 @@ resource "aws_secretsmanager_secret" "ztmf_kion_prod" {
   }
 }
 
-# Slack webhook URL for data sync alerts (shared across environments)
+# Slack webhook URL for data sync alerts.
+# Suffix-renamed for impl so impl alerts route to a separate channel without
+# noising dev/prod incident response.
 resource "aws_secretsmanager_secret" "ztmf_slack_webhook" {
-  name = "ztmf_slack_webhook"
+  name = "ztmf_slack_webhook${local.underscore_sfx}"
 
   description = "Slack webhook URL for ZTMF data sync alerts and notifications"
 

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -6,6 +6,13 @@
 // Same two-phase bootstrap dev went through.
 resource "aws_secretsmanager_secret" "ztmf_va_trust_provider" {
   name = "ztmf_va_trust_provider${local.underscore_sfx}"
+
+  // Operator-seeded OIDC JSON is not in terraform state. A `terraform
+  // destroy` (or accidental resource removal) would orphan the credentials
+  // and break the ALB OIDC handshake until reseeded. Block the destroy.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # cert and key are the TLS digicert certificate purchased by Elizabeth S.
@@ -34,6 +41,13 @@ resource "aws_secretsmanager_secret" "ztmf_tls_key" {
 # operator seeds a username string; re-apply creates the cluster.
 resource "aws_secretsmanager_secret" "ztmf_db_user" {
   name = "ztmf_db_user${local.underscore_sfx}"
+
+  // Aurora master_username is set at cluster creation and cannot be
+  // changed afterward. Losing this secret would orphan the value and
+  // make rotation/recovery messy. Block accidental destroy.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # host, port, and credentials for logging in to CMS SMTP service.

--- a/infrastructure/tfvars/impl.tfvars
+++ b/infrastructure/tfvars/impl.tfvars
@@ -1,0 +1,23 @@
+# impl runs in the dev AWS account alongside dev. Resource names suffix-rendered
+# to "_impl" / "-impl" via locals.tf. Snowflake/Kion sync disabled at the
+# schedule level until SDL/Kion coordination lands; cert-rotation Lambda is on
+# and re-uses dev's existing multi-SAN ACM certificate (impl.ztmf.cms.gov SAN).
+
+environment            = "impl"
+domain_name_prefix     = "impl."
+ecs_service_task_count = 1
+
+# CFACTS / Snowflake sync configuration
+# Impl has no Snowflake account; left blank, schedule disabled via locals.
+cfacts_snowflake_view  = ""
+snowflake_table_prefix = "ZTMF"
+
+# Kion rotation: impl has no ztmf_kion_impl secret yet; keep schedule off
+kion_rotate_schedule_enabled = false
+
+# TLS cert rotation Lambda
+# ACM ARN sourced from SSM Parameter Store /ztmf/impl/cert-rotation/acm-arn,
+# which is seeded with the dev account's existing multi-SAN cert ARN.
+enable_cert_rotation_lambda = true
+cert_rotation_prefix        = "impl"
+cert_rotation_domain        = "impl.ztmf.cms.gov"

--- a/infrastructure/tfvars/impl.tfvars
+++ b/infrastructure/tfvars/impl.tfvars
@@ -18,6 +18,12 @@ kion_rotate_schedule_enabled = false
 # TLS cert rotation Lambda
 # ACM ARN sourced from SSM Parameter Store /ztmf/impl/cert-rotation/acm-arn,
 # which is seeded with the dev account's existing multi-SAN cert ARN.
+#
+# IMPORTANT: the cert rotation Lambda runs with DRY_RUN=true for any env
+# other than prod (see lambda-cert-rotation.tf). Cert bundle uploads to
+# s3://ztmf-cert-rotation-impl/impl/ are validated and archived but are
+# NEVER imported into ACM. impl reuses dev's already-imported multi-SAN
+# cert; rotations are exercised in prod only.
 enable_cert_rotation_lambda = true
 cert_rotation_prefix        = "impl"
 cert_rotation_domain        = "impl.ztmf.cms.gov"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -13,8 +13,9 @@ variable "ecs_service_task_count" {
 }
 
 variable "cfacts_snowflake_view" {
-  description = "Fully qualified Snowflake view for CFACTS system sync"
+  description = "Fully qualified Snowflake view for CFACTS system sync. Empty for impl v1 (no Snowflake account)."
   type        = string
+  default     = ""
 }
 
 variable "snowflake_table_prefix" {

--- a/infrastructure/vpc.tf
+++ b/infrastructure/vpc.tf
@@ -1,7 +1,10 @@
-# CMS already provides a VPC, we just need some endpoints in it
+// CMS already provides a VPC, we just need some endpoints in it.
+// impl shares dev's VPC; the endpoint SG and 9 interface endpoints are
+// gated to dev/prod and looked up via data sources from impl.
 
 resource "aws_security_group" "ztmf_vpc_endpoints" {
-  name        = "ztmf_vpc_endpoints"
+  count       = local.manage_vpc_endpoints ? 1 : 0
+  name        = local.ztmf_vpce_sg_name
   description = "Allow HTTP(S) traffic from private subnets"
   vpc_id      = data.aws_vpc.ztmf.id
 
@@ -23,12 +26,12 @@ resource "aws_security_group" "ztmf_vpc_endpoints" {
 }
 
 resource "aws_vpc_endpoint" "ztmf" {
-  for_each            = toset(["ec2", "logs", "ecr.api", "ecr.dkr", "secretsmanager", "ssm", "ec2messages", "ssmmessages", "s3"])
+  for_each            = local.manage_vpc_endpoints ? toset(["ec2", "logs", "ecr.api", "ecr.dkr", "secretsmanager", "ssm", "ec2messages", "ssmmessages", "s3"]) : toset([])
   vpc_id              = data.aws_vpc.ztmf.id
   service_name        = "com.amazonaws.us-east-1.${each.value}"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = data.aws_subnets.private.ids
-  security_group_ids  = [aws_security_group.ztmf_vpc_endpoints.id]
+  security_group_ids  = [aws_security_group.ztmf_vpc_endpoints[0].id]
   private_dns_enabled = true
   dns_options { private_dns_only_for_inbound_resolver_endpoint = false }
 }
@@ -49,7 +52,8 @@ data "aws_eip" "nat_gateway" {
   id    = data.aws_nat_gateway.existing[0].allocation_id
 }
 
-# Security group for Lambda function
+# Security group for Lambda function. Already environment-suffixed in name so
+# impl gets its own SG without colliding with dev's `ztmf-data-sync-lambda-dev`.
 resource "aws_security_group" "ztmf_sync_lambda" {
   name        = "ztmf-data-sync-lambda-${var.environment}"
   description = "Security group for ZTMF Data Sync Lambda function"


### PR DESCRIPTION
## Summary

- Adds a third Terraform environment \`impl\` for business-owner experimental testing
- Lives in the dev AWS account (451245779631), shares dev's CMS-provisioned VPC, isolated from dev/prod via per-resource suffix renaming and account-singleton sharing through data sources
- Net effect on dev/prod: zero AWS resource changes; all HCL touches resolve as state-only \`moved\` migrations
- Adds new orchestration workflow that triggers on push to the long-lived \`impl\` branch and runs Analysis on PRs against \`impl\`

## Strategy

- **Suffix namespace** for resources whose AWS object name can carry an env suffix (RDS cluster, ALB, ECS cluster, security groups, log groups, per-env secrets). \`local.name_suffix\` renders empty for dev/prod (preserving existing AWS object names) and \`-impl\`/\`_impl\` for impl.
- **Count-gate** account-level singletons (ECR repos, OIDC provider, GitHub Actions IAM role, account-shared S3 logs bucket, SMTP/TLS secrets, Slack webhook, CloudFront OAC, HSTS policy, VPC endpoints + endpoint SG). dev/prod manage them; impl reuses them via data source fallbacks abstracted behind locals.
- **\`moved.tf\`** rewrites the address shifts from \`count\` adoption so dev/prod plans show only state-only \`moved\` entries, no destroy/create.
- **Snowflake / CFACTS-Snowflake EventBridge schedules** disabled for impl via the \`state\` attribute; lambdas themselves remain ungated to avoid extensive moved-block churn. Kion rotation held off via \`kion_rotate_schedule_enabled = false\` in tfvars.
- **\`prevent_destroy\` lifecycle** on \`ztmf_va_trust_provider\` and \`ztmf_db_user\` secrets across all envs. These hold operator-seeded values terraform never tracks (OIDC JSON, Aurora master_username); \`terraform destroy\` would orphan them.

## CI

- New \`orchestration-impl.yml\` triggers on push and pull_request against the \`impl\` branch
- Push to impl runs full pipeline (analysis -> diff -> backend -> infrastructure)
- PR to impl runs Analysis only (no deploy; avoids racing concurrent impl PRs for shared state)
- \`backend.yml\` gains a \`PARAMETER_NAME\` assertion before SSM put-parameter so an IMPL environment misconfigured with dev's parameter name fails fast instead of overwriting dev's image pointer

## Out-of-band prereqs (already executed in dev account before this PR)

Tracked in #303:
- S3 state bucket \`ztmf-terraform-state-use1-impl\` created (AES256, versioned, public-blocked, SSL-only)
- SSM \`/ztmf/impl/cert-rotation/acm-arn\` seeded with dev's existing multi-SAN ACM ARN (cert covers \`impl.ztmf.cms.gov\`)
- SSM \`ztmf-impl_api_tag\` seeded
- Secret \`ztmf_va_trust_provider_impl\` created (stub OIDC JSON; replace with real Okta config once ztmf-misc#145 lands)
- Secret \`ztmf_db_user_impl\` created with master username \`ztmfAdmin\` (matches dev)
- Both secrets imported into impl's terraform state

## Verification

- \`terraform validate\` passes
- \`terraform plan -var-file=tfvars/dev.tfvars\` against live dev state: **0 to add, 0 to change, 0 to destroy** (clean after #304 engine_version bump merged)
- \`terraform plan -var-file=tfvars/impl.tfvars\` against impl state: 135 to add, 0 to destroy (greenfield impl deploy)
- All count-gated resources resolve through \`moved\` blocks
- 85/85 Emberfall E2E tests pass on push
- Unit tests pass on push

## Post-merge runbook

1. Configure GitHub repo Environment \`IMPL\` with the 6 secrets listed at the top of \`orchestration-impl.yml\` (ROLEARN, ECR_REPO_URL, PARAMETER_NAME=\`ztmf-impl_api_tag\`, BUCKET_NAME, CLOUDFRONT_DISTRIBUTION_ID, SNYK_TOKEN). ROLEARN/SNYK_TOKEN reuse dev's values; ECR_REPO_URL points at the same dev ECR; CLOUDFRONT_DISTRIBUTION_ID populated after first apply.
2. Apply branch protection on \`impl\` branch (PR required, 1 approval, linear history, no force pushes, admin bypass enabled — full config in workflow header).
3. Fast-forward \`impl\` branch to main HEAD: \`git push origin main:impl --force-with-lease\`. This is the trigger for the first impl deploy.
4. CI runs orchestration-impl.yml -> first apply creates 135 impl resources in dev account.
5. Capture \`cloudfront_distribution_domain\` output -> file CNAME ticket (or update ztmf-misc#144) for \`impl.ztmf.cms.gov\`.
6. Once impl Okta app is registered (ztmf-misc#145), replace stub OIDC JSON in \`ztmf_va_trust_provider_impl\`.
7. Smoke test: \`https://impl.ztmf.cms.gov/api/v1/users/current\` returns Okta auth challenge then 200 after login.

## Test plan

- [x] terraform validate passes
- [x] terraform plan against dev shows 0 add, 0 destroy
- [x] terraform plan against impl shows 135 add, 0 destroy (greenfield)
- [x] Unit tests pass
- [x] 85/85 Emberfall E2E tests pass
- [ ] Dev CI pipeline runs and confirms no destructive changes against dev infra
- [ ] Post-merge: first impl deploy completes; CloudFront domain captured for DNS request