### PR TITLE
fix(#309): accept non-UUID system IDs and case-insensitive CFACTS matching

### DIFF
--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -121,7 +121,7 @@ func UserCanAccessFismaSystemByUUID(ctx context.Context, userID string, fismaUUI
 		Select("1").
 		From("users_fismasystems").
 		InnerJoin("fismasystems ON fismasystems.fismasystemid = users_fismasystems.fismasystemid").
-		Where("fismasystems.fismauid = ? AND users_fismasystems.userid = ?", fismaUUID, userID).
+		Where("LOWER(fismasystems.fismauid) = LOWER(?) AND users_fismasystems.userid = ?", fismaUUID, userID).
 		Limit(1)
 
 	_, err := queryRow(ctx, sqlb, pgx.RowTo[int])
@@ -370,8 +370,8 @@ func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSy
 func (f *FismaSystem) validate() error {
 	err := InvalidInputError{data: map[string]any{}}
 
-	if !isValidUUID(f.FismaUID) {
-		err.data["fismauid"] = f.FismaUID
+	if f.FismaUID == "" {
+		err.data["fismauid"] = "required"
 	}
 
 	if f.DataCallContact != nil && !isValidEmail(*f.DataCallContact) {

--- a/backend/internal/model/fismasystems_test.go
+++ b/backend/internal/model/fismasystems_test.go
@@ -162,9 +162,9 @@ func TestFismaSystem_Validate(t *testing.T) {
 		description string
 	}{
 		{
-			name: "ValidSystem",
+			name: "ValidSystemUUID",
 			system: FismaSystem{
-				FismaUID:              "12345678-1234-4abc-8def-123456789abc", // Valid UUID v4
+				FismaUID:              "12345678-1234-4abc-8def-123456789abc",
 				FismaAcronym:          "TEST",
 				FismaName:             "Test System",
 				DataCenterEnvironment: stringPtr("AWS"),
@@ -172,12 +172,25 @@ func TestFismaSystem_Validate(t *testing.T) {
 				ISSOEmail:             stringPtr("isso@example.com"),
 			},
 			wantErr:     false,
-			description: "A valid FISMA system should not return an error",
+			description: "A FISMA system with a UUID fismauid should not return an error",
+		},
+		{
+			name: "ValidSystemNonUUID",
+			system: FismaSystem{
+				FismaUID:              "CDC8767221",
+				FismaAcronym:          "CDC",
+				FismaName:             "CDC Test System",
+				DataCenterEnvironment: stringPtr("AWS"),
+				DataCallContact:       stringPtr("test@example.com"),
+				ISSOEmail:             stringPtr("isso@example.com"),
+			},
+			wantErr:     false,
+			description: "A FISMA system with a non-UUID fismauid (e.g. CDC-style) should not return an error",
 		},
 		{
 			name: "InvalidEmail",
 			system: FismaSystem{
-				FismaUID:              "12345678-1234-1234-1234-123456789abc",
+				FismaUID:              "CDC8767221",
 				FismaAcronym:          "TEST",
 				FismaName:             "Test System",
 				DataCenterEnvironment: stringPtr("AWS"),
@@ -188,9 +201,9 @@ func TestFismaSystem_Validate(t *testing.T) {
 			description: "Invalid email should return validation error",
 		},
 		{
-			name: "InvalidUUID",
+			name: "EmptyFismaUID",
 			system: FismaSystem{
-				FismaUID:              "not-a-uuid",
+				FismaUID:              "",
 				FismaAcronym:          "TEST",
 				FismaName:             "Test System",
 				DataCenterEnvironment: stringPtr("AWS"),
@@ -198,7 +211,7 @@ func TestFismaSystem_Validate(t *testing.T) {
 				ISSOEmail:             stringPtr("isso@example.com"),
 			},
 			wantErr:     true,
-			description: "Invalid UUID should return validation error",
+			description: "Empty fismauid should return validation error",
 		},
 	}
 


### PR DESCRIPTION
Closes #309

> **Note:** Rebased onto latest `main` after #326 landed (which retired the legacy CFACTS read surface and deleted `cfactssystems.go`). The original `cfactssystems.go` hunks were dropped as part of that rebase — the case-insensitive matching now lives in `UserCanAccessFismaSystemByUUID`, where the old `UserCanAccessCfactsSystem` access check was relocated.

## Summary

- Relaxed `fismauid` validation in `FismaSystem.validate()` to require only a non-empty string instead of a valid UUID. Some HHS OpDiv system IDs (e.g. `CDC8767221`) are not GUIDs and were being rejected with a 400. This is the core #309 fix — the gate that blocks creating a CDC-style system.
- Made the access-check `WHERE` clause in `UserCanAccessFismaSystemByUUID` (`fismasystems.go`) case-insensitive using `LOWER()`. Defensive future-proofing so non-GUID OpDiv IDs match regardless of case once system enrichment opens beyond CMS.
- Updated `fismasystems_test.go`: replaced the `InvalidUUID` test case with `ValidSystemNonUUID` (CDC-style ID should pass) and `EmptyFismaUID` (empty string should still fail).

## Testing

Go unit tests pass (run in a `golang:1.25` container — `go test -short ./...`):
```
--- PASS: TestFismaSystem_Validate/ValidSystemUUID
--- PASS: TestFismaSystem_Validate/ValidSystemNonUUID
--- PASS: TestFismaSystem_Validate/InvalidEmail
--- PASS: TestFismaSystem_Validate/EmptyFismaUID
ok  github.com/CMS-Enterprise/ztmf/backend/internal/model  0.003s
```
Full `go test -short ./...` suite is green; `go build ./...` and `go vet ./internal/model/` clean.

> Snyk / secret-dependent CI checks show red because this branch is from a fork (no repo secrets) — expected, maintainers re-run on their side.
