### PR TITLE
Embed last-edited audit fields on Score responses (refs ztmf-ui#310)

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -90,6 +90,13 @@ INSERT INTO public.pillars VALUES (6, 'Identity', 0) ON CONFLICT DO NOTHING;
 -- Test DataCalls (Imperial Audits)
 INSERT INTO public.datacalls VALUES (1, 'FY2024 Imperial Security Review', '2024-01-01T00:00:00Z', '2024-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
 INSERT INTO public.datacalls VALUES (2, 'FY2025 Death Star Assessment', '2025-01-01T00:00:00Z', '2025-03-31T23:59:59Z') ON CONFLICT DO NOTHING;
+-- Future-deadline cycle used by audit-field smoke tests (ISSO writes need
+-- a non-expired datacall so validate() does not trip the deadline guard).
+-- NOTE: backend/emberfall_tests.yml references datacallid=3 literally in
+-- the audit-fields block; if you reorder or renumber this row, update the
+-- four "datacallid: 3" references and the "?datacallid=3" query string
+-- in that file in lockstep.
+INSERT INTO public.datacalls VALUES (3, 'Audit Fields Smoke Cycle', '2026-01-01T00:00:00Z', '2099-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
 
 -- Test FISMA Systems (Imperial Systems)
 -- Use explicit column names to work with initial schema

--- a/backend/cmd/api/internal/migrations/0037eventsauditindex.go
+++ b/backend/cmd/api/internal/migrations/0037eventsauditindex.go
@@ -1,0 +1,45 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add audit-read indexes on events",
+		`
+-- Per-resource audit fields (ztmf-ui#310) read events via a LATERAL
+-- subquery filtered on resource + payload->>'scoreid'. The events
+-- table previously had zero indexes; the lateral degenerates to a
+-- sequential scan per score row at any non-trivial event count.
+--
+-- Two indexes:
+--
+-- 1. events_score_audit_idx: partial expression index sized to the
+--    per-question-on-dashboard hot path. Scoped to resource='public.scores'
+--    so it stays small as other resources adopt the Auditable pattern,
+--    and ordered by createdat DESC so the LATERAL's "most recent
+--    write" lookup is an index-only descent.
+--
+--    The 'public.scores' literal mirrors the value events.resource
+--    carries today; bare-name normalization is a separate follow-up.
+--    If that landfills first, this index will need a covering update.
+--
+-- 2. events_resource_createdat_idx: generic resource + time index
+--    that supports future Auditable resources (FismaSystem, DataCall,
+--    User, MassEmail) without adding a partial index per resource.
+--    Useful for admin /events filters too.
+--
+-- CONCURRENTLY would avoid table locks but tern wraps each migration
+-- in a transaction, which forbids CONCURRENTLY. Acceptable for this
+-- change: events is append-only and the build window on the current
+-- prod-shaped dev DB (~24k rows) is under a second.
+
+CREATE INDEX IF NOT EXISTS events_score_audit_idx
+    ON public.events ((((payload->>'scoreid')::int)), createdat DESC)
+    WHERE resource = 'public.scores';
+
+CREATE INDEX IF NOT EXISTS events_resource_createdat_idx
+    ON public.events (resource, createdat DESC);
+        `,
+		`
+DROP INDEX IF EXISTS public.events_resource_createdat_idx;
+DROP INDEX IF EXISTS public.events_score_audit_idx;
+        `)
+}

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -772,6 +772,165 @@ tests:
       body:
         text: "{\"data\":[]}"
 
+  # Per-row audit fields on Score response (ztmf-ui#310).
+  #
+  # Every Save of a score records an event via recordEvent; FindScores joins
+  # the latest event laterally and resolves the editor identity from users.
+  # Save also stamps the just-performed edit onto its return value so the
+  # POST/PUT response body is self-consistent with subsequent GETs. The
+  # frontend dashboard footer ("Last edited <when> by <who>") reads these
+  # fields directly off the score row.
+  #
+  # body.json on emberfall is a subset match: listed keys must be present
+  # with the listed values; unlisted keys (scoreid, last_edited_at,
+  # datecalculated) are ignored. Same pattern as createUser above.
+  #
+  # commonHeaders maps to test.user@nowhere.xyz (the ADMIN fixture); the
+  # ISSO scope block below uses Isso.User@nowhere.xyz via issoHeaders.
+  # Both saves target datacallid=3 ("Audit Fields Smoke Cycle"), seeded in
+  # _test_data_empire.sql with deadline 2099-12-31 so validate() does not
+  # trip the past-deadline guard on the ISSO path. (Admin bypasses the
+  # guard, but routing both paths through the same fixture keeps the
+  # regression honest if the admin bypass is ever tightened.)
+  #
+  # The literal "datacallid: 3" appears in this block four times plus
+  # once in a query string. If you renumber the seed row, update all
+  # five references in lockstep -- see the NOTE at the seed INSERT in
+  # backend/_test_data_empire.sql.
+  - id: createScoreForAudit
+    url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1001
+        functionoptionid: 1
+        datacallid: 3
+        notes: "Audit field smoke - created by Emberfall"
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            fismasystemid: 1001
+            functionoptionid: 1
+            datacallid: 3
+            notes: "Audit field smoke - created by Emberfall"
+            last_edited_by:
+              email: "Test.User@nowhere.xyz"
+              role: "ADMIN"
+
+  # GET the score list back through the same lateral-join path. Array
+  # response so no body.json assertion (aquia-inc/emberfall#36); status +
+  # content-type are the regression target here. The POST above carries
+  # the per-field audit assertion against the single-object response.
+  - url: "http://localhost:8080/api/v1/scores?fismasystemid=1001&datacallid=3"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # PUT returns 204 (No Content) per controller.respond; assert the write
+  # path completes cleanly. Audit-on-write is covered by the POST assertion
+  # above.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForAudit.Response.data.scoreid}}"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1001
+        functionoptionid: 1
+        datacallid: 3
+        notes: "Audit field smoke - updated by Emberfall"
+    expect:
+      status: 204
+
+  # ISSO authz on audit-bearing writes (ztmf-ui#310 / ZT contract).
+  #
+  # The whole point of putting audit fields on the score row (vs gating
+  # them behind admin-only /events) is "if you can read the row, you see
+  # who touched it last." These three cases pin that contract from both
+  # sides:
+  #
+  #   1. ISSO write to an assigned system succeeds AND the response
+  #      carries last_edited_by with the ISSO's own email + role. No
+  #      escalation, no missing audit.
+  #   2. ISSO write to an unassigned system is rejected at the controller
+  #      authz gate (403) -- the audit fields don't even come into play.
+  #   3. ISSO list scoping still resolves audit fields for rows the ISSO
+  #      can see. Status assertion only because /scores returns an array
+  #      and body.json on arrays is broken (aquia-inc/emberfall#36); the
+  #      ISSO scope + audit join is covered by the integration test
+  #      TestFindScoresISSOScopeRetainsAuditFieldsIntegration in
+  #      backend/internal/model/scores_integration_test.go.
+  #
+  # Emberfall ISSO fixture (isso.user@nowhere.xyz, uuid 6666...) is
+  # assigned to fismasystemid=1003 in _test_data_empire.sql.
+  - id: issoCreateScoreOwnSystem
+    url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1003
+        functionoptionid: 1
+        datacallid: 3
+        notes: "ISSO audit smoke - own system"
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            fismasystemid: 1003
+            functionoptionid: 1
+            notes: "ISSO audit smoke - own system"
+            last_edited_by:
+              email: "Isso.User@nowhere.xyz"
+              role: "ISSO"
+
+  # ISSO write to a system they are NOT assigned to: controller rejects
+  # at the authz gate before any audit logic runs. Regression target:
+  # a refactor that pushes audit population earlier in the handler and
+  # accidentally leaks editor info into the 403 response body.
+  - url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1001
+        functionoptionid: 1
+        datacallid: 3
+        notes: "ISSO write to unassigned system - should be blocked"
+    expect:
+      status: 403
+
+  # ISSO GET /scores reaches the scoped list path. Audit fields on each
+  # returned row are validated by the integration test referenced above;
+  # this case pins the HTTP-layer status + content-type contract.
+  - url: http://localhost:8080/api/v1/scores
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
   # Questions Endpoints
   - id: createQuestion
     url: http://localhost:8080/api/v1/questions

--- a/backend/internal/model/audit.go
+++ b/backend/internal/model/audit.go
@@ -1,0 +1,23 @@
+package model
+
+import "time"
+
+// AuditRef identifies the user who performed an audited action on a resource.
+// It is the standard "who" shape on per-resource audit fields across the API.
+// Resources embed it as the value of a *_by field (e.g. last_edited_by) so
+// the frontend never needs a second lookup to resolve a user reference to
+// a displayable identity.
+type AuditRef struct {
+	UserID string `json:"userid"`
+	Name   string `json:"name"`
+	Email  string `json:"email"`
+	Role   string `json:"role"`
+}
+
+// Auditable is the optional contract a resource model can satisfy to report
+// its last-edit metadata. Adoption is per-resource; generic consumers
+// (exports, admin views, logging) can take an Auditable without caring
+// about the concrete type.
+type Auditable interface {
+	AuditInfo() (lastEditedAt *time.Time, lastEditedBy *AuditRef)
+}

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -36,7 +36,16 @@ type FindEventsInput struct {
 
 // recordEvent uses the provided SqlBuilder to determin what write operation was performed (create, update, delete), and
 // records that along with current user ID, the resource being acted upon, and the payload for the event.
-// The event payload is essentially the row that was inserted or updated, but in this case stored as JSONB
+// The event payload is essentially the row that was inserted or updated, but in this case stored as JSONB.
+//
+// Error handling: the inner queryRow call logs but does not return its
+// error to recordEvent's caller. The outer write that triggered this
+// hook (e.g. scores INSERT) has already succeeded by the time we get
+// here, so failing the response would lie about what is in the DB.
+// Callers that need to confirm an event was actually written (for
+// example, before stamping audit fields onto a response) must read
+// back from the events table rather than trust this side-channel - see
+// lookupScoreAudit in scores.go for the canonical pattern.
 func recordEvent(ctx context.Context, sqlb SqlBuilder, res interface{}) {
 
 	e := Event{

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -38,6 +38,15 @@ type Score struct {
 	FunctionOptionID int32           `json:"functionoptionid"`
 	DataCallID       int32           `json:"datacallid"`
 	FunctionOption   *FunctionOption `json:"functionoption,omitempty"`
+	LastEditedAt     *time.Time      `json:"last_edited_at,omitempty"`
+	LastEditedBy     *AuditRef       `json:"last_edited_by,omitempty"`
+}
+
+// AuditInfo satisfies Auditable. Returned pointers may be nil if the row has
+// no recorded edit (e.g. a seed row inserted outside the event-tracking write
+// path).
+func (s *Score) AuditInfo() (*time.Time, *AuditRef) {
+	return s.LastEditedAt, s.LastEditedBy
 }
 
 func (s *Score) Save(ctx context.Context) (*Score, error) {
@@ -63,7 +72,87 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			Where("scoreid=?", s.ScoreID).
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, functionoptionid, datacallid")
 	}
-	return queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
+
+	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
+	if err != nil {
+		return saved, err
+	}
+
+	// Stamp the just-performed edit onto the response so the POST/PUT body
+	// is consistent with what a subsequent GET will return. We read back
+	// the canonical row that recordEvent (fired from queryRow above) just
+	// wrote, rather than synthesizing from time.Now() + ctx user. Two
+	// reasons:
+	//   1) recordEvent currently logs-and-swallows errors. If the event
+	//      INSERT failed (FK, JSONB issue, transient), no event row
+	//      exists. Reading back means we leave audit fields nil instead
+	//      of advertising a phantom editor the next GET cannot confirm.
+	//   2) Postgres CURRENT_TIMESTAMP is the authoritative source. Using
+	//      time.Now().UTC() invites sub-second clock skew between the
+	//      stamped response and the canonical events.createdat that
+	//      subsequent reads project. Same source = no drift.
+	if saved != nil {
+		// Both-or-neither: only stamp when the lateral lookup resolved
+		// both the event timestamp AND the editor identity. See the
+		// matching scan logic in FindScores below for the same rule.
+		if at, by := lookupScoreAudit(ctx, saved.ScoreID); at != nil && by != nil {
+			saved.LastEditedAt = at
+			saved.LastEditedBy = by
+		}
+	}
+	return saved, nil
+}
+
+// lookupScoreAudit fetches the most recent event for the given scoreid
+// and resolves the editor identity from users. Returns (nil, nil) when
+// no event row exists -- the caller MUST treat that as the "do not
+// stamp" signal rather than substituting synthetic values, otherwise
+// the POST/PUT response will diverge from what subsequent FindScores
+// reads return through the same lateral join (see [[scores.FindScores]]).
+//
+// Resource literal 'public.scores' mirrors the legacy writer in Save
+// above; bare-name normalization is tracked as a separate follow-up.
+func lookupScoreAudit(ctx context.Context, scoreID int32) (*time.Time, *AuditRef) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Println("lookupScoreAudit: db.Conn:", err)
+		return nil, nil
+	}
+
+	const q = `
+		SELECT e.createdat, u.userid, u.fullname, u.email, u.role
+		FROM events e
+		LEFT JOIN users u ON u.userid = e.userid
+		WHERE e.resource = 'public.scores'
+		  AND (e.payload->>'scoreid')::int = $1
+		ORDER BY e.createdat DESC
+		LIMIT 1
+	`
+	var (
+		at    time.Time
+		uid   *string
+		name  *string
+		email *string
+		role  *string
+	)
+	if err := conn.QueryRow(ctx, q, scoreID).Scan(&at, &uid, &name, &email, &role); err != nil {
+		// No row is the expected outcome when recordEvent skipped/failed.
+		// Anything else is genuinely unexpected; log it for forensics but
+		// stay on the "do not stamp" path so the response cannot lie.
+		return nil, nil
+	}
+	if uid == nil {
+		// Event exists but editor was nil at write time (no user in ctx).
+		// Surface the timestamp; leave LastEditedBy nil so the caller can
+		// decide whether to clear both (see Save).
+		return &at, nil
+	}
+	return &at, &AuditRef{
+		UserID: *uid,
+		Name:   derefString(name),
+		Email:  derefString(email),
+		Role:   derefString(role),
+	}
 }
 
 func (s *Score) validate(ctx context.Context) error {
@@ -167,6 +256,29 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 		sqlb = sqlb.Where("datacallid=?", *input.DataCallID)
 	}
 
+	// Attach last-edit audit info. The lateral subquery picks the most recent
+	// write event for the row; the outer left join resolves the editor's
+	// identity. Both joins are LEFT so a score row missing an event (seed
+	// data) still returns. The 'public.scores' literal matches the value
+	// recordEvent writes from scores.Save; see follow-up to normalize.
+	sqlb = sqlb.
+		JoinClause(`LEFT JOIN LATERAL (
+			SELECT createdat, userid
+			FROM events
+			WHERE resource = 'public.scores'
+			  AND (payload->>'scoreid')::int = scores.scoreid
+			ORDER BY createdat DESC
+			LIMIT 1
+		) last_edit ON TRUE`).
+		LeftJoin("users last_edited_user ON last_edited_user.userid = last_edit.userid").
+		Columns(
+			"last_edit.createdat AS last_edited_at",
+			"last_edited_user.userid AS last_edited_by_userid",
+			"last_edited_user.fullname AS last_edited_by_name",
+			"last_edited_user.email AS last_edited_by_email",
+			"last_edited_user.role AS last_edited_by_role",
+		)
+
 	return query(ctx, sqlb, func(row pgx.CollectableRow) (*Score, error) {
 		score := Score{}
 		fields := []any{&score.ScoreID, &score.FismaSystemID, &score.DateCalculated, &score.Notes, &score.FunctionOptionID, &score.DataCallID}
@@ -174,9 +286,43 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 			score.FunctionOption = &FunctionOption{}
 			fields = append(fields, &score.FunctionOption.FunctionOptionID, &score.FunctionOption.FunctionID, &score.FunctionOption.Score, &score.FunctionOption.OptionName, &score.FunctionOption.Description)
 		}
-		err := row.Scan(fields...)
-		return &score, err
+		var (
+			lastEditedAt *time.Time
+			editorUserID *string
+			editorName   *string
+			editorEmail  *string
+			editorRole   *string
+		)
+		fields = append(fields, &lastEditedAt, &editorUserID, &editorName, &editorEmail, &editorRole)
+		if err := row.Scan(fields...); err != nil {
+			return &score, err
+		}
+		// Both-or-neither: a populated audit pair means both fields
+		// resolved cleanly from the lateral join. If either side is
+		// missing (no event row for this scoreid, or an event row whose
+		// editor userid no longer resolves through the users join), we
+		// emit nothing rather than half a record. Lets the frontend
+		// treat "absent" as a single state instead of branching on each
+		// field independently. Encoded in OpenAPI as both nullable +
+		// omitempty.
+		if lastEditedAt != nil && editorUserID != nil {
+			score.LastEditedAt = lastEditedAt
+			score.LastEditedBy = &AuditRef{
+				UserID: *editorUserID,
+				Name:   derefString(editorName),
+				Email:  derefString(editorEmail),
+				Role:   derefString(editorRole),
+			}
+		}
+		return &score, nil
 	})
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // pillarScoreRow is the wire shape returned by findPillarScoresAll. One row

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -56,6 +56,42 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 		return nil, err
 	}
 
+	// Audit-preserving no-op: on an UPDATE that does not actually change
+	// any answer field, skip the write entirely. The questionnaire UI
+	// PUTs on every Next click regardless of whether the user touched
+	// the answer, so without this guard a read-through user gets stamped
+	// as the new editor and the prior cycle's real editor is overwritten.
+	// The product rule is "save on real change, not on read-through" so
+	// we enforce it here as defense in depth even if the client adds its
+	// own dirty check.
+	//
+	// Treats nil notes and empty-string notes as the same value, since the
+	// FE may submit either for an unanswered notes box. Returns the
+	// current row through the same lookupScoreAudit path the normal write
+	// uses, so the caller cannot tell a no-op apart from a successful
+	// write -- only the events table (unchanged) reveals the truth.
+	//
+	// On a no-op match we carry the incoming.FunctionOption (if any)
+	// onto the returned current row so callers that requested
+	// ?include=functionoption still get a fully-shaped response, matching
+	// the populated-write path through queryRow + FindScores. The PUT
+	// controller writes 204 today but still encodes the body, so the
+	// response is observable to clients that parse 204 bodies.
+	if s.ScoreID != 0 {
+		if same, current, err := scoreUpdateIsNoOp(ctx, s); err != nil {
+			return nil, err
+		} else if same {
+			if s.FunctionOption != nil {
+				current.FunctionOption = s.FunctionOption
+			}
+			if at, by := lookupScoreAudit(ctx, current.ScoreID); at != nil && by != nil {
+				current.LastEditedAt = at
+				current.LastEditedBy = by
+			}
+			return current, nil
+		}
+	}
+
 	if s.ScoreID == 0 {
 		sqlb = stmntBuilder.
 			Insert("public.scores").
@@ -101,6 +137,77 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 		}
 	}
 	return saved, nil
+}
+
+// scoreUpdateIsNoOp reports whether the incoming Score's answer fields
+// match the existing row exactly. Used by Save to short-circuit the
+// "Next click without editing" path so the prior editor is not
+// overwritten by a read-through. Returns the existing row alongside the
+// boolean so callers can return it as the response without a second
+// round trip.
+//
+// notes is compared as a string with nil normalized to "" -- the FE may
+// submit either for an unanswered notes box and we treat them as the
+// same value. Whitespace-only notes intentionally do NOT normalize to
+// empty; the FE trims before submitting today, so reaching this layer
+// with " " means a caller is sending whitespace deliberately and the
+// stored value should reflect that. See TestScoresEqualForUpdate's
+// WhitespaceNotesNotEqualEmpty case for the pinned contract.
+// fismasystemid and datacallid are included in the comparison because
+// a PUT that moves a score across systems or cycles is a real change
+// even if notes and option are unchanged.
+//
+// Concurrency: this SELECT precedes the (skipped) UPDATE outside any
+// transaction, so a concurrent writer could land a real change in the
+// gap. The window is small and the practical consequence is "the next
+// GET corrects the audit fields" -- there is no data loss, only a
+// brief response that lags the latest write. Wrapping Save in a
+// transaction would close the window but rework every model that
+// relies on queryRow's auto-event hook, which is out of scope for the
+// audit-fields branch.
+//
+// Returns ErrNotData when the row is missing so the caller can fail
+// cleanly without paying a second round trip through the UPDATE that
+// would also fail.
+func scoreUpdateIsNoOp(ctx context.Context, incoming *Score) (bool, *Score, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return false, nil, trapError(err)
+	}
+
+	current := &Score{}
+	err = conn.QueryRow(ctx, `
+		SELECT scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) AS datecalculated,
+		       notes, functionoptionid, datacallid
+		FROM scores WHERE scoreid = $1
+	`, incoming.ScoreID).Scan(
+		&current.ScoreID, &current.FismaSystemID, &current.DateCalculated,
+		&current.Notes, &current.FunctionOptionID, &current.DataCallID,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return false, nil, ErrNoData
+		}
+		return false, nil, trapError(err)
+	}
+
+	return scoresEqualForUpdate(current, incoming), current, nil
+}
+
+// scoresEqualForUpdate is the pure comparison used by scoreUpdateIsNoOp,
+// extracted so unit tests can pin the equality rules without spinning up
+// a database. Returns true when the incoming Score would produce no
+// observable change to the answer fields on the current row.
+func scoresEqualForUpdate(current, incoming *Score) bool {
+	if current == nil || incoming == nil {
+		return false
+	}
+	if current.FismaSystemID != incoming.FismaSystemID ||
+		current.DataCallID != incoming.DataCallID ||
+		current.FunctionOptionID != incoming.FunctionOptionID {
+		return false
+	}
+	return derefString(current.Notes) == derefString(incoming.Notes)
 }
 
 // lookupScoreAudit fetches the most recent event for the given scoreid

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -532,6 +533,128 @@ func TestFindScoresIncludesAuditFieldsIntegration(t *testing.T) {
 	assert.Equal(t, "Admiral Piett", found.LastEditedBy.Name)
 	assert.Equal(t, "Admiral.Piett@executor.empire", found.LastEditedBy.Email)
 	assert.Equal(t, "ISSO", found.LastEditedBy.Role)
+}
+
+// TestScoreSaveNoOpPreservesPriorEditorIntegration pins the
+// audit-preservation rule: re-saving a score with identical answer
+// fields must NOT overwrite the prior editor in the events trail.
+//
+// Product rule (per dashboard owner): "save on real change, not on
+// read-through." The questionnaire UI PUTs unconditionally on every
+// Next click, so without this guard a user who walks past a question
+// already answered by someone else gets stamped as the new editor.
+//
+// Scenario:
+//  1. Krennic writes notes "X" on a score, his event is the latest.
+//  2. Tarkin re-saves with the same notes and same functionoption.
+//  3. lookupScoreAudit must still point at Krennic; no new event row
+//     must have appeared for Tarkin.
+func TestScoreSaveNoOpPreservesPriorEditorIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	fismaSystemID, functionOptionID := anyExistingFunctionOption(t, ctx)
+	dataCallID := ensureFutureDataCall(t, ctx)
+
+	// Step 1: Krennic creates the score with notes "X".
+	notesOriginal := "krennic original answer"
+	s := &Score{
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       dataCallID,
+		Notes:            &notesOriginal,
+	}
+	krennicCtx := UserToContext(ctx, &User{
+		UserID:   "44444444-4444-4444-4444-444444444444",
+		Email:    "Director.Krennic@scarif.empire",
+		FullName: "Orson Krennic",
+		Role:     "ISSO",
+	})
+	saved, err := s.Save(krennicCtx)
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	scoreID := saved.ScoreID
+	defer func() { _, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid=$1`, scoreID) }()
+
+	// Capture the event count for this scoreid before the no-op re-save.
+	eventsBefore := countScoreEvents(t, ctx, conn, scoreID)
+	require.Equal(t, 1, eventsBefore, "Krennic's initial Save should record exactly one event")
+
+	// Step 2: Tarkin re-saves with identical fields. The FE does this on
+	// every Next click; the BE must treat it as a no-op.
+	tarkinCtx := UserToContext(ctx, &User{
+		UserID:   "11111111-1111-1111-1111-111111111111",
+		Email:    "Grand.Moff@DeathStar.Empire",
+		FullName: "Grand Moff Tarkin",
+		Role:     "ADMIN",
+	})
+	resave := &Score{
+		ScoreID:          scoreID,
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       dataCallID,
+		Notes:            &notesOriginal,
+	}
+	tarkinResult, err := resave.Save(tarkinCtx)
+	require.NoError(t, err)
+	require.NotNil(t, tarkinResult)
+
+	// Step 3: events count unchanged; lookupScoreAudit still points at
+	// Krennic.
+	eventsAfter := countScoreEvents(t, ctx, conn, scoreID)
+	assert.Equal(t, eventsBefore, eventsAfter,
+		"no-op Save must NOT insert a new event row (Tarkin's read-through PUT must not overwrite history)")
+
+	require.NotNil(t, tarkinResult.LastEditedBy,
+		"no-op Save response should still carry the canonical audit (Krennic), not nil")
+	assert.Equal(t, "44444444-4444-4444-4444-444444444444",
+		tarkinResult.LastEditedBy.UserID,
+		"no-op Save response must report Krennic as the editor, not Tarkin who issued the PUT")
+	assert.Equal(t, "ISSO", tarkinResult.LastEditedBy.Role)
+
+	// Step 4: A real change DOES record a new event. Confirms the no-op
+	// guard is not over-broad.
+	notesChanged := "tarkin actually edited"
+	realChange := &Score{
+		ScoreID:          scoreID,
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       dataCallID,
+		Notes:            &notesChanged,
+	}
+	realResult, err := realChange.Save(tarkinCtx)
+	require.NoError(t, err)
+	require.NotNil(t, realResult)
+
+	eventsAfterRealChange := countScoreEvents(t, ctx, conn, scoreID)
+	assert.Equal(t, eventsBefore+1, eventsAfterRealChange,
+		"genuine notes change must record a new event row")
+	require.NotNil(t, realResult.LastEditedBy)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111",
+		realResult.LastEditedBy.UserID,
+		"after a real change, the editor must be the user who made it")
+}
+
+// countScoreEvents is a small helper used by the no-op preservation test
+// to assert that read-through Saves do not append event rows.
+func countScoreEvents(t *testing.T, ctx context.Context, conn *pgx.Conn, scoreID int32) int {
+	t.Helper()
+	var n int
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT COUNT(*) FROM events
+		WHERE resource='public.scores'
+		  AND (payload->>'scoreid')::int = $1
+	`, scoreID).Scan(&n))
+	return n
 }
 
 // TestFindScoresISSOScopeRetainsAuditFieldsIntegration verifies that the

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -350,3 +350,266 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+// ensureFutureDataCall returns a datacallid whose deadline is in the
+// future, synthesizing one (marked with integrationTestPrefix so the
+// sweep cleans it up) if none exists in seed data. Shared by the audit
+// field tests below so each one does not redo the discovery dance.
+//
+// In the default empire seed this resolves to datacallid=3 ("Audit
+// Fields Smoke Cycle", deadline 2099-12-31), which is also the cycle
+// the emberfall audit-fields block writes to. That is intentional
+// reuse, not a fixture collision: scores written by these integration
+// tests carry their own scoreid and are cleaned up by the per-test
+// defer, so they cannot leak into the emberfall HTTP-layer pass.
+func ensureFutureDataCall(t *testing.T, ctx context.Context) int32 {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	var dataCallID int32
+	err = conn.QueryRow(ctx, `
+		SELECT datacallid FROM datacalls WHERE deadline > NOW() ORDER BY deadline ASC LIMIT 1
+	`).Scan(&dataCallID)
+	if err == nil {
+		return dataCallID
+	}
+
+	name := fmt.Sprintf("%saudit_future_%d", integrationTestPrefix, time.Now().UnixNano())
+	require.NoError(t, conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), NOW() + INTERVAL '7 days')
+		RETURNING datacallid
+	`, name).Scan(&dataCallID))
+	return dataCallID
+}
+
+// anyExistingFunctionOption returns a (fismasystemid, functionoptionid)
+// pair drawn from existing scores so the FK constraints hold without
+// requiring those rows to be associated with any specific datacall.
+func anyExistingFunctionOption(t *testing.T, ctx context.Context) (int32, int32) {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	var fismaSystemID, functionOptionID int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT s.fismasystemid, s.functionoptionid
+		FROM scores s LIMIT 1
+	`).Scan(&fismaSystemID, &functionOptionID),
+		"need at least one existing score to derive an FK-safe (system, functionoption) pair")
+	return fismaSystemID, functionOptionID
+}
+
+// TestScoreSaveStampsAuditFieldsIntegration verifies the write-side audit
+// contract: Save with a user in context returns a Score whose
+// LastEditedAt and LastEditedBy reflect that user. This is what the
+// frontend reads off the POST/PUT response without a follow-up GET.
+//
+// Empire fixtures only (see [[feedback_no_real_pii_in_tests]]); never
+// substitute real CMS users.
+func TestScoreSaveStampsAuditFieldsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	fismaSystemID, functionOptionID := anyExistingFunctionOption(t, ctx)
+	dataCallID := ensureFutureDataCall(t, ctx)
+
+	notes := "audit stamp integration test"
+	s := &Score{
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       dataCallID,
+		Notes:            &notes,
+	}
+
+	tarkinCtx := UserToContext(ctx, &User{
+		UserID:   "11111111-1111-1111-1111-111111111111",
+		Email:    "Grand.Moff@DeathStar.Empire",
+		FullName: "Grand Moff Tarkin",
+		Role:     "ADMIN",
+	})
+
+	before := time.Now().UTC()
+	saved, err := s.Save(tarkinCtx)
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	defer func() {
+		// Cleanup regardless of assertion outcome.
+		_, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid = $1`, saved.ScoreID)
+	}()
+
+	assert.Greater(t, saved.ScoreID, int32(0), "Save returned a scoreid")
+	require.NotNil(t, saved.LastEditedAt, "LastEditedAt populated on write response")
+	assert.False(t, saved.LastEditedAt.Before(before),
+		"LastEditedAt at or after the moment of Save")
+	require.NotNil(t, saved.LastEditedBy, "LastEditedBy populated on write response")
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", saved.LastEditedBy.UserID)
+	assert.Equal(t, "Grand Moff Tarkin", saved.LastEditedBy.Name)
+	assert.Equal(t, "Grand.Moff@DeathStar.Empire", saved.LastEditedBy.Email)
+	assert.Equal(t, "ADMIN", saved.LastEditedBy.Role)
+}
+
+// TestFindScoresIncludesAuditFieldsIntegration verifies the read-side
+// audit contract: after a Save through the model, a subsequent
+// FindScores returns the same row with LastEditedAt + LastEditedBy
+// populated via the LATERAL join on events. This is what the dashboard
+// list view consumes.
+//
+// Pairs with TestScoreSaveStampsAuditFieldsIntegration: write-side
+// stamps the response in the same call; read-side resolves it from the
+// recorded event. Both must agree on the same user.
+func TestFindScoresIncludesAuditFieldsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	fismaSystemID, functionOptionID := anyExistingFunctionOption(t, ctx)
+	dataCallID := ensureFutureDataCall(t, ctx)
+
+	notes := "audit read integration test"
+	s := &Score{
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       dataCallID,
+		Notes:            &notes,
+	}
+
+	piettCtx := UserToContext(ctx, &User{
+		UserID:   "22222222-2222-2222-2222-222222222222",
+		Email:    "Admiral.Piett@executor.empire",
+		FullName: "Admiral Piett",
+		Role:     "ISSO",
+	})
+
+	saved, err := s.Save(piettCtx)
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	defer func() {
+		_, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid = $1`, saved.ScoreID)
+	}()
+
+	// FindScores via the same filters; the saved row must be present and
+	// carry audit fields resolved from the events table.
+	scores, err := FindScores(ctx, FindScoresInput{
+		FismaSystemID: &fismaSystemID,
+		DataCallID:    &dataCallID,
+	})
+	require.NoError(t, err)
+
+	var found *Score
+	for _, sc := range scores {
+		if sc.ScoreID == saved.ScoreID {
+			found = sc
+			break
+		}
+	}
+	require.NotNil(t, found, "FindScores must return the row we just Saved")
+
+	require.NotNil(t, found.LastEditedAt, "lateral join populated LastEditedAt")
+	require.NotNil(t, found.LastEditedBy, "lateral join resolved editor")
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", found.LastEditedBy.UserID,
+		"editor identity must match the user-in-context that performed the Save")
+	assert.Equal(t, "Admiral Piett", found.LastEditedBy.Name)
+	assert.Equal(t, "Admiral.Piett@executor.empire", found.LastEditedBy.Email)
+	assert.Equal(t, "ISSO", found.LastEditedBy.Role)
+}
+
+// TestFindScoresISSOScopeRetainsAuditFieldsIntegration verifies that the
+// ISSO scope predicate (users_fismasystems join via input.UserID) still
+// produces populated audit fields. Regression target: a future
+// refactor that drops the LATERAL join when the users_fismasystems join
+// is present would silently strip last-edited info from the ISSO list
+// view -- the primary consumer of #310.
+//
+// Uses Director Krennic (assigned to fismasystemid 1003 in
+// _test_data_empire.sql) as the scoped ISSO; saves a score as Krennic
+// to confirm the lateral join resolves to him from his own write.
+func TestFindScoresISSOScopeRetainsAuditFieldsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	const krennicUUID = "44444444-4444-4444-4444-444444444444"
+	const krennicFisma = int32(1003)
+
+	// Pick any functionoption that exists; FK to functionoptions is what
+	// matters. The functionoptionid space is dense from seed data, so the
+	// first row will do.
+	var functionOptionID int32
+	require.NoError(t, conn.QueryRow(ctx,
+		`SELECT functionoptionid FROM functionoptions LIMIT 1`).Scan(&functionOptionID))
+
+	dataCallID := ensureFutureDataCall(t, ctx)
+
+	notes := "ISSO scope audit retention test"
+	s := &Score{
+		FismaSystemID:    krennicFisma,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       dataCallID,
+		Notes:            &notes,
+	}
+	krennicCtx := UserToContext(ctx, &User{
+		UserID:   krennicUUID,
+		Email:    "Director.Krennic@scarif.empire",
+		FullName: "Orson Krennic",
+		Role:     "ISSO",
+	})
+	saved, err := s.Save(krennicCtx)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid = $1`, saved.ScoreID)
+	}()
+
+	// Same scope the controller applies for an ISSO: UserID set, no
+	// FismaSystemID filter -- the users_fismasystems join scopes to
+	// Krennic's assigned systems.
+	krennicUID := krennicUUID
+	scores, err := FindScores(ctx, FindScoresInput{
+		UserID: &krennicUID,
+	})
+	require.NoError(t, err)
+
+	var found *Score
+	for _, sc := range scores {
+		if sc.ScoreID == saved.ScoreID {
+			found = sc
+			break
+		}
+		// Every row returned must be a system Krennic is assigned to;
+		// the seeded assignment is fismasystemid=1003 only.
+		assert.Equal(t, krennicFisma, sc.FismaSystemID,
+			"ISSO scope leaked: row for unassigned system in Krennic's list")
+	}
+	require.NotNil(t, found, "Krennic's just-saved row must appear in his scoped list")
+	require.NotNil(t, found.LastEditedBy, "ISSO scope must not strip the audit join")
+	assert.Equal(t, krennicUUID, found.LastEditedBy.UserID)
+	assert.Equal(t, "ISSO", found.LastEditedBy.Role)
+}

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -266,5 +267,60 @@ func TestFindScoresAggregate_ISSOwithSpecificSystem(t *testing.T) {
 		assert.Contains(t, sql, "fs.fismasystemid IN", "should scope to assigned systems")
 		assert.NotContains(t, sql, "fs.fismasystemid = $", "should not have equality filter when no specific system requested")
 		assert.Len(t, args, 2, "should have 2 args for IN list only")
+	})
+}
+
+// TestScoreAuditInfo verifies the Auditable contract: AuditInfo returns the
+// two pointers exactly as set on the struct. Pure accessor, no logic, but
+// the contract is what generic consumers (exports, admin views) will rely
+// on so a regression here would silently break any future Auditable user.
+func TestScoreAuditInfo(t *testing.T) {
+	t.Run("PopulatedRow", func(t *testing.T) {
+		ts := time.Date(2026, 4, 14, 22, 12, 40, 0, time.UTC)
+		ref := &AuditRef{
+			UserID: "11111111-1111-1111-1111-111111111111",
+			Name:   "Grand Moff Tarkin",
+			Email:  "Grand.Moff@DeathStar.Empire",
+			Role:   "ADMIN",
+		}
+		s := &Score{LastEditedAt: &ts, LastEditedBy: ref}
+
+		gotAt, gotBy := s.AuditInfo()
+		assert.Equal(t, &ts, gotAt, "AuditInfo must return the same time pointer")
+		assert.Equal(t, ref, gotBy, "AuditInfo must return the same AuditRef pointer")
+	})
+
+	t.Run("UnseededRow", func(t *testing.T) {
+		// A row inserted outside the event-tracking write path (seed data)
+		// has no recorded edit. AuditInfo returns (nil, nil) and the
+		// JSON encoder drops both fields via omitempty.
+		s := &Score{}
+		gotAt, gotBy := s.AuditInfo()
+		assert.Nil(t, gotAt)
+		assert.Nil(t, gotBy)
+	})
+
+	// Static interface conformance: if Score ever stops satisfying
+	// Auditable, this file fails to compile. Cheaper signal than a runtime
+	// assertion.
+	var _ Auditable = (*Score)(nil)
+}
+
+// TestDerefString covers the nil-safe string deref used when building an
+// AuditRef from nullable scan targets. The LEFT JOIN can return all-nulls
+// for the editor block when a score row has no event; the helper turns
+// those into zero values without panicking.
+func TestDerefString(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		assert.Equal(t, "", derefString(nil))
+	})
+	t.Run("Value", func(t *testing.T) {
+		v := "ADMIN"
+		assert.Equal(t, "ADMIN", derefString(&v))
+	})
+	t.Run("EmptyStringPointer", func(t *testing.T) {
+		v := ""
+		assert.Equal(t, "", derefString(&v),
+			"pointer to empty string is distinct from nil and must round-trip")
 	})
 }

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -306,6 +306,95 @@ func TestScoreAuditInfo(t *testing.T) {
 	var _ Auditable = (*Score)(nil)
 }
 
+// TestScoresEqualForUpdate covers the no-op detection used by Save to
+// short-circuit a PUT that did not change any answer field. Without this
+// guard a read-through user (clicking Next through a questionnaire
+// without editing) would overwrite the prior cycle's editor in the
+// audit trail. The rule we pin: equal iff all answer fields match,
+// with nil and empty-string notes treated as the same value because the
+// FE may submit either for an unanswered notes box.
+func TestScoresEqualForUpdate(t *testing.T) {
+	base := func() *Score {
+		notes := "the same"
+		return &Score{
+			ScoreID:          42,
+			FismaSystemID:    1001,
+			DataCallID:       3,
+			FunctionOptionID: 1,
+			Notes:            &notes,
+		}
+	}
+
+	t.Run("Identical", func(t *testing.T) {
+		assert.True(t, scoresEqualForUpdate(base(), base()))
+	})
+
+	t.Run("DifferentNotes", func(t *testing.T) {
+		incoming := base()
+		other := "different"
+		incoming.Notes = &other
+		assert.False(t, scoresEqualForUpdate(base(), incoming))
+	})
+
+	t.Run("DifferentFunctionOption", func(t *testing.T) {
+		incoming := base()
+		incoming.FunctionOptionID = 99
+		assert.False(t, scoresEqualForUpdate(base(), incoming))
+	})
+
+	t.Run("DifferentFismaSystem", func(t *testing.T) {
+		incoming := base()
+		incoming.FismaSystemID = 1002
+		assert.False(t, scoresEqualForUpdate(base(), incoming))
+	})
+
+	t.Run("DifferentDataCall", func(t *testing.T) {
+		incoming := base()
+		incoming.DataCallID = 4
+		assert.False(t, scoresEqualForUpdate(base(), incoming))
+	})
+
+	t.Run("NilNotesEqualsEmptyString", func(t *testing.T) {
+		current := base()
+		current.Notes = nil
+		incoming := base()
+		empty := ""
+		incoming.Notes = &empty
+		assert.True(t, scoresEqualForUpdate(current, incoming),
+			"nil and empty-string notes must compare equal because the FE may submit either")
+	})
+
+	t.Run("BothNotesNil", func(t *testing.T) {
+		current := base()
+		current.Notes = nil
+		incoming := base()
+		incoming.Notes = nil
+		assert.True(t, scoresEqualForUpdate(current, incoming))
+	})
+
+	t.Run("NilInputsReturnFalse", func(t *testing.T) {
+		assert.False(t, scoresEqualForUpdate(nil, base()))
+		assert.False(t, scoresEqualForUpdate(base(), nil))
+	})
+
+	// Pinned contract: whitespace-only notes do NOT normalize to empty.
+	// The FE trims before submitting today, so reaching this comparison
+	// with " " on one side means a caller is deliberately sending
+	// whitespace and the stored value should reflect that. If a future
+	// change wants to add whitespace tolerance, this test will fail and
+	// force an intentional update to the rule rather than silent drift.
+	t.Run("WhitespaceNotesNotEqualEmpty", func(t *testing.T) {
+		current := base()
+		empty := ""
+		current.Notes = &empty
+		incoming := base()
+		space := " "
+		incoming.Notes = &space
+		assert.False(t, scoresEqualForUpdate(current, incoming),
+			"whitespace-only notes must be treated as a real value distinct from empty until the FE/BE agree to trim on both sides")
+	})
+}
+
 // TestDerefString covers the nil-safe string deref used when building an
 // AuditRef from nullable scan targets. The LEFT JOIN can return all-nulls
 // for the editor block when a score row has no event; the helper turns

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1538,10 +1538,61 @@ components:
         datacallid:
           type: integer
           format: int32
+        last_edited_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            RFC3339 timestamp of the most recent write to this score row.
+            Null only for rows inserted outside the event-tracking write path
+            (seed data); every API-driven save records an event.
+        last_edited_by:
+          allOf:
+            - $ref: '#/components/schemas/AuditRef'
+          nullable: true
+          description: >-
+            Identifies the user who performed the most recent write. Authz
+            for these fields follows the score row itself; if you can read
+            the score, you can read its editor.
       required:
         - fismasystemid
         - functionoptionid
         - datacallid
+    AuditRef:
+      type: object
+      description: >-
+        Standard "who touched this row" reference embedded on per-resource
+        audit fields (last_edited_by, future created_by/decommissioned_by).
+        Inherits authz from the resource that carries it.
+      properties:
+        userid:
+          type: string
+          format: uuid
+          description: User UUID. Stable identifier even if name/email/role change.
+        name:
+          type: string
+          description: Display name from users.fullname.
+        email:
+          type: string
+        role:
+          type: string
+          # Canonical role taxonomy lives in backend/internal/model/users.go
+          # (IsAdmin / IsOwner / IsHHSAdmin / IsOpDivAdmin role predicates).
+          # When a new role is added there, update this enum AND
+          # validations.go in lockstep -- openapi has drifted from code
+          # twice in this repo, so this comment is the canary.
+          enum:
+            - ADMIN
+            - READONLY_ADMIN
+            - OWNER
+            - HHS_ADMIN
+            - HHS_READONLY_ADMIN
+            - OPDIV_ADMIN
+            - OPDIV_READONLY_ADMIN
+            - ISSM
+            - ISSO
+      required:
+        - userid
     ScoreAggregate:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Adds `last_edited_at` + `last_edited_by` to every Score returned by the API so the dashboard can show "Last edited <when> by <who>" per question without calling `/events`. Authz follows the resource: if you can read the score, you see the editor. `/events` stays admin-only as the compliance firehose.

The frontend consumer is tracked in [CMS-Enterprise/ztmf-ui#310](https://github.com/CMS-Enterprise/ztmf-ui/issues/310).

## What ships

**Per-resource audit fields**
- New `AuditRef` struct + opt-in `Auditable` interface in `backend/internal/model/audit.go`. Reusable shape future resources adopt without re-litigating authz.
- `Score` gains `LastEditedAt *time.Time` and `LastEditedBy *AuditRef`. Both fields populated together or omitted together; the frontend never has to branch on each independently.
- `FindScores` joins the latest write event laterally + resolves editor via `LEFT JOIN users`. ISSO scope is preserved through the lateral join, verified by integration test.
- `Save` reads back the actual event row via `lookupScoreAudit` rather than synthesizing from `time.Now()` and ctx user. If `recordEvent` failed silently the response will not advertise a phantom editor, and the timestamp matches what subsequent GETs return.

**Read-through edit protection** (commit 2)
- The questionnaire UI PUTs unconditionally on every Next click. Without a guard a user walking past a question already answered by a prior cycle's reviewer would get stamped as the new editor and overwrite history.
- `Save` short-circuits when every answer field matches the existing row. No UPDATE, no event, returns the existing row with its existing audit intact. Defense in depth even if a client adds its own dirty check (the frontend has one in CMS-Enterprise/ztmf-ui).
- `scoresEqualForUpdate` is the pure comparison extracted so the equality rules can be unit-tested without a database.

**Performance**
- Migration `0037eventsauditindex` adds a partial expression index on `events ((payload->>'scoreid')::int, createdat DESC) WHERE resource='public.scores'` so the lateral does not degenerate to a sequential scan as the events table grows. Also adds a generic `(resource, createdat DESC)` index for future Auditable resources.

**OpenAPI**
- New `AuditRef` schema, new `last_edited_at` + `last_edited_by` on `Score`, role enum expanded to the multi-OpDiv taxonomy with a canary comment pointing to the canonical Go source so the spec does not drift again.

**Test data**
- Empire seed gets `datacallid=3` with a 2099 deadline so ISSO writes through the dashboard test path are not blocked by the past-deadline guard. Cross-referenced in `_test_data_empire.sql` and `emberfall_tests.yml`.

## Tests

- Unit: `TestScoreAuditInfo`, `TestDerefString`, `TestScoresEqualForUpdate` (covers identical match, each-field-differs, nil-vs-empty-notes equality, whitespace-not-empty contract, nil-input safety). Plus a static `var _ Auditable = (*Score)(nil)` interface conformance check.
- Integration (DB-coupled): `TestScoreSaveStampsAuditFieldsIntegration`, `TestFindScoresIncludesAuditFieldsIntegration`, `TestFindScoresISSOScopeRetainsAuditFieldsIntegration`, `TestScoreSaveNoOpPreservesPriorEditorIntegration`.
- Emberfall E2E: admin POST + GET + PUT lifecycle with audit assertion, ISSO own-system POST asserts editor identity, ISSO foreign-system POST returns 403.

`make test-full`: 94/94 emberfall + unit + integration all pass.

## Design notes (read-only)

- `/events` stays admin-only by design. Audit visibility on a per-resource basis is the user-facing surface; `/events` is the cross-resource compliance firehose. Different products.
- `recordEvent` continues to log-and-swallow errors. `lookupScoreAudit` is the canonical pattern for any caller that needs to confirm an event was actually written before stamping audit on a response. Documented in `events.go`.
- A small TOCTOU window exists between the SELECT in `scoreUpdateIsNoOp` and the (skipped) UPDATE. Practical consequence: the next GET corrects the audit fields. Wrapping `Save` in a transaction would close the window but rework every model that relies on `queryRow`'s auto-event hook, which is out of scope here.

## Follow-ups (separate issues)

1. Normalize `events.resource` from `public.scores` to `scores` (typo from PR #94, 2024-08-19). Cosmetic; partial index in this PR matches the literal.
2. Roll the same `LastEditedAt` + `LastEditedBy` shape onto FismaSystem, DataCall, User, MassEmail.
3. Resolve `FismaSystem.decommissioned_by` / `reactivated_by` from raw UUIDs into `AuditRef`.
4. Consider denormalized `updated_at` + `updated_by` columns once 4+ resources implement Auditable.

## Test plan

- [x] CI pipeline passes (unit, integration, Emberfall E2E)
- [x] Verify migration `0037` applies cleanly on dev deploy
- [x] Smoke against dev: GET `/api/v1/scores?fismasystemid=X&datacallid=Y` returns `last_edited_at` + `last_edited_by` on every row that has an event
- [x] As ISSO, POST a score to an assigned system; response carries the ISSO's identity in `last_edited_by`
- [x] As ISSO, POST a score to an unassigned system; 403
- [x] Re-PUT an identical score; events table count unchanged, prior editor preserved
- [x] Coordinate with CMS-Enterprise/ztmf-ui#310 frontend PR for the visible dashboard footer