### PR TITLE
chore(deps): bump github.com/apache/thrift from 0.22.0 to 0.23.0

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/apache/arrow-go/v18 v18.4.0 // indirect
-	github.com/apache/thrift v0.22.0 // indirect
+	github.com/apache/thrift v0.23.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -28,8 +28,8 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.4.0 h1:/RvkGqH517iY8bZKc4FD5/kkdwXJGjxf28JIXbJ/oB0=
 github.com/apache/arrow-go/v18 v18.4.0/go.mod h1:Aawvwhj8x2jURIzD9Moy72cF0FyJXOpkYpdmGRHcw14=
-github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
-github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
+github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
+github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/aws/aws-lambda-go v1.49.0 h1:z4VhTqkFZPM3xpEtTqWqRqsRH4TZBMJqTkRiBPYLqIQ=
 github.com/aws/aws-lambda-go v1.49.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=


### PR DESCRIPTION
## Summary

Bumps `github.com/apache/thrift` from 0.22.0 to 0.23.0 in `backend/`. Resolves Dependabot alert #30 (Apache Thrift TFramedTransport integer overflow / wraparound in the Go implementation; high severity; vulnerable range `<0.23.0`, patched in 0.23.0).

This PR is a cherry-pick of the Dependabot commit onto a maintainer branch so the workflows can run against repository secrets. The Dependabot-authored PR #306 cannot run the Backend or Infrastructure jobs because secret-bearing workflows are skipped on PRs from `dependabot[bot]`. Once this PR merges and the alert clears, PR #306 will be closed as a duplicate.

## Test plan

- [x] `make test-unit` clean on this branch
- [x] `make test-e2e` clean on this branch (85/85 emberfall tests)
- [x] `go mod tidy` produces no additional changes after the cherry-pick
- [x] `apache/thrift` is an indirect dependency in `backend/go.mod`; nothing in our code imports it directly, so behavior change is limited to the upstream library

## Files changed

- `backend/go.mod` (indirect dependency line)
- `backend/go.sum` (checksum update)

## References

- Dependabot alert: https://github.com/CMS-Enterprise/ztmf/security/dependabot/30
- Replaces / supersedes: #306 (close after merge)
- Upstream changelog: https://github.com/apache/thrift/blob/master/CHANGES.md#0230