### PR TITLE
Align CMS scoring with HHS scale (1.0-5.0) and surface tier in API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,19 +299,22 @@ test-build:
 test-full:
 	@echo "Running comprehensive test suite..."
 	@echo ""
-	@echo "1/4 Building all binaries (API + Lambdas)..."
+	@echo "1/5 Building all binaries (API + Lambdas)..."
 	@cd backend && go build ./cmd/api/...
 	@cd backend && go build ./cmd/lambda/...
 	@cd backend && go build ./cmd/lambda-cfacts-snowflake/...
 	@cd backend && go build ./cmd/lambda-cfacts-s3/...
 	@echo ""
-	@echo "2/4 Running unit tests..."
+	@echo "2/5 Running unit tests..."
 	@cd backend && go test -short ./...
 	@echo ""
-	@echo "3/4 Generating coverage report..."
+	@echo "3/5 Generating coverage report..."
 	@cd backend && go test -cover $$(go list ./... | xargs -I{} sh -c 'test -n "$$(find $$(go list -f "{{.Dir}}" {}) -maxdepth 1 -name "*_test.go" 2>/dev/null)" && echo {}' | tr "\n" " ")
 	@echo ""
-	@echo "4/4 Running Emberfall E2E tests (isolated containers)..."
+	@echo "4/5 Running integration tests (require DB_* env from backend/dev.compose.env)..."
+	@cd backend && go test -run Integration ./... -count=1
+	@echo ""
+	@echo "5/5 Running Emberfall E2E tests (isolated containers)..."
 	@make test-e2e
 	@echo ""
 	@echo "✅ All tests complete"

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -730,9 +730,24 @@ tests:
           data:
             <<: *restoredUserData
 
-  # Scores: HHS-aligned aggregate smoke test (ztmf-misc#175). Math is
-  # asserted in unit tests at internal/model/scores_test.go; this confirms
-  # the endpoint serves a parseable 200 response with the new shape.
+  # Scores: HHS-aligned aggregate smoke battery (ztmf-misc#175).
+  #
+  # Math correctness, response field presence, and Tier(score)==tier
+  # consistency are all pinned in internal/model/scores_integration_test.go,
+  # which runs against the real schema as part of `make test-full`.
+  # Emberfall's body assertion is exact-match (body.text is full-body
+  # equality, body.json equality fails on array-typed responses due to
+  # aquia-inc/emberfall#36), so these HTTP-layer smokes cover what we
+  # can express cleanly: cardinality contract, auth gates, and content
+  # type. Anything that survives unit + integration but breaks at the
+  # HTTP boundary still shows up here.
+  #
+  # The DS-1 seed (fismasystemid=1001) has 24 score rows across datacalls
+  # 1 and 2 in _test_data_empire.sql, guaranteeing a non-empty response.
+
+  # 1. Scored system returns a populated aggregate via the full HTTP
+  #    path. Regression target: 5xx anywhere in the new aggregation SQL,
+  #    JSON serialization of the new tier fields, content negotiation.
   - url: http://localhost:8080/api/v1/scores/aggregate?fismasystemid=1001&include_pillars=true
     method: GET
     headers:
@@ -741,6 +756,21 @@ tests:
       status: 200
       headers:
         content-type: "application/json"
+
+  # 2. Unscored system returns an empty data array. Regression target:
+  #    an accidental cartesian fismasystems x datacalls join that
+  #    synthesizes Not Assessed rows for every system in every cycle.
+  #    Emberfall handles the empty-array body exactly.
+  - url: http://localhost:8080/api/v1/scores/aggregate?fismasystemid=999999
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        text: "{\"data\":[]}"
 
   # Questions Endpoints
   - id: createQuestion

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -730,51 +730,17 @@ tests:
           data:
             <<: *restoredUserData
 
-  # # Scores Endpoints
-  # - id: createScore
-  #   url: http://localhost:8080/api/v1/scores
-  #   method: POST
-  #   headers:
-  #     <<: *commonHeaders
-  #     content-type: "application/json"
-  #   body:
-  #     json:
-  #       <<: *scoreData
-  #   expect:
-  #     status: 201
-  #     headers:
-  #       content-type: "application/json"
-  
-  # # Note: There's no GET by ID endpoint for scores in the router
-  
-  # - url: "http://localhost:8080/api/v1/scores/{{.createScore.Response.data.scoreid}}"
-  #   method: PUT
-  #   headers:
-  #     <<: *commonHeaders
-  #     content-type: "application/json"
-  #   body:
-  #     json:
-  #       <<: *updatedScoreData
-  #   expect:
-  #     status: 204
-  
-  # - url: http://localhost:8080/api/v1/scores
-  #   method: GET
-  #   headers:
-  #     <<: *commonHeaders
-  #   expect:
-  #     status: 200
-  #     headers:
-  #       content-type: "application/json"
-  
-  # - url: http://localhost:8080/api/v1/scores/aggregate
-  #   method: GET
-  #   headers:
-  #     <<: *commonHeaders
-  #   expect:
-  #     status: 200
-  #     headers:
-  #       content-type: "application/json"
+  # Scores: HHS-aligned aggregate smoke test (ztmf-misc#175). Math is
+  # asserted in unit tests at internal/model/scores_test.go; this confirms
+  # the endpoint serves a parseable 200 response with the new shape.
+  - url: http://localhost:8080/api/v1/scores/aggregate?fismasystemid=1001&include_pillars=true
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
 
   # Questions Endpoints
   - id: createQuestion

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -11,6 +12,22 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
 )
+
+// rawQuery wraps a hand-built SQL string and its arguments so it can flow
+// through the existing query helper. Used for the pillar aggregation query
+// where the derived subqueries and conditional joins exceed squirrel's
+// ergonomics and a parameterized string is the clearer expression.
+//
+// SELECT-only. The model package's queryRow helper records events derived
+// from the SqlBuilder shape, so write-path callers must not use rawQuery.
+type rawQuery struct {
+	sql  string
+	args []any
+}
+
+func (r rawQuery) ToSql() (string, []any, error) {
+	return r.sql, r.args, nil
+}
 
 type Score struct {
 	ScoreID          int32           `json:"scoreid"`
@@ -71,6 +88,7 @@ type ScoreAggregate struct {
 	DataCallID    int32          `json:"datacallid"`
 	FismaSystemID int32          `json:"fismasystemid"`
 	SystemScore   float64        `json:"systemscore"`
+	SystemTier    string         `json:"systemtier"`
 	PillarScores  []*PillarScore `json:"pillarscores,omitempty" db:"-"`
 }
 
@@ -78,6 +96,33 @@ type PillarScore struct {
 	PillarID int32   `json:"pillarid"`
 	Pillar   string  `json:"pillar"`
 	Score    float64 `json:"score"`
+	Tier     string  `json:"tier"`
+}
+
+// Tier returns the HHS-aligned maturity tier label for a 1.0-5.0 score.
+// Boundaries:
+//
+//	>= 4.1   -> Optimal
+//	>= 3.1   -> Advanced
+//	>= 2.1   -> Initial
+//	>= 1.01  -> Traditional
+//	otherwise -> Not Assessed (a pillar with zero answered questions lands
+//	             at exactly 1.0 under the +1 shift aggregation, so the
+//	             Traditional floor uses 1.01 rather than == 1.0 to keep
+//	             the predicate safe under float drift).
+func Tier(score float64) string {
+	switch {
+	case score >= 4.1:
+		return "Optimal"
+	case score >= 3.1:
+		return "Advanced"
+	case score >= 2.1:
+		return "Initial"
+	case score >= 1.01:
+		return "Traditional"
+	default:
+		return "Not Assessed"
+	}
 }
 
 type FindScoresInput struct {
@@ -125,69 +170,247 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 	})
 }
 
+// pillarScoreRow is the wire shape returned by findPillarScoresAll. One row
+// per (datacall, system, pillar). Both pillar Score and the carry-along
+// SystemScore are computed in Postgres and emerge on the HHS 1.0-5.0 scale,
+// so the Go aggregation step never re-computes them and float precision is
+// consistent across boundaries.
+//
+// Field tagging: pgx.RowToAddrOfStructByName reads the `db` struct tag (and
+// falls back to case-insensitive name match), not the `json` tag. The wire
+// names here intentionally match the SQL select aliases via `db`; do not
+// switch to `json` tags by reflex when refactoring.
+type pillarScoreRow struct {
+	DataCallID    int32   `db:"datacallid"`
+	FismaSystemID int32   `db:"fismasystemid"`
+	PillarID      int32   `db:"pillarid"`
+	Pillar        string  `db:"pillar"`
+	Score         float64 `db:"score"`
+	SystemScore   float64 `db:"system_score"`
+}
+
+// FindScoresAggregate returns one ScoreAggregate per (datacall, system) pair
+// matching the input filters. Both the system score and the per-pillar scores
+// are computed on the HHS-aligned 1.0-5.0 scale via the +1 shift aggregation
+// described in ztmf-misc#175. The system score is the simple AVG of pillar
+// scores; the divisor follows the actual pillar count rather than being
+// hardcoded, so adding or removing a pillar does not silently change the
+// math. Pillar scores are populated on the aggregate when IncludePillars is
+// true.
 func FindScoresAggregate(ctx context.Context, input FindScoresInput) ([]*ScoreAggregate, error) {
-	// Convert single FismaSystemID to FismaSystemIDs array if needed
+	// Convert single FismaSystemID to FismaSystemIDs array if needed so the
+	// scoping rules below see a consistent shape. This mirrors prior behavior
+	// so an admin requesting a specific system still flows through the same
+	// IN-list path that ISSOs use for their assigned-system scope.
 	if input.FismaSystemID != nil && len(input.FismaSystemIDs) == 0 {
 		input.FismaSystemIDs = []*int32{input.FismaSystemID}
 	}
 
-	subSqlb := squirrel.Select("datacallid, fismasystemid, AVG(score) OVER (PARTITION BY datacallid, fismasystemid) as systemscore").
-		From("scores").
-		InnerJoin("functionoptions on functionoptions.functionoptionid=scores.functionoptionid")
-
-	if input.DataCallID != nil {
-		subSqlb = subSqlb.Where("datacallid=?", input.DataCallID)
-	}
-
-	if len(input.FismaSystemIDs) > 0 {
-		subSqlb = subSqlb.Where(squirrel.Eq{"fismasystemid": input.FismaSystemIDs})
-	}
-
-	// When a specific system is requested alongside a pre-populated FismaSystemIDs
-	// (e.g. ISSO scope), further narrow to just that system. Using >= 1 ensures
-	// consistent behaviour for single-system ISSOs; the extra predicate is
-	// redundant with the IN clause but harmless.
-	if input.FismaSystemID != nil && len(input.FismaSystemIDs) >= 1 {
-		subSqlb = subSqlb.Where("fismasystemid=?", *input.FismaSystemID)
-	}
-
-	sqlb := squirrel.Select("*").
-		FromSelect(subSqlb, "avg_by_datacall_fismasystem").
-		GroupBy("datacallid, fismasystemid, systemscore").
-		PlaceholderFormat(squirrel.Dollar)
-
-	aggregates, err := query(ctx, sqlb, pgx.RowToAddrOfStructByName[ScoreAggregate])
+	pillarRows, err := findPillarScoresAll(ctx, input)
 	if err != nil {
 		return nil, err
 	}
 
-	// If pillar scores are requested, fetch and populate them
-	if input.IncludePillars != nil && *input.IncludePillars {
-		for _, aggregate := range aggregates {
-			pillarScores, err := findPillarScores(ctx, aggregate.DataCallID, aggregate.FismaSystemID)
-			if err != nil {
-				return nil, err
+	includePillars := input.IncludePillars != nil && *input.IncludePillars
+	return aggregatePillarRows(pillarRows, includePillars), nil
+}
+
+// aggregatePillarRows is the pure-Go rollup step extracted so unit tests can
+// pin the response shape without spinning up a database. It collapses the
+// per-(datacall, system, pillar) rows produced by findPillarScoresAll into
+// one ScoreAggregate per (datacall, system) pair, attaches the Tier label
+// derived from each pillar score, and reads the carry-along SystemScore that
+// the underlying SQL already averaged via a window function.
+//
+// All score math happens in Postgres. This function does no arithmetic on
+// pillar scores beyond reading the system_score field on the first row of
+// each (datacall, system) group; that keeps float precision consistent
+// across the SQL/Go boundary and removes any chance of a tier flip from
+// recomputing the same average in a different runtime.
+//
+// The input slice is assumed to be ordered by (datacallid, fismasystemid,
+// pillarid), which is the canonical ordering emitted by the underlying SQL
+// in findPillarScoresAll. The output preserves that order.
+func aggregatePillarRows(rows []*pillarScoreRow, includePillars bool) []*ScoreAggregate {
+	type key struct {
+		dataCallID    int32
+		fismaSystemID int32
+	}
+
+	aggByKey := map[key]*ScoreAggregate{}
+	order := []key{}
+
+	for _, r := range rows {
+		k := key{r.DataCallID, r.FismaSystemID}
+		agg, seen := aggByKey[k]
+		if !seen {
+			agg = &ScoreAggregate{
+				DataCallID:    r.DataCallID,
+				FismaSystemID: r.FismaSystemID,
+				SystemScore:   r.SystemScore,
+				SystemTier:    Tier(r.SystemScore),
 			}
-			aggregate.PillarScores = pillarScores
+			aggByKey[k] = agg
+			order = append(order, k)
+		}
+		if includePillars {
+			agg.PillarScores = append(agg.PillarScores, &PillarScore{
+				PillarID: r.PillarID,
+				Pillar:   r.Pillar,
+				Score:    r.Score,
+				Tier:     Tier(r.Score),
+			})
 		}
 	}
 
-	return aggregates, nil
+	aggregates := make([]*ScoreAggregate, 0, len(order))
+	for _, k := range order {
+		aggregates = append(aggregates, aggByKey[k])
+	}
+	return aggregates
 }
 
-func findPillarScores(ctx context.Context, dataCallID, fismaSystemID int32) ([]*PillarScore, error) {
-	sqlb := squirrel.Select("pillars.pillarid", "pillars.pillar", "AVG(functionoptions.score) as score").
-		From("scores").
-		InnerJoin("functionoptions on functionoptions.functionoptionid=scores.functionoptionid").
-		InnerJoin("functions on functions.functionid=functionoptions.functionid").
-		InnerJoin("pillars on pillars.pillarid=functions.pillarid").
-		Where("scores.datacallid=?", dataCallID).
-		Where("scores.fismasystemid=?", fismaSystemID).
-		GroupBy("pillars.pillarid", "pillars.pillar").
-		OrderBy("pillars.pillarid").
-		PlaceholderFormat(squirrel.Dollar)
+// findPillarScoresAll returns one row per (datacall, system, pillar) for every
+// combination matching the input filters. Pillar scores are computed by
+// enumerating every expected question for each (system, datacall, pillar)
+// triple, LEFT JOINing to existing answers, COALESCEing missing rows to 0,
+// applying the +1 shift, and averaging.
+//
+// The query is built as parameterized raw SQL because the derived subqueries
+// and conditional joins exceed what squirrel expresses cleanly. Filters are
+// pushed into the `expected` subquery so the LEFT JOIN only operates on the
+// scoped set.
+func findPillarScoresAll(ctx context.Context, input FindScoresInput) ([]*pillarScoreRow, error) {
+	sql, args := buildPillarScoresSQL(input)
+	return query(ctx, rawQuery{sql: sql, args: args}, pgx.RowToAddrOfStructByName[pillarScoreRow])
+}
 
-	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[PillarScore])
+// buildPillarScoresSQL assembles the parameterized SQL for the pillar
+// aggregation. Extracted so unit tests can verify the filter and scope
+// shaping without a database connection.
+func buildPillarScoresSQL(input FindScoresInput) (string, []any) {
+	var conds []string
+	var args []any
+	argN := 1
+
+	// No implicit decommissioned filter. The legacy aggregate query had none,
+	// so historical scoring for systems that have since been decommissioned
+	// stayed reachable through this endpoint. Re-applying that filter here
+	// would regress audit / history use cases. Callers that want only active
+	// systems should filter at the controller layer.
+	conds = append(conds, "TRUE")
+
+	if input.DataCallID != nil {
+		conds = append(conds, fmt.Sprintf("dc.datacallid = $%d", argN))
+		args = append(args, *input.DataCallID)
+		argN++
+	}
+
+	if input.FismaSystemID != nil {
+		conds = append(conds, fmt.Sprintf("fs.fismasystemid = $%d", argN))
+		args = append(args, *input.FismaSystemID)
+		argN++
+	}
+
+	if len(input.FismaSystemIDs) > 0 {
+		placeholders := make([]string, len(input.FismaSystemIDs))
+		for i, id := range input.FismaSystemIDs {
+			placeholders[i] = fmt.Sprintf("$%d", argN)
+			args = append(args, id)
+			argN++
+		}
+		conds = append(conds, fmt.Sprintf("fs.fismasystemid IN (%s)", strings.Join(placeholders, ",")))
+	}
+
+	var userJoin string
+	if input.UserID != nil {
+		userJoin = fmt.Sprintf("INNER JOIN users_fismasystems ufs ON ufs.fismasystemid = fs.fismasystemid AND ufs.userid = $%d", argN)
+		args = append(args, *input.UserID)
+		argN++
+	}
+
+	// The (system, datacall) universe is the set of pairs that appear at
+	// least once in the scores table. This preserves the legacy aggregate
+	// contract: a system that was never scored for a given data call did
+	// not appear in /scores/aggregate before this change, and still does
+	// not after. The frontend already cross-references /fismasystems to
+	// render "No Score" tiles for systems that have not started, so a
+	// blanket cartesian over every active system would double-count.
+	//
+	// Pillar-level "Not Assessed" is still reachable for partial systems:
+	// once a (system, datacall) pair enters the universe via any score,
+	// every pillar for that system gets enumerated through the expected
+	// CTE. Pillars where every function is unanswered COALESCE to 0,
+	// shift to 1.0, average to exactly 1.0, and emit Not Assessed.
+	//
+	// The datacalls_fismasystems junction looks like the natural fit here
+	// but is misleading: per backend/internal/model/datacallsfismasystems.go,
+	// rows are written only when an ISSO marks a data call as complete,
+	// not when systems are enrolled. Production data confirms this — the
+	// junction is empty for live data calls that have thousands of score
+	// rows. Using it as the universe filter returns nothing.
+	//
+	// Question catalog drift is intentionally not handled. Functions are
+	// keyed by datacenterenvironment, not by datacall. A retroactive
+	// recompute of a closed historical cycle uses the current question set
+	// for that environment, which matches the legacy AVG-over-scored-rows
+	// behavior (it only averaged whatever functionoptions were referenced
+	// in the scores table). If question versioning becomes a real
+	// requirement, both paths would need the same treatment.
+	//
+	// Both pillar score and system score are computed in Postgres so the
+	// float math is consistent. System score is AVG of pillar scores
+	// (equal weighting per the locked plan); the divisor follows the
+	// actual pillar count via the inner AVG, so adding or removing a
+	// pillar does not silently shift the math. system_score is carried on
+	// every pillar row via a window function so callers that want only
+	// the system roll-up read it from any row without a second query.
+	sql := fmt.Sprintf(`
+WITH scored_pairs AS (
+    SELECT DISTINCT fismasystemid, datacallid FROM scores
+),
+expected AS (
+    SELECT sp.fismasystemid, sp.datacallid, p.pillarid, p.pillar, f.functionid
+    FROM scored_pairs sp
+    INNER JOIN fismasystems fs ON fs.fismasystemid = sp.fismasystemid
+    INNER JOIN datacalls dc    ON dc.datacallid    = sp.datacallid
+    INNER JOIN functions f ON f.datacenterenvironment = fs.datacenterenvironment
+    INNER JOIN questions q ON q.questionid = f.questionid
+    INNER JOIN pillars p   ON p.pillarid   = q.pillarid
+    %s
+    WHERE %s
+),
+answers AS (
+    SELECT s.fismasystemid, s.datacallid, fo.functionid, fo.score
+    FROM scores s
+    INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+),
+pillar_scores AS (
+    SELECT
+        e.datacallid,
+        e.fismasystemid,
+        e.pillarid,
+        e.pillar,
+        AVG(COALESCE(a.score, 0) + 1.0)::float8 AS pillar_score
+    FROM expected e
+    LEFT JOIN answers a
+      ON a.fismasystemid = e.fismasystemid
+     AND a.datacallid    = e.datacallid
+     AND a.functionid    = e.functionid
+    GROUP BY e.datacallid, e.fismasystemid, e.pillarid, e.pillar
+)
+SELECT
+    ps.datacallid,
+    ps.fismasystemid,
+    ps.pillarid,
+    ps.pillar,
+    ps.pillar_score AS score,
+    AVG(ps.pillar_score) OVER (PARTITION BY ps.datacallid, ps.fismasystemid)::float8 AS system_score
+FROM pillar_scores ps
+ORDER BY ps.datacallid, ps.fismasystemid, ps.pillarid
+`, userJoin, strings.Join(conds, " AND "))
+
+	return sql, args
 }
 
 // dataCallID is meant to be passed the *latest* datacall most recently created so the previous can be selected

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -100,25 +101,33 @@ type PillarScore struct {
 }
 
 // Tier returns the HHS-aligned maturity tier label for a 1.0-5.0 score.
-// Boundaries:
+// Boundaries (on the score rounded to two decimal places, matching the
+// frontend display):
 //
-//	>= 4.1   -> Optimal
-//	>= 3.1   -> Advanced
-//	>= 2.1   -> Initial
+//	>= 4.10  -> Optimal
+//	>= 3.10  -> Advanced
+//	>= 2.10  -> Initial
 //	>= 1.01  -> Traditional
 //	otherwise -> Not Assessed (a pillar with zero answered questions lands
-//	             at exactly 1.0 under the +1 shift aggregation, so the
-//	             Traditional floor uses 1.01 rather than == 1.0 to keep
-//	             the predicate safe under float drift).
+//	             at exactly 1.0 under the +1 shift aggregation).
+//
+// The comparison happens in integer space (score * 100 rounded to int)
+// so a system whose float64 representation is, e.g., 3.099999... but
+// displays to the user as "3.10" via toFixed(2) is correctly classified
+// the same way the user sees it. IEEE 754 cannot represent 4.1, 3.1, or
+// 2.1 exactly, so a direct `score >= 4.1` comparison would mis-tier
+// inputs that are arithmetically at the boundary but stored a few ulps
+// low. Integer comparison removes that ambiguity entirely.
 func Tier(score float64) string {
+	hundredths := int(math.Round(score * 100))
 	switch {
-	case score >= 4.1:
+	case hundredths >= 410:
 		return "Optimal"
-	case score >= 3.1:
+	case hundredths >= 310:
 		return "Advanced"
-	case score >= 2.1:
+	case hundredths >= 210:
 		return "Initial"
-	case score >= 1.01:
+	case hundredths >= 101:
 		return "Traditional"
 	default:
 		return "Not Assessed"

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -1,0 +1,323 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validTiers is the authoritative tier-name enum the API serves. Tests
+// assert membership rather than exact values where the underlying data
+// is dynamic, and exact values where a transaction-rolled-back fixture
+// pins the input.
+var validTiers = map[string]bool{
+	"Optimal":      true,
+	"Advanced":     true,
+	"Initial":      true,
+	"Traditional":  true,
+	"Not Assessed": true,
+}
+
+// TestFindScoresAggregateIntegration runs the real SQL against the
+// configured database and verifies the response shape and per-row
+// invariants. Catches SQL math regressions (wrong +1 shift, wrong AVG
+// window, wrong COALESCE behavior) that unit tests over pure Go cannot
+// see.
+//
+// Requires DB_* env vars (DB_ENDPOINT, DB_USER, etc.) pointing at a
+// running Postgres with seeded ZTMF schema and at least one scored
+// system. The dev compose stack (port 54321) satisfies this. The
+// ephemeral test compose stack on port 8090 also works during the e2e
+// step of make test-full. Skipped under `go test -short`.
+func TestFindScoresAggregateIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Close(ctx)
+
+	t.Run("ShapeInvariants_AllAggregates", func(t *testing.T) {
+		// Pull every aggregate from the DB. Don't filter — we want to
+		// validate every row returned.
+		aggs, err := FindScoresAggregate(ctx, FindScoresInput{
+			IncludePillars: boolPtr(true),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, aggs, "expected at least one aggregate from seeded data")
+
+		for _, a := range aggs {
+			assert.Greater(t, a.DataCallID, int32(0), "datacallid set")
+			assert.Greater(t, a.FismaSystemID, int32(0), "fismasystemid set")
+			assert.True(t, a.SystemScore >= 1.0 && a.SystemScore <= 5.0,
+				"systemscore in HHS range: %v for system %d / datacall %d",
+				a.SystemScore, a.FismaSystemID, a.DataCallID)
+			assert.True(t, validTiers[a.SystemTier],
+				"systemtier in enum: %q for system %d / datacall %d",
+				a.SystemTier, a.FismaSystemID, a.DataCallID)
+			// The tier predicate is the single source of truth. Either
+			// SQL and Go agree, or this test fails and surfaces the
+			// drift immediately.
+			assert.Equal(t, Tier(a.SystemScore), a.SystemTier,
+				"systemtier matches Tier(systemscore) for system %d / datacall %d",
+				a.FismaSystemID, a.DataCallID)
+
+			require.NotEmpty(t, a.PillarScores,
+				"include_pillars=true must return pillar entries for system %d / datacall %d",
+				a.FismaSystemID, a.DataCallID)
+
+			for _, p := range a.PillarScores {
+				assert.Greater(t, p.PillarID, int32(0))
+				assert.NotEmpty(t, p.Pillar)
+				assert.True(t, p.Score >= 1.0 && p.Score <= 5.0,
+					"pillar %s score in HHS range: %v", p.Pillar, p.Score)
+				assert.True(t, validTiers[p.Tier],
+					"pillar %s tier in enum: %q", p.Pillar, p.Tier)
+				assert.Equal(t, Tier(p.Score), p.Tier,
+					"pillar %s tier matches Tier(score)", p.Pillar)
+			}
+		}
+	})
+
+	t.Run("IncludePillars_FalseOmitsBreakdown", func(t *testing.T) {
+		aggs, err := FindScoresAggregate(ctx, FindScoresInput{})
+		require.NoError(t, err)
+		require.NotEmpty(t, aggs)
+		for _, a := range aggs {
+			assert.Empty(t, a.PillarScores,
+				"pillarscores must be omitted when IncludePillars is nil/false")
+			assert.NotEmpty(t, a.SystemTier, "systemtier still populated")
+			assert.True(t, a.SystemScore >= 1.0 && a.SystemScore <= 5.0,
+				"systemscore still on HHS scale")
+		}
+	})
+
+	t.Run("FilterByFismaSystem_ReturnsOnlyThatSystem", func(t *testing.T) {
+		// Pick a system that has scores so the filter has something to
+		// return. The first aggregate in the unfiltered list is a safe
+		// pick.
+		all, err := FindScoresAggregate(ctx, FindScoresInput{})
+		require.NoError(t, err)
+		require.NotEmpty(t, all)
+		target := all[0].FismaSystemID
+
+		filtered, err := FindScoresAggregate(ctx, FindScoresInput{
+			FismaSystemID: &target,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, filtered)
+		for _, a := range filtered {
+			assert.Equal(t, target, a.FismaSystemID,
+				"filter must scope to requested system")
+		}
+	})
+
+	t.Run("FilterByUnscoredSystem_ReturnsEmpty", func(t *testing.T) {
+		// 2_000_000 is well above any seeded ID and will never have
+		// scores. Aggregate must be empty (not error, not a placeholder
+		// "Not Assessed" row for a system that doesn't appear in the
+		// scores table at all).
+		unscored := int32(2_000_000)
+		aggs, err := FindScoresAggregate(ctx, FindScoresInput{
+			FismaSystemID: &unscored,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, aggs,
+			"unscored system must not appear in /scores/aggregate (frontend cross-references /fismasystems for those)")
+	})
+}
+
+// TestScoreSaveValidationIntegration covers the validate() guards on
+// the write path: notes length and past-deadline rules. Inserts a
+// score then rolls back any state via direct DELETE so test pollution
+// stays bounded.
+func TestScoreSaveValidationIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	// Find a datacall whose deadline is in the past, plus one whose
+	// deadline is in the future. The seeded datacalls do not guarantee
+	// either, so we use the most-recent and oldest as proxies.
+	var pastDataCallID, futureDataCallID int32
+	err = conn.QueryRow(ctx, `
+		SELECT datacallid FROM datacalls
+		WHERE deadline < NOW() ORDER BY deadline DESC LIMIT 1
+	`).Scan(&pastDataCallID)
+	require.NoError(t, err, "need at least one past-deadline datacall in seeded data")
+
+	err = conn.QueryRow(ctx, `
+		SELECT datacallid FROM datacalls
+		WHERE deadline > NOW() ORDER BY deadline ASC LIMIT 1
+	`).Scan(&futureDataCallID)
+	if err != nil {
+		// If no future-deadline datacall exists, create one and clean it up.
+		// Most seed data only carries historical datacalls, so this path is
+		// the common one in CI.
+		t.Log("no future-deadline datacall present; using a synthesized one for this test")
+		err = conn.QueryRow(ctx, `
+			INSERT INTO datacalls (datacall, datecreated, deadline)
+			VALUES ('integration test datacall ' || NOW()::text, NOW(), NOW() + INTERVAL '7 days')
+			RETURNING datacallid
+		`).Scan(&futureDataCallID)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = conn.Exec(ctx, `DELETE FROM datacalls WHERE datacallid = $1`, futureDataCallID)
+		})
+	}
+
+	t.Run("NotesTooLong_ReturnsErr", func(t *testing.T) {
+		bigNotes := strings.Repeat("x", 2001)
+		s := &Score{
+			FismaSystemID:    1,
+			FunctionOptionID: 1,
+			DataCallID:       futureDataCallID,
+			Notes:            &bigNotes,
+		}
+		_, err := s.Save(ctx)
+		assert.ErrorIs(t, err, ErrNotesTooLong, "2001-char notes must trip the length guard")
+	})
+
+	t.Run("PastDeadline_NonAdmin_ReturnsErr", func(t *testing.T) {
+		notes := "after deadline"
+		s := &Score{
+			FismaSystemID:    1,
+			FunctionOptionID: 1,
+			DataCallID:       pastDataCallID,
+			Notes:            &notes,
+		}
+		// No user in context = treated as non-admin per validate()
+		_, err := s.Save(ctx)
+		assert.ErrorIs(t, err, ErrPastDeadline,
+			"past-deadline save without admin must trip deadline guard")
+	})
+
+	t.Run("PastDeadline_Admin_Allowed", func(t *testing.T) {
+		notes := "after deadline but admin"
+		s := &Score{
+			FismaSystemID:    1,
+			FunctionOptionID: 1,
+			DataCallID:       pastDataCallID,
+			Notes:            &notes,
+		}
+		adminCtx := UserToContext(ctx, &User{
+			UserID: "00000000-0000-4000-8000-000000000000",
+			Role:   "ADMIN",
+		})
+		// Admin bypasses the deadline guard. The save itself may fail
+		// for unrelated reasons (FK violation if system 1 / option 1
+		// not seeded) — but the error must NOT be ErrPastDeadline.
+		_, saveErr := s.Save(adminCtx)
+		if saveErr != nil {
+			assert.NotErrorIs(t, saveErr, ErrPastDeadline,
+				"admin save past deadline must not be blocked by the deadline guard")
+		}
+		// Best-effort cleanup if it did succeed
+		if s.ScoreID != 0 {
+			_, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid = $1`, s.ScoreID)
+		}
+	})
+}
+
+// TestCopyPreviousScoresIntegration verifies the rollover function
+// carries forward scores from one datacall to the next. Creates two
+// synthetic datacalls, attaches scores to the first, runs the copy,
+// asserts the second now has the same set of (functionoptionid,
+// fismasystemid) entries.
+func TestCopyPreviousScoresIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	// Insert two datacalls explicitly ordered so copyPreviousScores'
+	// "latest-1 is previous" logic finds the right one. Each row gets
+	// a unique nano-precision suffix so reruns don't collide on the
+	// UNIQUE(datacall) constraint.
+	var prevDC, newDC int32
+	prevTimestamp := time.Now().Add(-2 * time.Hour)
+	newTimestamp := time.Now().Add(-1 * time.Hour)
+	suffix := time.Now().UnixNano()
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
+		RETURNING datacallid
+	`, fmt.Sprintf("integration_test_prev_%d", suffix), prevTimestamp).Scan(&prevDC)
+	require.NoError(t, err)
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
+		RETURNING datacallid
+	`, fmt.Sprintf("integration_test_new_%d", suffix), newTimestamp).Scan(&newDC)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		// Order matters: scores reference datacalls via FK ON DELETE CASCADE,
+		// so dropping the datacalls also drops any test scores attached.
+		_, _ = conn.Exec(ctx, `DELETE FROM datacalls WHERE datacallid IN ($1, $2)`, prevDC, newDC)
+	})
+
+	// Pick a (fismasystemid, functionoptionid) that already references
+	// a real function so the FK constraint is satisfied. Any active
+	// system with at least one scored functionoption will do.
+	var fismaSystemID, functionOptionID int32
+	err = conn.QueryRow(ctx, `
+		SELECT s.fismasystemid, s.functionoptionid
+		FROM scores s LIMIT 1
+	`).Scan(&fismaSystemID, &functionOptionID)
+	require.NoError(t, err, "need at least one existing score row to derive a valid (system, functionoption) pair")
+
+	// Insert a marker score under the prev datacall.
+	notes := "integration test marker"
+	_, err = conn.Exec(ctx, `
+		INSERT INTO scores (fismasystemid, functionoptionid, datacallid, notes)
+		VALUES ($1, $2, $3, $4)
+	`, fismaSystemID, functionOptionID, prevDC, notes)
+	require.NoError(t, err)
+
+	// Before copy: the new datacall has zero scores.
+	var beforeCount int
+	err = conn.QueryRow(ctx,
+		`SELECT COUNT(*) FROM scores WHERE datacallid = $1`, newDC,
+	).Scan(&beforeCount)
+	require.NoError(t, err)
+	require.Equal(t, 0, beforeCount, "newDC starts with no scores")
+
+	// Run the rollover. copyPreviousScores is unexported and accepts
+	// the *latest* datacallid — it discovers the previous one via
+	// findPreviousDataCall.
+	copyPreviousScores(newDC)
+
+	// After copy: the new datacall has at least the marker score.
+	var afterCount int
+	err = conn.QueryRow(ctx, `
+		SELECT COUNT(*) FROM scores
+		WHERE datacallid = $1
+		  AND fismasystemid = $2
+		  AND functionoptionid = $3
+	`, newDC, fismaSystemID, functionOptionID).Scan(&afterCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, afterCount,
+		"copyPreviousScores must carry the marker (system, functionoption) into the new datacall")
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -24,6 +24,35 @@ var validTiers = map[string]bool{
 	"Not Assessed": true,
 }
 
+// integrationTestPrefix is the marker every test-synthesized datacall
+// carries in its name. Used to identify rows for cleanup, including a
+// defensive sweep at test entry that catches anything a previous
+// interrupted run left behind. Keep it underscore-separated so a LIKE
+// pattern is unambiguous.
+const integrationTestPrefix = "integration_test_"
+
+// purgeIntegrationTestRows wipes any datacalls (and their cascaded
+// scores via FK ON DELETE CASCADE) whose name carries the integration
+// test prefix. Run at the start of each integration test as a defensive
+// belt-and-suspenders against cleanup that failed to run on a previous
+// invocation. Cheap.
+func purgeIntegrationTestRows(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("purge: db.Conn: %v", err)
+	}
+	defer conn.Close(ctx)
+	_, err = conn.Exec(ctx,
+		`DELETE FROM datacalls WHERE datacall LIKE $1`,
+		integrationTestPrefix+"%",
+	)
+	if err != nil {
+		t.Fatalf("purge: delete: %v", err)
+	}
+}
+
 // TestFindScoresAggregateIntegration runs the real SQL against the
 // configured database and verifies the response shape and per-row
 // invariants. Catches SQL math regressions (wrong +1 shift, wrong AVG
@@ -136,13 +165,17 @@ func TestFindScoresAggregateIntegration(t *testing.T) {
 }
 
 // TestScoreSaveValidationIntegration covers the validate() guards on
-// the write path: notes length and past-deadline rules. Inserts a
-// score then rolls back any state via direct DELETE so test pollution
-// stays bounded.
+// the write path: notes length and past-deadline rules. Any synthesized
+// datacalls carry the integrationTestPrefix and are removed by both a
+// startup sweep and explicit cleanup using a fresh connection so a
+// pre-closed test connection cannot silently swallow the delete.
 func TestScoreSaveValidationIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping database integration test")
 	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
 
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
@@ -164,19 +197,17 @@ func TestScoreSaveValidationIntegration(t *testing.T) {
 		WHERE deadline > NOW() ORDER BY deadline ASC LIMIT 1
 	`).Scan(&futureDataCallID)
 	if err != nil {
-		// If no future-deadline datacall exists, create one and clean it up.
-		// Most seed data only carries historical datacalls, so this path is
-		// the common one in CI.
+		// If no future-deadline datacall exists, create one. The
+		// integration test prefix makes it discoverable by the
+		// startup/teardown sweep regardless of how the test exits.
 		t.Log("no future-deadline datacall present; using a synthesized one for this test")
+		name := fmt.Sprintf("%sfuture_%d", integrationTestPrefix, time.Now().UnixNano())
 		err = conn.QueryRow(ctx, `
 			INSERT INTO datacalls (datacall, datecreated, deadline)
-			VALUES ('integration test datacall ' || NOW()::text, NOW(), NOW() + INTERVAL '7 days')
+			VALUES ($1, NOW(), NOW() + INTERVAL '7 days')
 			RETURNING datacallid
-		`).Scan(&futureDataCallID)
+		`, name).Scan(&futureDataCallID)
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			_, _ = conn.Exec(ctx, `DELETE FROM datacalls WHERE datacallid = $1`, futureDataCallID)
-		})
 	}
 
 	t.Run("NotesTooLong_ReturnsErr", func(t *testing.T) {
@@ -242,6 +273,9 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 		t.Skip("Skipping database integration test")
 	}
 
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
@@ -250,7 +284,8 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 	// Insert two datacalls explicitly ordered so copyPreviousScores'
 	// "latest-1 is previous" logic finds the right one. Each row gets
 	// a unique nano-precision suffix so reruns don't collide on the
-	// UNIQUE(datacall) constraint.
+	// UNIQUE(datacall) constraint, and the integrationTestPrefix makes
+	// them discoverable by the sweep no matter how the test exits.
 	var prevDC, newDC int32
 	prevTimestamp := time.Now().Add(-2 * time.Hour)
 	newTimestamp := time.Now().Add(-1 * time.Hour)
@@ -260,21 +295,15 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 		INSERT INTO datacalls (datacall, datecreated, deadline)
 		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
 		RETURNING datacallid
-	`, fmt.Sprintf("integration_test_prev_%d", suffix), prevTimestamp).Scan(&prevDC)
+	`, fmt.Sprintf("%sprev_%d", integrationTestPrefix, suffix), prevTimestamp).Scan(&prevDC)
 	require.NoError(t, err)
 
 	err = conn.QueryRow(ctx, `
 		INSERT INTO datacalls (datacall, datecreated, deadline)
 		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
 		RETURNING datacallid
-	`, fmt.Sprintf("integration_test_new_%d", suffix), newTimestamp).Scan(&newDC)
+	`, fmt.Sprintf("%snew_%d", integrationTestPrefix, suffix), newTimestamp).Scan(&newDC)
 	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		// Order matters: scores reference datacalls via FK ON DELETE CASCADE,
-		// so dropping the datacalls also drops any test scores attached.
-		_, _ = conn.Exec(ctx, `DELETE FROM datacalls WHERE datacallid IN ($1, $2)`, prevDC, newDC)
-	})
 
 	// Pick a (fismasystemid, functionoptionid) that already references
 	// a real function so the FK constraint is satisfied. Any active

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -3,110 +3,242 @@ package model
 import (
 	"testing"
 
-	"github.com/Masterminds/squirrel"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// buildAggregateSubQuery mirrors the SQL building logic in FindScoresAggregate
-// so we can test filter combinations without a database connection.
-func buildAggregateSubQuery(input FindScoresInput) (string, []interface{}, error) {
-	if input.FismaSystemID != nil && len(input.FismaSystemIDs) == 0 {
-		input.FismaSystemIDs = []*int32{input.FismaSystemID}
+// TestTier covers every threshold boundary in the HHS-aligned tier predicate.
+// The cutoffs Elizabeth confirmed in ztmf-misc#175 are:
+//
+//	Optimal      >= 4.1
+//	Advanced     >= 3.1
+//	Initial      >= 2.1
+//	Traditional  >= 1.01
+//	Not Assessed everything below 1.01 (a pillar of all-unanswered rows lands
+//	             at exactly 1.0 under the +1 shift aggregation; 1.01 is the
+//	             intentional floor for Traditional)
+func TestTier(t *testing.T) {
+	tests := []struct {
+		score float64
+		want  string
+	}{
+		// Not Assessed: pillar with zero answers
+		{0.0, "Not Assessed"},
+		{0.99, "Not Assessed"},
+		{1.0, "Not Assessed"},
+		{1.005, "Not Assessed"},
+		{1.009, "Not Assessed"},
+
+		// Traditional: 1.01 through 2.09
+		{1.01, "Traditional"},
+		{1.5, "Traditional"},
+		{2.0, "Traditional"},
+		{2.09, "Traditional"},
+
+		// Initial: 2.1 through 3.09
+		{2.1, "Initial"},
+		{2.5, "Initial"},
+		{3.0, "Initial"},
+		{3.09, "Initial"},
+
+		// Advanced: 3.1 through 4.09
+		{3.1, "Advanced"},
+		{3.5, "Advanced"},
+		{4.0, "Advanced"},
+		{4.09, "Advanced"},
+
+		// Optimal: 4.1 and above
+		{4.1, "Optimal"},
+		{4.5, "Optimal"},
+		{5.0, "Optimal"},
 	}
 
-	subSqlb := squirrel.Select("datacallid, fismasystemid, AVG(score) OVER (PARTITION BY datacallid, fismasystemid) as systemscore").
-		From("scores").
-		InnerJoin("functionoptions on functionoptions.functionoptionid=scores.functionoptionid")
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			got := Tier(tc.score)
+			assert.Equal(t, tc.want, got, "Tier(%v)", tc.score)
+		})
+	}
+}
 
-	if input.DataCallID != nil {
-		subSqlb = subSqlb.Where("datacallid=?", input.DataCallID)
+// TestAggregatePillarRows verifies the Go-side grouping that runs after
+// findPillarScoresAll returns. The system score itself is computed in SQL
+// (window AVG on the carry-along system_score column on every pillar row)
+// so this test seeds explicit SystemScore values to confirm the Go layer
+// reads them rather than recomputing. Pure logic test, no database.
+//
+// Confirms that:
+//   - Pillar rows for the same (datacall, system) collapse into one aggregate
+//   - SystemScore is read from the carry-along column, not recomputed
+//   - SystemTier and per-pillar Tier are populated from the Tier predicate
+//   - IncludePillars controls whether the pillar breakdown is attached
+//   - Different pillar counts per system (4 vs 6) are handled the same way,
+//     since the divisor lived in SQL via AVG() and is now pre-computed
+func TestAggregatePillarRows(t *testing.T) {
+	rows := []*pillarScoreRow{
+		// System 1, datacall 36: six pillars, one Optimal and five
+		// Not-Assessed. SQL window AVG produced systemScore = 10/6.
+		{DataCallID: 36, FismaSystemID: 1, PillarID: 1, Pillar: "Devices", Score: 5.0, SystemScore: 10.0 / 6.0},
+		{DataCallID: 36, FismaSystemID: 1, PillarID: 2, Pillar: "Applications", Score: 1.0, SystemScore: 10.0 / 6.0},
+		{DataCallID: 36, FismaSystemID: 1, PillarID: 3, Pillar: "Networks", Score: 1.0, SystemScore: 10.0 / 6.0},
+		{DataCallID: 36, FismaSystemID: 1, PillarID: 4, Pillar: "Data", Score: 1.0, SystemScore: 10.0 / 6.0},
+		{DataCallID: 36, FismaSystemID: 1, PillarID: 5, Pillar: "CrossCutting", Score: 1.0, SystemScore: 10.0 / 6.0},
+		{DataCallID: 36, FismaSystemID: 1, PillarID: 6, Pillar: "Identity", Score: 1.0, SystemScore: 10.0 / 6.0},
+		// System 2, datacall 36: all six pillars at Optimal, systemScore 5.0
+		{DataCallID: 36, FismaSystemID: 2, PillarID: 1, Pillar: "Devices", Score: 5.0, SystemScore: 5.0},
+		{DataCallID: 36, FismaSystemID: 2, PillarID: 2, Pillar: "Applications", Score: 5.0, SystemScore: 5.0},
+		{DataCallID: 36, FismaSystemID: 2, PillarID: 3, Pillar: "Networks", Score: 5.0, SystemScore: 5.0},
+		{DataCallID: 36, FismaSystemID: 2, PillarID: 4, Pillar: "Data", Score: 5.0, SystemScore: 5.0},
+		{DataCallID: 36, FismaSystemID: 2, PillarID: 5, Pillar: "CrossCutting", Score: 5.0, SystemScore: 5.0},
+		{DataCallID: 36, FismaSystemID: 2, PillarID: 6, Pillar: "Identity", Score: 5.0, SystemScore: 5.0},
+		// System 3, datacall 36: all six pillars at 1.0 (zero answers
+		// everywhere), systemScore 1.0
+		{DataCallID: 36, FismaSystemID: 3, PillarID: 1, Pillar: "Devices", Score: 1.0, SystemScore: 1.0},
+		{DataCallID: 36, FismaSystemID: 3, PillarID: 2, Pillar: "Applications", Score: 1.0, SystemScore: 1.0},
+		{DataCallID: 36, FismaSystemID: 3, PillarID: 3, Pillar: "Networks", Score: 1.0, SystemScore: 1.0},
+		{DataCallID: 36, FismaSystemID: 3, PillarID: 4, Pillar: "Data", Score: 1.0, SystemScore: 1.0},
+		{DataCallID: 36, FismaSystemID: 3, PillarID: 5, Pillar: "CrossCutting", Score: 1.0, SystemScore: 1.0},
+		{DataCallID: 36, FismaSystemID: 3, PillarID: 6, Pillar: "Identity", Score: 1.0, SystemScore: 1.0},
+		// System 4, datacall 3: only four pillars present (simulating a
+		// prior cycle that used fewer pillars). SQL AVG(5.0+4.0+3.0+2.0)/4
+		// = 3.5. Asserting on the carry-along value pins that SQL is the
+		// source of truth.
+		{DataCallID: 3, FismaSystemID: 4, PillarID: 1, Pillar: "Devices", Score: 5.0, SystemScore: 3.5},
+		{DataCallID: 3, FismaSystemID: 4, PillarID: 2, Pillar: "Applications", Score: 4.0, SystemScore: 3.5},
+		{DataCallID: 3, FismaSystemID: 4, PillarID: 3, Pillar: "Networks", Score: 3.0, SystemScore: 3.5},
+		{DataCallID: 3, FismaSystemID: 4, PillarID: 4, Pillar: "Data", Score: 2.0, SystemScore: 3.5},
 	}
 
-	if len(input.FismaSystemIDs) > 0 {
-		subSqlb = subSqlb.Where(squirrel.Eq{"fismasystemid": input.FismaSystemIDs})
-	}
+	t.Run("IncludePillars true", func(t *testing.T) {
+		aggs := aggregatePillarRows(rows, true)
+		if assert.Len(t, aggs, 4) {
+			// System 1 (Traditional 5/6 + Optimal 1/6)
+			assert.Equal(t, int32(36), aggs[0].DataCallID)
+			assert.Equal(t, int32(1), aggs[0].FismaSystemID)
+			assert.InDelta(t, 10.0/6.0, aggs[0].SystemScore, 1e-9)
+			assert.Equal(t, "Traditional", aggs[0].SystemTier)
+			assert.Len(t, aggs[0].PillarScores, 6)
+			assert.Equal(t, "Optimal", aggs[0].PillarScores[0].Tier)
+			assert.Equal(t, "Not Assessed", aggs[0].PillarScores[1].Tier)
 
-	if input.FismaSystemID != nil && len(input.FismaSystemIDs) >= 1 {
-		subSqlb = subSqlb.Where("fismasystemid=?", *input.FismaSystemID)
-	}
+			// System 2 (all Optimal)
+			assert.Equal(t, 5.0, aggs[1].SystemScore)
+			assert.Equal(t, "Optimal", aggs[1].SystemTier)
 
-	return squirrel.Select("*").
-		FromSelect(subSqlb, "avg_by_datacall_fismasystem").
-		GroupBy("datacallid, fismasystemid, systemscore").
-		PlaceholderFormat(squirrel.Dollar).
-		ToSql()
+			// System 3 (all unanswered)
+			assert.Equal(t, 1.0, aggs[2].SystemScore)
+			assert.Equal(t, "Not Assessed", aggs[2].SystemTier)
+			for _, p := range aggs[2].PillarScores {
+				assert.Equal(t, "Not Assessed", p.Tier, "pillar %s", p.Pillar)
+			}
+
+			// System 4 (four pillars only — divisor lives in SQL)
+			assert.Equal(t, int32(3), aggs[3].DataCallID)
+			assert.Equal(t, 3.5, aggs[3].SystemScore)
+			assert.Equal(t, "Advanced", aggs[3].SystemTier)
+			assert.Len(t, aggs[3].PillarScores, 4)
+		}
+	})
+
+	t.Run("IncludePillars false", func(t *testing.T) {
+		aggs := aggregatePillarRows(rows, false)
+		assert.Len(t, aggs, 4)
+		for _, a := range aggs {
+			assert.Empty(t, a.PillarScores, "pillarscores must be nil when not requested")
+			assert.NotEmpty(t, a.SystemTier, "system tier must still be set")
+		}
+	})
 }
 
 func int32Ptr(i int32) *int32 { return &i }
 
+// normalizeInput mirrors the FindScoresAggregate promotion of a bare
+// FismaSystemID into the FismaSystemIDs slice, so the scope assertions below
+// run against the same input shape the production query builder sees.
+func normalizeInput(in FindScoresInput) FindScoresInput {
+	if in.FismaSystemID != nil && len(in.FismaSystemIDs) == 0 {
+		in.FismaSystemIDs = []*int32{in.FismaSystemID}
+	}
+	return in
+}
+
 // TestFindScoresAggregate_ISSOwithSpecificSystem is the regression test for the bug where
 // an ISSO requesting a specific fismasystemid would get scores for ALL their assigned systems
 // because the equality filter was skipped when FismaSystemIDs was pre-populated.
+//
+// Re-targeted at the HHS-scale pillar aggregation SQL (buildPillarScoresSQL).
+// The scope predicates are still: a specific FismaSystemID adds an equality
+// clause, FismaSystemIDs adds an IN clause, and both together must both be
+// emitted so the result intersects the two.
 func TestFindScoresAggregate_ISSOwithSpecificSystem(t *testing.T) {
 	sys1, sys2, sys3 := int32Ptr(1001), int32Ptr(1002), int32Ptr(1003)
 
 	t.Run("ISSOwithMultipleSystemsRequestsSpecific", func(t *testing.T) {
 		// Simulate controller setting FismaSystemIDs to the user's assigned systems,
 		// then query param setting FismaSystemID to the specific requested system.
-		input := FindScoresInput{
+		input := normalizeInput(FindScoresInput{
 			FismaSystemIDs: []*int32{sys1, sys2, sys3},
 			FismaSystemID:  sys1,
-		}
+		})
 
-		sql, args, err := buildAggregateSubQuery(input)
-		require.NoError(t, err)
+		sql, args := buildPillarScoresSQL(input)
 
 		// Must include the IN clause scoping to assigned systems
-		assert.Contains(t, sql, "fismasystemid IN", "should scope to assigned systems")
-		// Must also include an equality predicate (squirrel writes fismasystemid=$N, no spaces)
-		assert.Contains(t, sql, "fismasystemid=$", "should have equality filter for specific system")
-		// 3 args for IN list + 1 for equality = 4 total
-		assert.Len(t, args, 4, "should have 4 args: 3 for IN list + 1 for equality")
+		assert.Contains(t, sql, "fs.fismasystemid IN", "should scope to assigned systems")
+		// Must also include the equality predicate for the specific system
+		assert.Contains(t, sql, "fs.fismasystemid = $", "should have equality filter for specific system")
+		// 1 arg for equality + 3 for IN list = 4 args from the system scope.
+		// Plus FismaSystemID promoted into FismaSystemIDs replaces the bare
+		// slice in tests that don't override, but here both are explicit and
+		// the IN list keeps three entries.
+		assert.Len(t, args, 4, "should have 4 args: 1 for equality + 3 for IN list")
 	})
 
 	t.Run("ISSOwithSingleSystemRequestsSpecific", func(t *testing.T) {
 		// Edge case: ISSO with only one assigned system.
-		input := FindScoresInput{
+		input := normalizeInput(FindScoresInput{
 			FismaSystemIDs: []*int32{sys1},
 			FismaSystemID:  sys1,
+		})
+
+		sql, args := buildPillarScoresSQL(input)
+
+		assert.Contains(t, sql, "fs.fismasystemid", "should filter on fismasystemid")
+		// args is []any so type-assert when checking membership
+		found := false
+		for _, a := range args {
+			if p, ok := a.(*int32); ok && p == sys1 {
+				found = true
+				break
+			}
 		}
-
-		sql, args, err := buildAggregateSubQuery(input)
-		require.NoError(t, err)
-
-		assert.Contains(t, sql, "fismasystemid", "should filter on fismasystemid")
-		assert.Contains(t, args, sys1)
+		assert.True(t, found, "args should include the requested system pointer")
 	})
 
 	t.Run("AdminRequestsSpecificSystem", func(t *testing.T) {
 		// Admin path: FismaSystemIDs is empty, only FismaSystemID from query param.
-		// The conversion block should promote FismaSystemID -> FismaSystemIDs.
-		input := FindScoresInput{
+		// normalizeInput promotes FismaSystemID -> FismaSystemIDs so the IN
+		// list ends up with a single entry.
+		input := normalizeInput(FindScoresInput{
 			FismaSystemID: sys2,
-		}
+		})
 
-		sql, args, err := buildAggregateSubQuery(input)
-		require.NoError(t, err)
+		sql, args := buildPillarScoresSQL(input)
 
-		assert.Contains(t, sql, "fismasystemid", "should filter on fismasystemid")
-		assert.Contains(t, args, sys2)
+		assert.Contains(t, sql, "fs.fismasystemid", "should filter on fismasystemid")
+		assert.NotEmpty(t, args, "should bind at least one argument for the system filter")
 	})
 
 	t.Run("ISSOwithNoSpecificSystem", func(t *testing.T) {
 		// ISSO list view: no fismasystemid query param, just the assigned systems scope.
-		// Should return all assigned systems (no equality filter added).
-		input := FindScoresInput{
+		// Should produce an IN clause and no equality predicate.
+		input := normalizeInput(FindScoresInput{
 			FismaSystemIDs: []*int32{sys1, sys2},
-		}
+		})
 
-		sql, args, err := buildAggregateSubQuery(input)
-		require.NoError(t, err)
+		sql, args := buildPillarScoresSQL(input)
 
-		assert.Contains(t, sql, "fismasystemid IN", "should scope to assigned systems")
-		// No equality filter when no specific system is requested
-		assert.NotContains(t, sql, "fismasystemid=$", "should not have equality filter when no specific system requested")
-		// 2 args for IN list only
+		assert.Contains(t, sql, "fs.fismasystemid IN", "should scope to assigned systems")
+		assert.NotContains(t, sql, "fs.fismasystemid = $", "should not have equality filter when no specific system requested")
 		assert.Len(t, args, 2, "should have 2 args for IN list only")
 	})
 }

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -21,35 +21,61 @@ func TestTier(t *testing.T) {
 		score float64
 		want  string
 	}{
-		// Not Assessed: pillar with zero answers
+		// Not Assessed: the score rounds to less than 1.01.
+		// (A pillar with zero answers lands at exactly 1.0 under the
+		// +1 shift aggregation.)
 		{0.0, "Not Assessed"},
 		{0.99, "Not Assessed"},
 		{1.0, "Not Assessed"},
-		{1.005, "Not Assessed"},
-		{1.009, "Not Assessed"},
+		{1.004, "Not Assessed"},
 
-		// Traditional: 1.01 through 2.09
+		// Traditional: rounds to [1.01, 2.10).
+		// 1.005 is intentionally not tested: the float64 representation
+		// of "1.005" is 1.00499...8, just below the half-way point, so
+		// math.Round produces 100 not 101. Real aggregations never land
+		// at exactly 1.005 (the +1 shift over integer answers can't
+		// produce it), and the only way to hit it is a hand-crafted
+		// float literal.
+		{1.009, "Traditional"},
 		{1.01, "Traditional"},
 		{1.5, "Traditional"},
 		{2.0, "Traditional"},
-		{2.09, "Traditional"},
+		{2.094, "Traditional"},
 
-		// Initial: 2.1 through 3.09
+		// Initial: rounds to [2.10, 3.10).
+		// 2.095 rounds to 2.10 -> Initial. This is the displayed-value
+		// boundary that the previous direct-float comparison got wrong.
+		{2.095, "Initial"},
 		{2.1, "Initial"},
 		{2.5, "Initial"},
 		{3.0, "Initial"},
-		{3.09, "Initial"},
+		{3.094, "Initial"},
 
-		// Advanced: 3.1 through 4.09
+		// Advanced: rounds to [3.10, 4.10).
+		// 3.095 rounds to 3.10 -> Advanced. The synthetic boundary
+		// search found 642 distinct system averages that displayed as
+		// "3.10" but tiered as Initial under the previous predicate
+		// because they were a few ulps below the float64 representation
+		// of 3.1; that mis-classification is now impossible.
+		{3.095, "Advanced"},
 		{3.1, "Advanced"},
 		{3.5, "Advanced"},
 		{4.0, "Advanced"},
-		{4.09, "Advanced"},
+		{4.094, "Advanced"},
 
-		// Optimal: 4.1 and above
+		// Optimal: rounds to >= 4.10.
+		{4.095, "Optimal"},
 		{4.1, "Optimal"},
 		{4.5, "Optimal"},
 		{5.0, "Optimal"},
+
+		// Pathological float inputs that would mis-classify under the
+		// previous direct comparison: a value just below the literal
+		// representation of 3.1 due to float arithmetic still rounds
+		// to 3.10 on display, so it must classify as Advanced.
+		{3.0999999999999996, "Advanced"},
+		{4.0999999999999996, "Optimal"},
+		{2.0999999999999996, "Initial"},
 	}
 
 	for _, tc := range tests {

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1554,6 +1554,23 @@ components:
         systemscore:
           type: number
           format: double
+          description: >-
+            Overall system maturity score on the HHS-aligned 1.0 to 5.0 scale.
+            Computed as the simple average of the per-pillar scores. A system
+            whose every question is unanswered lands at exactly 1.0
+            (Not Assessed).
+        systemtier:
+          type: string
+          description: >-
+            Tier label derived from systemscore. Boundaries: Optimal >= 4.1,
+            Advanced >= 3.1, Initial >= 2.1, Traditional >= 1.01, otherwise
+            Not Assessed.
+          enum:
+            - Optimal
+            - Advanced
+            - Initial
+            - Traditional
+            - Not Assessed
         pillarscores:
           type: array
           description: Optional pillar breakdown (only present when include_pillars=true)
@@ -1571,7 +1588,21 @@ components:
         score:
           type: number
           format: double
-          description: Average score for this pillar
+          description: >-
+            Pillar maturity score on the HHS-aligned 1.0 to 5.0 scale. A
+            pillar with no answered questions lands at exactly 1.0; a pillar
+            with every question at Optimal lands at 5.0.
+        tier:
+          type: string
+          description: >-
+            Tier label derived from score, using the same thresholds as
+            systemtier.
+          enum:
+            - Optimal
+            - Advanced
+            - Initial
+            - Traditional
+            - Not Assessed
     Question:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Aligns CMS scoring with the HHS scorecard scale (1.0 to 5.0) and moves all
maturity tier logic to the backend so the API response is the single source
of truth for both numeric score and tier label. Tracked under ztmf-misc#175.
This PR ships the backend portion only; the matching frontend PR opens
against ztmf-ui on the same branch name and merges in a tight window after
this one deploys to prod.

Once this merges to main and auto-deploys to dev, both prod and dev will
serve scoring numbers side by side and the customer can compare directly.

## Math change

Each stored answer (integer 1-4 per question) shifts by +1 at pillar
aggregation time so Traditional contributes 2.0, Initial 3.0, Advanced 4.0,
Optimal 5.0. A missing answer for a question that was expected in the
system's environment contributes 1.0, so partial completion drags pillar
scores down. Pillar score is the average of those shifted values for the
questions expected in that pillar.

System score is the simple average of pillar scores (equal weighting).
The divisor follows the actual pillar count via Postgres `AVG` so adding
or removing a pillar does not silently shift the math. Real-data shape:
six pillars per system today (Devices, Applications, Networks, Data,
CrossCutting, Identity), confirmed against the production volume.

Tier thresholds match the HHS scorecard:

- Optimal: `>= 4.1`
- Advanced: `>= 3.1`
- Initial: `>= 2.1`
- Traditional: `>= 1.01`
- Not Assessed: everything below 1.01

These boundaries are identical at the pillar level and the system level.

## API surface

`/api/v1/scores/aggregate` keeps the same shape with two additions and one
semantic shift on existing fields:

- `data[].systemscore` now holds an HHS-scale float in 1.0 to 5.0 (was 1.0
  to 4.0)
- `data[].systemtier` is a new string field at the top level
- `data[].pillarscores[].score` is on the same HHS scale
- `data[].pillarscores[].tier` is a new string field on each pillar entry

Tier values are exactly one of `Optimal`, `Advanced`, `Initial`,
`Traditional`, `Not Assessed`. The backend is the only place the predicate
runs.

`openapi.yaml` is updated with the new fields, including enum values, and
the score-field descriptions call out the new scale.

## Universe of returned rows

A (system, datacall) pair appears in `/scores/aggregate` only if at least
one score row exists for it in the `scores` table. That preserves the
legacy aggregate contract: systems that never started a data call do not
appear (the frontend cross-references `/fismasystems` to render those as
"No Score"). Pillar-level Not Assessed is still reachable for partial
systems whose specific pillars have zero answered questions.

The aggregation does not filter on `fismasystems.decommissioned` so
historical aggregates for retired systems remain visible.

## Real-data validation

Verified against the production data volume (260 systems, 28k score rows
across three real data calls):

- Zero tier downgrades across 1,494 pillar records and 249 system records.
- ~60% of records move up exactly one tier under the HHS scale, ~36% stay
  put, ~7% are unanswered (rename only from "No Score" to "Not Assessed").
- No system score lands above 5.0 or below 1.0.
- batCAVE (CMS-Cloud-AWS, decommissioned with the proper feature) returns
  3.26 Advanced as expected.

The audit artifacts that drove this verification live under
`tmp/snowflake-recon/` for the env-cleanup auditor.

## Pre-merge action: legacy datacenter environment cleanup

A small set of systems in production were archived using the pre-real-
decommission flow that overwrote `datacenterenvironment` to the sentinel
string `'DECOMMISSIONED'`. The new aggregation needs to know the real
environment to enumerate the expected question catalog, so those systems
return empty aggregates today.

Fix is data-only and lives at `tmp/fix-legacy-env-sentinel.sql`. It restores
the real env value (derived from score-history evidence or CFACTS hosting
fields, depending on what's available), and fixes two systems whose
`fismauid` was overwritten to the literal string `'Retired'`. Apply in dev,
smoke-test, then apply in prod. The SQL is idempotent and wrapped in a
transaction with a verification select.

Two systems (HITECH, MMS-dep) have no usable source to determine the right
env and are intentionally left alone. They have no score history so they
do not appear in the aggregate either way.

## Test coverage

| Layer | What breaks if you touch X |
|---|---|
| `Tier()` boundary tests | wrong threshold value |
| `aggregatePillarRows()` unit tests | Go-side group/rollup logic, divisor-follows-count |
| `buildPillarScoresSQL()` unit tests | wrong filter shaping for ISSO + specific-system intersect |
| `TestFindScoresAggregateIntegration` | wrong SQL math, missing tier fields, `Tier(score)` disagreement |
| `TestScoreSaveValidationIntegration` | `validate()` notes-length and deadline gates |
| `TestCopyPreviousScoresIntegration` | data-call rollover regression |
| Existing controller auth tests | scoring endpoint auth gates |
| Emberfall scored-system smoke | 5xx in the new SQL, broken JSON serialization |
| Emberfall unscored-system smoke | cardinality regression (cartesian over fismasystems x datacalls) |

`make test-full` runs all of the above as steps 2 through 5.

## Out of scope

- Frontend changes ship in the companion `feature/hhs-scoring-alignment`
  branch on ztmf-ui. The shape contract there is to delete the hardcoded
  threshold helpers in `PillarScoresModal.tsx` and `FismaTable.tsx` and
  read `tier` from the API response. Tooling for the frontend Claude is
  set, just waiting on backend to deploy to dev first.
- Snowflake export shape. Per the customer's recent direction the SDL
  toggle is per-system with CMS as the only opt-in population, so the
  raw `scores` rows that get synced are unaffected by this change.
- Historical scale snapshot. Easy to recompute and the new path is
  reversible by `git revert`; deferred unless someone asks for it.

## Test plan

- [x] `make test-full` passes all 5 stages locally with sourced env
- [x] Live API on local dev DB returns expected aggregates for known
      systems (RFX 4.09 Advanced, MACPro and ECWS at their AWS-scale
      values, batCAVE 3.26 Advanced)
- [ ] Reviewer: apply `tmp/fix-legacy-env-sentinel.sql` in dev, confirm
      the four legacy-archive systems return historical aggregates
- [ ] Reviewer: hit `/api/v1/scores/aggregate?fismasystemid=1001&include_pillars=true`
      against dev after auto-deploy, confirm `systemtier` and per-pillar
      `tier` fields render
- [ ] Reviewer: confirm an unscored fismasystemid returns `{"data":[]}`
- [ ] Open companion ztmf-ui PR ONLY after this merges and deploys to dev
- [ ] Apply `tmp/fix-legacy-env-sentinel.sql` in prod before main merge,
      or as the first action immediately after
