### PR TITLE
Fix local dev on Apple Silicon macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 # ZTMF Development Environment Makefile
 
+# Use bash (not the default /bin/sh, which on macOS is bash in POSIX mode and
+# treats `echo -n` as a literal argument, breaking JWT generation).
+SHELL := /bin/bash
+
 # Single source of truth for the local API port
 API_PORT ?= 8080
 
@@ -79,7 +83,8 @@ backend/compose-dev.yml:
 	@echo "    image: postgres:16.8" >> backend/compose-dev.yml
 	@echo "    env_file:" >> backend/compose-dev.yml
 	@echo "      - dev.compose.env" >> backend/compose-dev.yml
-	@echo "    network_mode: host" >> backend/compose-dev.yml
+	@echo "    ports:" >> backend/compose-dev.yml
+	@echo "      - \"54321:54321\"" >> backend/compose-dev.yml
 	@echo "    volumes:" >> backend/compose-dev.yml
 	@echo "      - postgres_data:/var/lib/postgresql/data" >> backend/compose-dev.yml
 	@echo "    command: -p 54321" >> backend/compose-dev.yml
@@ -96,7 +101,8 @@ backend/compose-dev.yml:
 	@echo "    command: [\"/usr/local/bin/ztmfapi\"]" >> backend/compose-dev.yml
 	@echo "    env_file:" >> backend/compose-dev.yml
 	@echo "      - dev.compose.env" >> backend/compose-dev.yml
-	@echo "    network_mode: host" >> backend/compose-dev.yml
+	@echo "    ports:" >> backend/compose-dev.yml
+	@echo "      - \"$(API_PORT):$(API_PORT)\"" >> backend/compose-dev.yml
 	@echo "    volumes:" >> backend/compose-dev.yml
 	@echo "      - ./_test_data_empire.sql:/app/_test_data_empire.sql:ro" >> backend/compose-dev.yml
 	@echo "    depends_on:" >> backend/compose-dev.yml
@@ -120,7 +126,7 @@ backend/dev.compose.env:
 	@echo "POSTGRES_PASSWORD=localdevpassword" >> backend/dev.compose.env
 	@echo "" >> backend/dev.compose.env
 	@echo "# for api container" >> backend/dev.compose.env
-	@echo "DB_ENDPOINT=localhost" >> backend/dev.compose.env
+	@echo "DB_ENDPOINT=postgre" >> backend/dev.compose.env
 	@echo "DB_PORT=54321" >> backend/dev.compose.env
 	@echo "DB_NAME=ztmf" >> backend/dev.compose.env
 	@echo "DB_USER=admin" >> backend/dev.compose.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,13 +13,9 @@ COPY ./internal/ /src/internal/
 
 RUN go build -o ./ ./cmd/api/...
 
-FROM scratch
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /src
 
 COPY --from=builder /src/api /usr/local/bin/ztmfapi
 COPY --from=builder /src/*.pem /src/
-COPY --from=builder /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libc.so.6 /usr/lib/x86_64-linux-gnu/libc.so.6
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-COPY --from=builder /etc/ca-certificates.conf /etc/ca-certificates.conf


### PR DESCRIPTION
## Summary

Three small, independent fixes that together make `make full-stack-up` work on Apple Silicon macOS out of the box. Each one addresses a Mac-specific quirk; none change behavior on Linux.

- **`backend/Dockerfile`** — `FROM scratch` → `FROM gcr.io/distroless/base-debian12`, and drop the hardcoded `x86_64-linux-gnu` libc/ld COPY lines. Distroless ships the right libc/ld/ca-certs for whichever arch the build runs on, so the build is now arch-agnostic and runs native-fast on both arm64 and amd64.
- **`Makefile` (compose-dev.yml + dev.compose.env generators)** — replace `network_mode: host` with explicit `ports:` mappings (`54321:54321` for postgres, `$(API_PORT):$(API_PORT)` for api) and change `DB_ENDPOINT=localhost` → `DB_ENDPOINT=postgre`. Docker Desktop on macOS runs containers inside a Linux VM, where `network_mode: host` binds to the VM, not the Mac, unless the experimental host-networking toggle is enabled. Port mappings behave the same on every platform.
- **`Makefile` (top)** — add `SHELL := /bin/bash`. The default `/bin/sh` on macOS is bash invoked in POSIX mode, where the `echo` builtin prints `-n` literally instead of suppressing the trailing newline. That corrupted every base64-encoded segment in `generate-jwt` and `frontend-env`, producing tokens the API rejected with 401.

## Symptom before this PR (Apple Silicon)

```
=> ERROR [stage-1 4/7] COPY --from=builder /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 ...
=> ERROR [stage-1 5/7] COPY --from=builder /usr/lib/x86_64-linux-gnu/libc.so.6 ...
failed to compute cache key: ... "/usr/lib/x86_64-linux-gnu/libc.so.6": not found
```

After patching the Dockerfile, the build succeeds but `curl localhost:8080` returns connection-refused (host networking issue), and once port mappings are in place, the JWT from `make frontend-env` decodes to `-n {"alg":"HS256"}\n...` and the API returns 401.

## Test plan

- [x] `make dev-down && rm backend/compose-dev.yml backend/dev.compose.env`
- [x] `make full-stack-up` on Apple Silicon (arm64) — backend container builds natively, both containers come up healthy
- [x] `curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: $VITE_AUTH_TOKEN3" http://localhost:8080/api/v1/users/current` → `200` with the seeded admin user
- [x] Frontend (`vite`) loads in browser and can hit the API
- [x] Verify on Linux that the same flow still works (echo behavior on dash differs but `SHELL := /bin/bash` is widely available; port-mapping change is platform-neutral)