### PR TITLE
Add system_enrichment table and read endpoint (refs #211)

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -545,6 +545,16 @@ INSERT INTO public.idm_scoring (idm_name, display_name, score, reasoning) VALUES
     ('Single Factor (Only)', 'Single Factor Only', 1, 'Single factor authentication only - no MFA capability.')
 ON CONFLICT (idm_name) DO NOTHING;
 
+-- Generic system_enrichment row (issue #211), keyed on fismasystems.fismauid for
+-- Shield Gen (1003), which the Emberfall ISSO is assigned to. Gives the
+-- /systemenrichment endpoint E2E coverage via the same access join as CFACTS.
+-- The payload is opaque to ztmf core (owned by the enrichment pipeline).
+INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
+    'E1D00198-36D4-4EAB-8C00-501E1D000999',
+    '{"fisma_acronym":"SLD-GEN","cfacts":{"lifecycle_phase":"Operational","fips_impact_level":"Moderate"},"scoring":{"suggested_score":2,"suggested_label":"Initial","evidence_sources":["Kion","Hardenize"]}}',
+    '2026-05-20 00:00:00+00'
+) ON CONFLICT (fisma_uuid) DO NOTHING;
+
 -- Reset every SERIAL sequence to its current table max. Use
 -- pg_get_serial_sequence() so the right name is resolved at runtime: some
 -- environments have historically renamed tables (e.g. functionscores -> scores)

--- a/backend/cmd/api/internal/controller/systemenrichment.go
+++ b/backend/cmd/api/internal/controller/systemenrichment.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
+)
+
+// GetSystemEnrichment returns the generic enrichment payload for a FISMA system
+// by its fisma_uuid. Access control mirrors the FISMA-system assignment check:
+// admins (and read-only admins) may read any system; an ISSO may read only
+// systems they are assigned to. A system with no enrichment row yields 404.
+func GetSystemEnrichment(w http.ResponseWriter, r *http.Request) {
+	user := model.UserFromContext(r.Context())
+
+	vars := mux.Vars(r)
+	fismaUUID, ok := vars["fisma_uuid"]
+	if !ok || fismaUUID == "" {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	if !user.HasAdminRead() {
+		canAccess, err := model.UserCanAccessCfactsSystem(r.Context(), user.UserID, fismaUUID)
+		if err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+		if !canAccess {
+			respond(w, r, nil, ErrForbidden)
+			return
+		}
+	}
+
+	enrichment, err := model.FindSystemEnrichment(r.Context(), fismaUUID)
+	respond(w, r, enrichment, err)
+}

--- a/backend/cmd/api/internal/migrations/0038systemenrichment.go
+++ b/backend/cmd/api/internal/migrations/0038systemenrichment.go
@@ -1,0 +1,20 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add generic system_enrichment extension table",
+		// UP: Generic, enrichment-agnostic extension point owned by ztmf core. The
+		// CMS-specific enrichment pipeline (private repo) populates the jsonb payload,
+		// keyed on fisma_uuid. Adding or removing enrichment fields is a payload-key
+		// change in that pipeline and requires no change here. fisma_uuid is
+		// VARCHAR(255) to match fismasystems.fismauid (no FK: that column is not
+		// unique, and this is a disposable TRUNCATE+INSERT cache, mirroring
+		// cfacts_systems which also has no FK).
+		`CREATE TABLE IF NOT EXISTS public.system_enrichment (
+			fisma_uuid VARCHAR(255) PRIMARY KEY,
+			payload    JSONB NOT NULL,
+			synced_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);`,
+		// DOWN
+		`DROP TABLE IF EXISTS public.system_enrichment;`)
+}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -73,6 +73,8 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/cfactssystems", controller.ListCfactsSystems).Methods("GET")
 	router.HandleFunc("/api/v1/cfactssystems/{fisma_uuid:[a-zA-Z0-9-]+}", controller.GetCfactsSystem).Methods("GET")
 
+	router.HandleFunc("/api/v1/systemenrichment/{fisma_uuid:[a-zA-Z0-9-]+}", controller.GetSystemEnrichment).Methods("GET")
+
 	// massemails resource only supports a single verb as there are no records to get list and details for, but the operation is non-idempotent
 	router.HandleFunc("/api/v1/massemails", controller.SaveMassEmail).Methods("POST")
 

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1045,6 +1045,28 @@ tests:
     expect:
       status: 404
 
+  # System Enrichment endpoint (generic enrichment payload, admin access)
+  - url: http://localhost:8080/api/v1/systemenrichment/E1D00198-36D4-4EAB-8C00-501E1D000999
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            fisma_uuid: "E1D00198-36D4-4EAB-8C00-501E1D000999"
+
+  # System with no enrichment row returns 404
+  - url: http://localhost:8080/api/v1/systemenrichment/nonexistent-uuid-does-not-exist
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 404
+
   # massemails only supports this one route
   # test that it errors on invalid input
   - url: http://localhost:8080/api/v1/massemails
@@ -1355,6 +1377,28 @@ tests:
 
   # ISSO gets 403 on GET /api/v1/cfactssystems/<uuid> for unassigned system
   - url: http://localhost:8080/api/v1/cfactssystems/12345678-ABCD-4321-AFAB-123456789ABC
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 403
+
+  # ISSO can GET /api/v1/systemenrichment/<uuid> for an assigned system
+  - url: http://localhost:8080/api/v1/systemenrichment/E1D00198-36D4-4EAB-8C00-501E1D000999
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            fisma_uuid: "E1D00198-36D4-4EAB-8C00-501E1D000999"
+
+  # ISSO gets 403 on GET /api/v1/systemenrichment/<uuid> for unassigned system
+  - url: http://localhost:8080/api/v1/systemenrichment/12345678-ABCD-4321-AFAB-123456789ABC
     method: GET
     headers:
       <<: *issoHeaders

--- a/backend/internal/model/systemenrichment.go
+++ b/backend/internal/model/systemenrichment.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// SystemEnrichment is one row of the generic public.system_enrichment table. The
+// payload is an opaque JSON document produced by the (CMS-specific, private)
+// enrichment pipeline and stored verbatim in a jsonb column. ztmf core does not
+// own or interpret its shape; it is returned to clients as-is. Payload is
+// json.RawMessage (not []byte) so it serializes back out as raw JSON rather than
+// base64.
+type SystemEnrichment struct {
+	FismaUUID string          `json:"fisma_uuid" db:"fisma_uuid"`
+	Payload   json.RawMessage `json:"payload" db:"payload"`
+	SyncedAt  time.Time       `json:"synced_at" db:"synced_at"`
+}
+
+// FindSystemEnrichment returns the enrichment row for a FISMA system by its
+// fisma_uuid, or ErrNoData if none exists (e.g. a deployment with no enrichment
+// pipeline attached, or a system the pipeline has not scored).
+func FindSystemEnrichment(ctx context.Context, fismaUUID string) (*SystemEnrichment, error) {
+	if fismaUUID == "" {
+		return nil, ErrNoData
+	}
+
+	sqlb := stmntBuilder.
+		Select("fisma_uuid", "payload", "synced_at").
+		From("system_enrichment").
+		Where("fisma_uuid=?", fismaUUID)
+
+	return queryRow(ctx, sqlb, pgx.RowToStructByName[SystemEnrichment])
+}

--- a/backend/internal/model/systemenrichment_test.go
+++ b/backend/internal/model/systemenrichment_test.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSystemEnrichment_StructFields(t *testing.T) {
+	now := time.Now()
+	se := SystemEnrichment{
+		FismaUUID: "12345678-1234-4abc-8def-123456789abc",
+		Payload:   json.RawMessage(`{"scoring":{"suggested_score":2}}`),
+		SyncedAt:  now,
+	}
+
+	assert.Equal(t, "12345678-1234-4abc-8def-123456789abc", se.FismaUUID)
+	assert.JSONEq(t, `{"scoring":{"suggested_score":2}}`, string(se.Payload))
+	assert.Equal(t, now, se.SyncedAt)
+}
+
+// TestSystemEnrichment_PayloadSerializesAsRawJSON guards the json.RawMessage field
+// choice: the opaque jsonb payload must serialize back out as a JSON object so
+// clients get raw JSON, never a base64 string (which is what a plain []byte field
+// would produce). This is the behavior the read endpoint depends on.
+func TestSystemEnrichment_PayloadSerializesAsRawJSON(t *testing.T) {
+	se := SystemEnrichment{
+		FismaUUID: "TEST",
+		Payload:   json.RawMessage(`{"cfacts":{"lifecycle_phase":"Operational"}}`),
+	}
+
+	out, err := json.Marshal(se)
+	assert.NoError(t, err)
+
+	s := string(out)
+	assert.Contains(t, s, `"payload":{`)   // rendered as a nested JSON object
+	assert.NotContains(t, s, `"payload":"`) // not a quoted/base64 string
+}
+
+func TestFindSystemEnrichment_EmptyUUID(t *testing.T) {
+	// Empty uuid short-circuits to ErrNoData before any DB access, so this needs
+	// no test database.
+	_, err := FindSystemEnrichment(context.TODO(), "")
+	assert.Equal(t, ErrNoData, err)
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1296,6 +1296,35 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  /systemenrichment/{fisma_uuid}:
+    get:
+      summary: Get system enrichment payload by FISMA UUID
+      description: Returns the generic enrichment payload for a FISMA system by its UUID. Admins and READONLY_ADMINs can access any system; ISSOs can only access systems they are assigned to. The payload is an opaque JSON document owned by the enrichment pipeline; systems with no enrichment data return 404.
+      operationId: getSystemEnrichment
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: fisma_uuid
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: System enrichment payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SystemEnrichment'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /massemails:
     post:
       summary: Send mass email
@@ -1798,6 +1827,23 @@ components:
       required:
         - fisma_uuid
         - fisma_acronym
+        - synced_at
+    SystemEnrichment:
+      type: object
+      description: Generic per-system enrichment payload. The payload shape is opaque to the core API and owned by the enrichment pipeline.
+      properties:
+        fisma_uuid:
+          type: string
+        payload:
+          type: object
+          description: Opaque JSON document produced by the enrichment pipeline; returned verbatim.
+          additionalProperties: true
+        synced_at:
+          type: string
+          format: date-time
+      required:
+        - fisma_uuid
+        - payload
         - synced_at
     Event:
       type: object


### PR DESCRIPTION
## Summary

Adds a generic `public.system_enrichment` table that ztmf core owns and a separate enrichment pipeline (private `ztmf-insights` stack) fills with an opaque JSON payload, plus a read-only endpoint that returns it. This is the core-side, **additive** half of decoupling the CMS-specific enrichment pipeline from the open-source data-call app.

The two sides meet at one stable contract: the table. Adding or changing enrichment fields becomes a payload-key change in the pipeline with no ztmf migration. The core app works with or without an enrichment pipeline attached (an unfilled table simply returns 404s).

## Changes

- **Migration 0038** creates `public.system_enrichment (fisma_uuid VARCHAR(255) PK, payload jsonb NOT NULL, synced_at timestamptz)`. `fisma_uuid` has no FK, matching the existing `cfacts_systems` precedent (`fismasystems.fismauid` is `VARCHAR(255)` and not unique); the table is a disposable cache the pipeline rewrites via TRUNCATE+INSERT.
- **`GET /api/v1/systemenrichment/{fisma_uuid}`** returns the payload verbatim. Access control reuses the existing FISMA-system assignment check: admins / read-only admins see any system, ISSOs only assigned ones, missing rows return 404.
- `model.SystemEnrichment.Payload` is `json.RawMessage` so the payload serializes back out as raw JSON, not base64.
- OpenAPI path + `SystemEnrichment` schema, Emberfall E2E coverage, and one empire seed row.

## Scope / deferred

Additive only — **no cfacts files are touched**. Retiring the enrichment-specific (CFACTS) read surface and dropping `cfacts_systems` is deferred until the UI repoints to this endpoint and the old sync is decommissioned, so this is safe to run alongside the current stack. Tracked under the enrichment-extraction epic.

## Deploy note

On merge/deploy to dev, migration 0038 applies on API startup and creates the table. This is intentionally sequenced ahead of the enrichment pipeline's first run against dev.

## Test plan

- [x] `go build` / `go vet` / `staticcheck` clean
- [x] model unit tests pass (incl. payload-serializes-as-JSON guard)
- [x] `make dev-setup` applies 0038; live curl returns 200 (admin), 404 (no row), 200 (assigned ISSO), 403 (unassigned ISSO)
- [x] `make test-full` passes (unit + Emberfall E2E), Failed: 0

Refs #211
