### PR TITLE
Import CMS-managed impl CloudFront, fix RDS secret tag-prefix collision

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -29,7 +29,11 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ROLEARN }}
-          role-duration-seconds: 900
+          # 1 hour: dev/prod applies normally complete in a few minutes, but
+          # first-time impl bootstrap takes 15+ minutes (Aurora cluster create,
+          # ECS service stabilization, CloudFront propagation) and the previous
+          # 900s window expired mid-apply, leaving an inconsistent state.
+          role-duration-seconds: 3600
           aws-region: us-east-1
 
       - name: Setup Terraform

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -62,6 +62,23 @@ resource "aws_cloudfront_vpc_origin" "internal_alb" {
   }
 }
 
+// CMS Cloud manages CloudFront creation centrally (cloudfront:CreateDistribution
+// is denied by SCP p-q0yh3mfg in this org). The dev/prod distributions were
+// provisioned via the same CMS Cloud intake before the SCP existed; impl's
+// distribution was provisioned via CLDSPT-106119 as an empty shell. We have
+// UpdateDistribution permission, so the import below brings the CMS-created
+// distribution under terraform management and our config below applies the
+// aliases, origins, cache behaviors, cert, and WAF on the next apply.
+//
+// To re-bootstrap a future env that goes through the same intake: file a CMS
+// Cloud "AWS CloudFront - New Distribution" request, capture the returned
+// distribution ID, add a parallel import block here gated on var.environment.
+import {
+  for_each = var.environment == "impl" ? toset(["impl"]) : toset([])
+  to       = aws_cloudfront_distribution.ztmf
+  id       = "E1AO1UMW0EY8PK"
+}
+
 resource "aws_cloudfront_distribution" "ztmf" {
   aliases             = [local.domain_name]
   enabled             = true

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -67,20 +67,14 @@ data "aws_secretsmanager_secret_version" "ztmf_db_user_current" {
   secret_id = data.aws_secretsmanager_secret.ztmf_db_user.id
 }
 
-data "aws_secretsmanager_secrets" "rds" {
-  filter {
-    name   = "tag-key"
-    values = ["aws:rds:primaryDBClusterArn"]
-  }
-
-  filter {
-    name = "tag-value"
-    // Impl runs its own Aurora cluster ztmf-impl in the dev account; use the
-    // env-suffixed cluster identifier so the RDS-managed master password
-    // secret resolves to the right cluster's secret.
-    values = ["arn:aws:rds:us-east-1:${local.account_id}:cluster:${local.ztmf_name}"]
-  }
-}
+// Note: this used to be a `data "aws_secretsmanager_secrets" "rds"` lookup that
+// found the RDS-managed master password secret by tag. The Secrets Manager API
+// `tag-value` filter is prefix-matching, so once impl was provisioned the same
+// filter started matching both dev's "cluster:ztmf" and impl's
+// "cluster:ztmf-impl" tag values, and join("") concatenated the two ARNs into
+// a corrupt DB_SECRET_ID that broke the ECS task definition. The cluster
+// resource's master_user_secret[0].secret_arn is exposed directly, so no
+// Secrets Manager lookup is needed (see locals.tf db_cred_secret).
 
 # Account-singletons that impl reuses from dev's state.
 # count = 1 only when this env doesn't manage them as resources, i.e. impl.

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -2,8 +2,15 @@ locals {
   // adding reference here to make other references shorter to type "local.account_id" :)
   account_id = data.aws_caller_identity.current.account_id
 
-  // join because terraform is stupid when it comes to sets, lists, and tuples
-  db_cred_secret = join("", data.aws_secretsmanager_secrets.rds.arns)
+  // Aurora's manage_master_user_password=true generates a password and stores
+  // it in a Secrets Manager secret tagged with the cluster ARN. The cluster
+  // resource exposes that secret's ARN directly via master_user_secret, which
+  // is the authoritative reference and avoids a Secrets Manager tag lookup.
+  // The earlier data.aws_secretsmanager_secrets filter returned both dev's
+  // and impl's secrets once both clusters lived in the same account because
+  // tag-value matching is prefix-based ("cluster:ztmf" is a prefix of
+  // "cluster:ztmf-impl").
+  db_cred_secret = aws_rds_cluster.ztmf.master_user_secret[0].secret_arn
 
   domain_name = "${var.domain_name_prefix}ztmf.cms.gov"
 


### PR DESCRIPTION
## Summary

- Imports the CMS-Cloud-provisioned impl CloudFront distribution (`E1AO1UMW0EY8PK`, ticket [CLDSPT-106119](https://jiraent.cms.gov/plugins/servlet/desk/portal/22/CLDSPT-106119)) into impl's terraform state via an env-gated `import {}` block.
- Fixes a real, dev-impacting bug: dev's `DB_SECRET_ID` was about to be rewritten as a corrupt concatenation of dev's and impl's RDS-managed secret ARNs because the Secrets Manager `tag-value` filter does prefix matching and `cluster:ztmf` is a prefix of `cluster:ztmf-impl`.
- Bumps the GitHub Actions infrastructure-job role duration from 15 min to 1 hour so first impl bootstrap apply has time to complete.

## CloudFront import

`cloudfront:CreateDistribution` is denied in this org by SCP `p-q0yh3mfg`. `UpdateDistribution` is allowed. CMS Cloud created an empty distribution shell; the import block brings it under management and the next impl apply attaches aliases, the ALB origin, cache behaviors, the cert, and WAF via UpdateDistribution.

## RDS secret resolution

Before:
```hcl
db_cred_secret = join("", data.aws_secretsmanager_secrets.rds.arns)
```

The data source filtered by tag-value `arn:...:cluster:ztmf`. AWS Secrets Manager treats that as a prefix, so once impl was provisioned the filter started returning both clusters' secrets and `join("")` produced a corrupt ARN string. Dev's next apply would have written that into the ECS task definition's `DB_SECRET_ID` env var.

After:
```hcl
db_cred_secret = aws_rds_cluster.ztmf.master_user_secret[0].secret_arn
```

The cluster resource is the authoritative source for the auto-generated secret ARN. No Secrets Manager lookup, no prefix-collision exposure.

## Verification

- `terraform validate` passes
- `tflint --chdir=infrastructure/` clean
- `terraform plan -var-file=tfvars/dev.tfvars` against live dev state: **No changes. Your infrastructure matches the configuration.**

## Test plan

- [x] terraform plan against dev shows zero diff after the master_user_secret refactor
- [x] tflint + fmt clean (now also enforced by the pre-push hook from #305)
- [ ] PR auto-deploys to dev via CI; confirm dev ECS service stays healthy after apply
- [ ] After merge, push main into impl branch; impl apply imports the CloudFront distribution and configures aliases/origins/cache behaviors via UpdateDistribution
- [ ] Capture the now-managed `cloudfront_distribution_domain` output for the impl DNS CNAME