### PR TITLE
feat(#314): remove legacy ADMIN / READONLY_ADMIN role values

### DIFF
--- a/backend/_test_data.sql
+++ b/backend/_test_data.sql
@@ -4,10 +4,10 @@
 -- new columns in the multi-OpDiv migration and the positional form would
 -- silently shift values across columns on future schema bumps.
 INSERT INTO public.users (email, fullname, role, identity_provider)
-    VALUES ('Test.User@nowhere.xyz', 'Admin User', 'ADMIN', 'okta')
+    VALUES ('Test.User@nowhere.xyz', 'Admin User', 'OWNER', 'okta')
     ON CONFLICT DO NOTHING;
 INSERT INTO public.users (email, fullname, role, identity_provider)
-    VALUES ('Readonly.Admin@nowhere.xyz', 'Readonly Admin User', 'READONLY_ADMIN', 'okta')
+    VALUES ('Readonly.Admin@nowhere.xyz', 'Readonly Admin User', 'HHS_READONLY_ADMIN', 'okta')
     ON CONFLICT DO NOTHING;
 INSERT INTO public.users (email, fullname, role, identity_provider)
     VALUES ('Isso.User@nowhere.xyz', 'ISSO Test User', 'ISSO', 'okta')

--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -13,12 +13,12 @@ INSERT INTO public.opdivs (code, name, is_parent, active)
 
 -- Test user for Emberfall E2E tests (matches _test_data.sql for CI/CD compatibility)
 INSERT INTO public.users (email, fullname, role, identity_provider)
-    VALUES ('Test.User@nowhere.xyz', 'Admin User', 'ADMIN', 'okta')
+    VALUES ('Test.User@nowhere.xyz', 'Admin User', 'OWNER', 'okta')
     ON CONFLICT DO NOTHING;
 
--- Test ADMIN User (Death Star Commander - full administrative access)
+-- Test OWNER User (Death Star Commander - full administrative access)
 INSERT INTO public.users (userid, email, fullname, role, identity_provider)
-    VALUES ('11111111-1111-1111-1111-111111111111', 'Grand.Moff@DeathStar.Empire', 'Grand Moff Tarkin', 'ADMIN', 'okta')
+    VALUES ('11111111-1111-1111-1111-111111111111', 'Grand.Moff@DeathStar.Empire', 'Grand Moff Tarkin', 'OWNER', 'okta')
     ON CONFLICT DO NOTHING;
 
 -- Test ISSO Users (Imperial Officers)
@@ -32,14 +32,14 @@ INSERT INTO public.users (userid, email, fullname, role, identity_provider)
     VALUES ('44444444-4444-4444-4444-444444444444', 'Director.Krennic@scarif.empire', 'Orson Krennic', 'ISSO', 'okta')
     ON CONFLICT DO NOTHING;
 
--- Test READONLY_ADMIN User (Emperor - can observe everything but not modify)
+-- Test HHS_READONLY_ADMIN User (Emperor - can observe everything but not modify)
 INSERT INTO public.users (userid, email, fullname, role, identity_provider)
-    VALUES ('55555555-5555-5555-5555-555555555555', 'Emperor.Palpatine@coruscant.empire', 'Emperor Palpatine', 'READONLY_ADMIN', 'okta')
+    VALUES ('55555555-5555-5555-5555-555555555555', 'Emperor.Palpatine@coruscant.empire', 'Emperor Palpatine', 'HHS_READONLY_ADMIN', 'okta')
     ON CONFLICT DO NOTHING;
 
--- Test READONLY_ADMIN for Emberfall E2E tests (matches _test_data.sql for CI/CD compatibility)
+-- Test HHS_READONLY_ADMIN for Emberfall E2E tests (matches _test_data.sql for CI/CD compatibility)
 INSERT INTO public.users (email, fullname, role, identity_provider)
-    VALUES ('Readonly.Admin@nowhere.xyz', 'Readonly Admin User', 'READONLY_ADMIN', 'okta')
+    VALUES ('Readonly.Admin@nowhere.xyz', 'Readonly Admin User', 'HHS_READONLY_ADMIN', 'okta')
     ON CONFLICT DO NOTHING;
 
 -- Test ISSO for Emberfall E2E tests (verifies ISSO role restrictions).

--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -39,11 +39,11 @@ func Middleware(next http.Handler) http.Handler {
 			user, err := model.FindUserByEmail(r.Context(), claims.Email)
 
 			if err != nil && cfg.Env == "local" {
-				log.Printf("Local dev: auto-creating ADMIN user for %s\n", claims.Email)
+				log.Printf("Local dev: auto-creating OWNER user for %s\n", claims.Email)
 				user = &model.User{
 					Email:    claims.Email,
 					FullName: claims.Name,
-					Role:     "ADMIN",
+					Role:     "OWNER",
 				}
 				if user.FullName == "" {
 					user.FullName = claims.Email

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -31,12 +31,12 @@ var (
 	adminUser = &model.User{
 		UserID: "11111111-1111-1111-1111-111111111111",
 		Email:  "admin@test.com",
-		Role:   "ADMIN",
+		Role:   "OWNER",
 	}
 	readonlyAdmin = &model.User{
 		UserID: "22222222-2222-2222-2222-222222222222",
 		Email:  "readonly@test.com",
-		Role:   "READONLY_ADMIN",
+		Role:   "HHS_READONLY_ADMIN",
 	}
 	issoUser = &model.User{
 		UserID: "33333333-3333-3333-3333-333333333333",
@@ -139,7 +139,7 @@ func TestListUsers_ReadonlyAdminAllowed(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	ListUsers(w, r)
-	// READONLY_ADMIN should get read access (not 403)
+	// HHS_READONLY_ADMIN should get read access (not 403)
 	assert.NotEqual(t, http.StatusForbidden, w.Code)
 }
 
@@ -191,11 +191,11 @@ func TestSaveScore_ReadonlyAdminForbidden(t *testing.T) {
 }
 
 func TestSaveScore_ReadonlyAdminForbiddenEvenIfAssigned(t *testing.T) {
-	// A READONLY_ADMIN assigned to a FISMA system should still be forbidden from saving
+	// An HHS_READONLY_ADMIN assigned to a FISMA system should still be forbidden from saving
 	assignedReadonly := &model.User{
 		UserID:               "22222222-2222-2222-2222-222222222222",
 		Email:                "readonly@test.com",
-		Role:                 "READONLY_ADMIN",
+		Role:                 "HHS_READONLY_ADMIN",
 		AssignedFismaSystems: []*int32{int32Ptr(1)},
 	}
 	body := jsonBody(t, map[string]any{
@@ -266,7 +266,7 @@ func TestSaveDataCallFismaSystem_ReadonlyAdminForbiddenEvenIfAssigned(t *testing
 	assignedReadonly := &model.User{
 		UserID:               "22222222-2222-2222-2222-222222222222",
 		Email:                "readonly@test.com",
-		Role:                 "READONLY_ADMIN",
+		Role:                 "HHS_READONLY_ADMIN",
 		AssignedFismaSystems: []*int32{int32Ptr(1)},
 	}
 	r := httptest.NewRequest("PUT", "/api/v1/datacalls/1/fismasystems/1", nil)

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -22,8 +22,8 @@ func ListFismaSystems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Scope predicate by role tier:
-	//   - Unscoped admins (OWNER / HHS_* / legacy ADMIN/READONLY_ADMIN
-	//     through Stage D) see every system, no filter.
+	//   - Unscoped admins (OWNER / HHS_ADMIN / HHS_READONLY_ADMIN) see every
+	//     system, no filter.
 	//   - OPDIV_ADMIN / OPDIV_READONLY_ADMIN see every system in the OpDivs
 	//     they hold a grant for (users_opdivs). RestrictToOpDivIDs is set
 	//     unconditionally so a user with zero grants fails closed (returns

--- a/backend/cmd/api/internal/migrations/0040rolecleanup.go
+++ b/backend/cmd/api/internal/migrations/0040rolecleanup.go
@@ -1,0 +1,33 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"Stage D: reject legacy ADMIN / READONLY_ADMIN role values",
+		`
+-- Stage D role cleanup. The Stage B swap (0036usersroleswap.go) already
+-- mapped ADMIN -> OWNER and READONLY_ADMIN -> HHS_READONLY_ADMIN, and the app
+-- no longer recognizes the legacy values (see internal/model/validations.go
+-- and users.go). This guard rejects any new write that carries a legacy value,
+-- as defense in depth against a stale client or a botched rollback re-seeding
+-- the old strings.
+--
+-- Pre-flight expectation: zero rows carry a legacy value at the moment this
+-- runs (SELECT count(*) FROM users WHERE role IN ('ADMIN','READONLY_ADMIN')
+-- returns 0). The Stage B swap emptied them, so a plain ADD CONSTRAINT
+-- validates against existing rows without a separate NOT VALID / VALIDATE
+-- pass. If a stray legacy row survived, this ALTER fails loudly rather than
+-- silently accepting bad data, which is the behavior we want.
+ALTER TABLE public.users
+    ADD CONSTRAINT users_role_no_legacy
+    CHECK (role NOT IN ('ADMIN', 'READONLY_ADMIN'));
+		`,
+		`
+-- Rollback drops the guard so the prior release (whose validation map and role
+-- helpers still recognize ADMIN / READONLY_ADMIN) can write those values again
+-- during the soak window. Schema-only: the legacy values live in the app's
+-- validation map and helpers, which are restored by redeploying the prior
+-- binary alongside this down migration.
+ALTER TABLE public.users
+    DROP CONSTRAINT IF EXISTS users_role_no_legacy;
+		`)
+}

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -164,7 +164,7 @@ tests:
         json:
           data:
             email: "Test.User@nowhere.xyz"
-            role: "ADMIN"
+            role: "OWNER"
             identity_provider: "okta"
 
   # OpDivs Endpoint - reference list used by frontend selectors
@@ -641,7 +641,7 @@ tests:
         content-type: "application/json"
   
   # list users with correct role should return a list of users
-  - url: http://localhost:8080/api/v1/users?role=ADMIN
+  - url: http://localhost:8080/api/v1/users?role=OWNER
     method: GET
     headers:
       <<: *commonHeaders
@@ -764,7 +764,7 @@ tests:
   # with the listed values; unlisted keys (scoreid, last_edited_at,
   # datecalculated) are ignored. Same pattern as createUser above.
   #
-  # commonHeaders maps to test.user@nowhere.xyz (the ADMIN fixture); the
+  # commonHeaders maps to test.user@nowhere.xyz (the OWNER fixture); the
   # ISSO scope block below uses Isso.User@nowhere.xyz via issoHeaders.
   # Both saves target datacallid=3 ("Audit Fields Smoke Cycle"), seeded in
   # _test_data_empire.sql with deadline 2099-12-31 so validate() does not
@@ -801,7 +801,7 @@ tests:
             notes: "Audit field smoke - created by Emberfall"
             last_edited_by:
               email: "Test.User@nowhere.xyz"
-              role: "ADMIN"
+              role: "OWNER"
 
   # GET the score list back through the same lateral-join path. Array
   # response so no body.json assertion (aquia-inc/emberfall#36); status +
@@ -1026,8 +1026,8 @@ tests:
             body: null
             group: "ADNIM"
 
-  # READONLY_ADMIN Tests
-  # Verify READONLY_ADMIN can authenticate
+  # HHS_READONLY_ADMIN Tests
+  # Verify HHS_READONLY_ADMIN can authenticate
   - url: http://localhost:8080/api/v1/users/current
     method: GET
     headers:
@@ -1040,9 +1040,9 @@ tests:
         json:
           data:
             email: "Readonly.Admin@nowhere.xyz"
-            role: "READONLY_ADMIN"
+            role: "HHS_READONLY_ADMIN"
 
-  # READONLY_ADMIN can GET /api/v1/users (read access)
+  # HHS_READONLY_ADMIN can GET /api/v1/users (read access)
   - url: http://localhost:8080/api/v1/users
     method: GET
     headers:
@@ -1052,7 +1052,7 @@ tests:
       headers:
         content-type: "application/json"
 
-  # READONLY_ADMIN can GET /api/v1/fismasystems (read access)
+  # HHS_READONLY_ADMIN can GET /api/v1/fismasystems (read access)
   - url: http://localhost:8080/api/v1/fismasystems
     method: GET
     headers:
@@ -1062,7 +1062,7 @@ tests:
       headers:
         content-type: "application/json"
 
-  # READONLY_ADMIN gets 403 on POST /api/v1/users (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on POST /api/v1/users (write blocked)
   - url: http://localhost:8080/api/v1/users
     method: POST
     headers:
@@ -1076,7 +1076,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on POST /api/v1/fismasystems (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on POST /api/v1/fismasystems (write blocked)
   - url: http://localhost:8080/api/v1/fismasystems
     method: POST
     headers:
@@ -1088,7 +1088,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on POST /api/v1/datacalls (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on POST /api/v1/datacalls (write blocked)
   - url: http://localhost:8080/api/v1/datacalls
     method: POST
     headers:
@@ -1100,7 +1100,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on POST /api/v1/questions (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on POST /api/v1/questions (write blocked)
   - url: http://localhost:8080/api/v1/questions
     method: POST
     headers:
@@ -1112,7 +1112,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on POST /api/v1/functions (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on POST /api/v1/functions (write blocked)
   - url: http://localhost:8080/api/v1/functions
     method: POST
     headers:
@@ -1139,7 +1139,7 @@ tests:
     expect:
       status: 400
 
-  # READONLY_ADMIN gets 403 on POST /api/v1/scores (write blocked - key fix)
+  # HHS_READONLY_ADMIN gets 403 on POST /api/v1/scores (write blocked - key fix)
   - url: http://localhost:8080/api/v1/scores
     method: POST
     headers:
@@ -1154,7 +1154,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on PUT datacalls/{id}/fismasystems/{id} (write blocked - key fix)
+  # HHS_READONLY_ADMIN gets 403 on PUT datacalls/{id}/fismasystems/{id} (write blocked - key fix)
   - url: "http://localhost:8080/api/v1/datacalls/{{.createDataCall.Response.data.datacallid}}/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}"
     method: PUT
     headers:
@@ -1162,7 +1162,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on DELETE /api/v1/users (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on DELETE /api/v1/users (write blocked)
   - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
     method: DELETE
     headers:
@@ -1170,7 +1170,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on DELETE /api/v1/fismasystems (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on DELETE /api/v1/fismasystems (write blocked)
   - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}"
     method: DELETE
     headers:
@@ -1182,7 +1182,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on PUT /api/v1/users/{id}/restore (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on PUT /api/v1/users/{id}/restore (write blocked)
   - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}/restore"
     method: PUT
     headers:
@@ -1190,7 +1190,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on PUT /api/v1/fismasystems/{id}/reactivate (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on PUT /api/v1/fismasystems/{id}/reactivate (write blocked)
   - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}/reactivate"
     method: PUT
     headers:
@@ -1202,7 +1202,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN gets 403 on POST /api/v1/massemails (write blocked)
+  # HHS_READONLY_ADMIN gets 403 on POST /api/v1/massemails (write blocked)
   - url: http://localhost:8080/api/v1/massemails
     method: POST
     headers:
@@ -1216,7 +1216,7 @@ tests:
     expect:
       status: 403
 
-  # READONLY_ADMIN can GET /api/v1/scores (read access)
+  # HHS_READONLY_ADMIN can GET /api/v1/scores (read access)
   - url: http://localhost:8080/api/v1/scores
     method: GET
     headers:
@@ -1226,7 +1226,7 @@ tests:
       headers:
         content-type: "application/json"
 
-  # READONLY_ADMIN can GET /api/v1/scores/aggregate (read access)
+  # HHS_READONLY_ADMIN can GET /api/v1/scores/aggregate (read access)
   - url: http://localhost:8080/api/v1/scores/aggregate
     method: GET
     headers:
@@ -1236,7 +1236,7 @@ tests:
       headers:
         content-type: "application/json"
 
-  # READONLY_ADMIN can GET /api/v1/datacalls (read access)
+  # HHS_READONLY_ADMIN can GET /api/v1/datacalls (read access)
   - url: http://localhost:8080/api/v1/datacalls
     method: GET
     headers:
@@ -1246,7 +1246,7 @@ tests:
       headers:
         content-type: "application/json"
 
-  # READONLY_ADMIN can GET /api/v1/events (read access)
+  # HHS_READONLY_ADMIN can GET /api/v1/events (read access)
   - url: http://localhost:8080/api/v1/events
     method: GET
     headers:
@@ -1256,8 +1256,8 @@ tests:
       headers:
         content-type: "application/json"
 
-  # READONLY_ADMIN can GET /api/v1/systemenrichment/<uuid> (read access; bypasses the
-  # per-system assignment check via HasAdminRead, same branch as ADMIN).
+  # HHS_READONLY_ADMIN can GET /api/v1/systemenrichment/<uuid> (read access; bypasses the
+  # per-system assignment check via HasAdminRead, same branch as the admin tiers).
   - url: http://localhost:8080/api/v1/systemenrichment/E1D00198-36D4-4EAB-8C00-501E1D000999
     method: GET
     headers:

--- a/backend/internal/model/events_test.go
+++ b/backend/internal/model/events_test.go
@@ -19,7 +19,7 @@ func TestUserToContext_RoundTrip(t *testing.T) {
 		UserID:   "test-id",
 		Email:    "test@example.com",
 		FullName: "Test User",
-		Role:     "ADMIN",
+		Role:     "OWNER",
 	}
 
 	ctx = UserToContext(ctx, original)
@@ -34,13 +34,13 @@ func TestUserToContext_RoundTrip(t *testing.T) {
 func TestUserToContext_Overwrite(t *testing.T) {
 	ctx := context.Background()
 
-	first := &User{UserID: "first", Role: "ADMIN"}
+	first := &User{UserID: "first", Role: "OWNER"}
 	ctx = UserToContext(ctx, first)
 
-	second := &User{UserID: "second", Role: "READONLY_ADMIN"}
+	second := &User{UserID: "second", Role: "HHS_READONLY_ADMIN"}
 	ctx = UserToContext(ctx, second)
 
 	retrieved := UserFromContext(ctx)
 	assert.Equal(t, "second", retrieved.UserID)
-	assert.Equal(t, "READONLY_ADMIN", retrieved.Role)
+	assert.Equal(t, "HHS_READONLY_ADMIN", retrieved.Role)
 }

--- a/backend/internal/model/massemails.go
+++ b/backend/internal/model/massemails.go
@@ -115,8 +115,9 @@ func sqlForADMIN() squirrel.SelectBuilder {
 	// "ADMIN" recipient group spans every admin tier in the multi-OpDiv role
 	// taxonomy. Read-only admin tiers are intentionally excluded for parity
 	// with the pre-multi-OpDiv behavior (which emailed only ADMIN, not
-	// READONLY_ADMIN). Legacy ADMIN stays in the list as a transition
-	// fallback until Stage D removes it from the role enum entirely.
+	// READONLY_ADMIN). The "ADMIN" key in massEmailGroups is an audience
+	// selector in the API contract, not a user role; the legacy ADMIN role
+	// value was removed from the role enum in Stage D.
 	return stmntBuilder.
 		Select("email").
 		From("users").
@@ -124,7 +125,6 @@ func sqlForADMIN() squirrel.SelectBuilder {
 			"OWNER",
 			"HHS_ADMIN",
 			"OPDIV_ADMIN",
-			"ADMIN",
 		}})
 }
 

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -247,7 +247,7 @@ func TestScoreSaveValidationIntegration(t *testing.T) {
 		}
 		adminCtx := UserToContext(ctx, &User{
 			UserID: "00000000-0000-4000-8000-000000000000",
-			Role:   "ADMIN",
+			Role:   "OWNER",
 		})
 		// Admin bypasses the deadline guard. The save itself may fail
 		// for unrelated reasons (FK violation if system 1 / option 1
@@ -439,7 +439,7 @@ func TestScoreSaveStampsAuditFieldsIntegration(t *testing.T) {
 		UserID:   "11111111-1111-1111-1111-111111111111",
 		Email:    "Grand.Moff@DeathStar.Empire",
 		FullName: "Grand Moff Tarkin",
-		Role:     "ADMIN",
+		Role:     "OWNER",
 	})
 
 	before := time.Now().UTC()
@@ -459,7 +459,7 @@ func TestScoreSaveStampsAuditFieldsIntegration(t *testing.T) {
 	assert.Equal(t, "11111111-1111-1111-1111-111111111111", saved.LastEditedBy.UserID)
 	assert.Equal(t, "Grand Moff Tarkin", saved.LastEditedBy.Name)
 	assert.Equal(t, "Grand.Moff@DeathStar.Empire", saved.LastEditedBy.Email)
-	assert.Equal(t, "ADMIN", saved.LastEditedBy.Role)
+	assert.Equal(t, "OWNER", saved.LastEditedBy.Role)
 }
 
 // TestFindScoresIncludesAuditFieldsIntegration verifies the read-side
@@ -601,7 +601,7 @@ func TestScoreSaveNoOpPreservesPriorEditorIntegration(t *testing.T) {
 		UserID:   "11111111-1111-1111-1111-111111111111",
 		Email:    "Grand.Moff@DeathStar.Empire",
 		FullName: "Grand Moff Tarkin",
-		Role:     "ADMIN",
+		Role:     "OWNER",
 	})
 	resave := &Score{
 		ScoreID:          scoreID,

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -281,7 +281,7 @@ func TestScoreAuditInfo(t *testing.T) {
 			UserID: "11111111-1111-1111-1111-111111111111",
 			Name:   "Grand Moff Tarkin",
 			Email:  "Grand.Moff@DeathStar.Empire",
-			Role:   "ADMIN",
+			Role:   "OWNER",
 		}
 		s := &Score{LastEditedAt: &ts, LastEditedBy: ref}
 
@@ -404,8 +404,8 @@ func TestDerefString(t *testing.T) {
 		assert.Equal(t, "", derefString(nil))
 	})
 	t.Run("Value", func(t *testing.T) {
-		v := "ADMIN"
-		assert.Equal(t, "ADMIN", derefString(&v))
+		v := "OWNER"
+		assert.Equal(t, "OWNER", derefString(&v))
 	})
 	t.Run("EmptyStringPointer", func(t *testing.T) {
 		v := ""

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -20,11 +20,11 @@ type User struct {
 	AssignedOpDivIDs     []*int32 `json:"assignedopdivids" db:"assignedopdivids"`
 }
 
-// Role helpers. The multi-OpDiv migration kept the legacy ADMIN /
-// READONLY_ADMIN values valid during transition (removed in Stage D), so the
-// checks below match both the new tier names and the legacy values. Callers
-// gate access with IsAdmin / HasAdminRead at the top of a controller, then
-// the query layer narrows by OpDiv scope using the helpers further down.
+// Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
+// READONLY_ADMIN values were removed in Stage D, so the checks below only
+// match the new tier names. Callers gate access with IsAdmin / HasAdminRead at
+// the top of a controller, then the query layer narrows by OpDiv scope using
+// the helpers further down.
 
 func (u *User) IsOwner() bool { return u.Role == "OWNER" }
 
@@ -46,13 +46,10 @@ func (u *User) IsOpDivTier() bool {
 
 // HasUnscopedRead is true for tiers that see across every OpDiv without an
 // OpDiv predicate (OWNER, HHS_ADMIN, HHS_READONLY_ADMIN). OpDiv-scoped admins
-// and system-scoped users do not get unscoped reads. Legacy ADMIN and
-// READONLY_ADMIN are treated as unscoped for back-compat through Stage D
-// (they map to the unscoped tiers when their owners log in, and the test
-// fixtures still hardcode role='ADMIN' on the auto-created E2E user).
+// and system-scoped users do not get unscoped reads.
 func (u *User) HasUnscopedRead() bool {
 	switch u.Role {
-	case "OWNER", "HHS_ADMIN", "HHS_READONLY_ADMIN", "ADMIN", "READONLY_ADMIN":
+	case "OWNER", "HHS_ADMIN", "HHS_READONLY_ADMIN":
 		return true
 	}
 	return false
@@ -77,22 +74,22 @@ func (u *User) CanAccessFismaSystem(opdivID *int32, fismasystemID int32) bool {
 	return u.IsAssignedFismaSystem(fismasystemID)
 }
 
-// IsAdmin returns true for any tier that historically had write access to
-// admin endpoints. Spans the new admin tiers (OWNER, HHS_ADMIN, OPDIV_ADMIN)
-// plus legacy ADMIN. Read-only tiers do not count as admins.
+// IsAdmin returns true for any tier that has write access to admin endpoints:
+// the admin tiers OWNER, HHS_ADMIN, and OPDIV_ADMIN. Read-only tiers do not
+// count as admins.
 func (u *User) IsAdmin() bool {
 	switch u.Role {
-	case "OWNER", "HHS_ADMIN", "OPDIV_ADMIN", "ADMIN":
+	case "OWNER", "HHS_ADMIN", "OPDIV_ADMIN":
 		return true
 	}
 	return false
 }
 
 // IsReadOnlyAdmin returns true for the read-only counterparts of the admin
-// tiers, plus the legacy READONLY_ADMIN.
+// tiers (HHS_READONLY_ADMIN, OPDIV_READONLY_ADMIN).
 func (u *User) IsReadOnlyAdmin() bool {
 	switch u.Role {
-	case "HHS_READONLY_ADMIN", "OPDIV_READONLY_ADMIN", "READONLY_ADMIN":
+	case "HHS_READONLY_ADMIN", "OPDIV_READONLY_ADMIN":
 		return true
 	}
 	return false

--- a/backend/internal/model/users_test.go
+++ b/backend/internal/model/users_test.go
@@ -29,9 +29,9 @@ var roleMatrix = []roleMatrixRow{
 	{role: "HHS_READONLY_ADMIN", isHHSTier: true, hasUnscopedRead: true, isReadOnlyAdmin: true, hasAdminRead: true},
 	{role: "OPDIV_ADMIN", isOpDivTier: true, isAdmin: true, hasAdminRead: true},
 	{role: "OPDIV_READONLY_ADMIN", isOpDivTier: true, isReadOnlyAdmin: true, hasAdminRead: true},
-	// Legacy values retained through Stage D
-	{role: "ADMIN", hasUnscopedRead: true, isAdmin: true, hasAdminRead: true},
-	{role: "READONLY_ADMIN", hasUnscopedRead: true, isReadOnlyAdmin: true, hasAdminRead: true},
+	// Legacy values removed in Stage D - no helper recognizes them anymore.
+	{role: "ADMIN"},
+	{role: "READONLY_ADMIN"},
 	// System-scoped tiers (unchanged)
 	{role: "ISSO"},
 	{role: "ISSM"},
@@ -100,8 +100,8 @@ func TestUser_CanAccessFismaSystem(t *testing.T) {
 		{"OWNER sees everything", withGrants("OWNER", nil, nil), &opdivCDC, system101, true},
 		{"HHS_ADMIN sees everything", withGrants("HHS_ADMIN", nil, nil), &opdivCDC, system101, true},
 		{"HHS_READONLY_ADMIN sees everything", withGrants("HHS_READONLY_ADMIN", nil, nil), &opdivCDC, system101, true},
-		{"legacy ADMIN sees everything (Stage D pending)", withGrants("ADMIN", nil, nil), &opdivCDC, system101, true},
-		{"legacy READONLY_ADMIN sees everything (Stage D pending)", withGrants("READONLY_ADMIN", nil, nil), &opdivCDC, system101, true},
+		{"legacy ADMIN no longer sees everything (removed in Stage D)", withGrants("ADMIN", nil, nil), &opdivCDC, system101, false},
+		{"legacy READONLY_ADMIN no longer sees everything (removed in Stage D)", withGrants("READONLY_ADMIN", nil, nil), &opdivCDC, system101, false},
 
 		{"OPDIV_ADMIN with matching OpDiv grant", withGrants("OPDIV_ADMIN", []int32{opdivCMS}, nil), &opdivCMS, system101, true},
 		{"OPDIV_ADMIN with non-matching OpDiv grant", withGrants("OPDIV_ADMIN", []int32{opdivCMS}, nil), &opdivCDC, system101, false},
@@ -161,13 +161,13 @@ func TestUser_Validate(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "valid ADMIN",
-			user:    User{Email: "test@example.com", Role: "ADMIN"},
+			name:    "valid OWNER",
+			user:    User{Email: "test@example.com", Role: "OWNER"},
 			wantErr: false,
 		},
 		{
-			name:    "valid READONLY_ADMIN",
-			user:    User{Email: "test@example.com", Role: "READONLY_ADMIN"},
+			name:    "valid HHS_READONLY_ADMIN",
+			user:    User{Email: "test@example.com", Role: "HHS_READONLY_ADMIN"},
 			wantErr: false,
 		},
 		{
@@ -181,8 +181,13 @@ func TestUser_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "legacy ADMIN is now invalid",
+			user:    User{Email: "test@example.com", Role: "ADMIN"},
+			wantErr: true,
+		},
+		{
 			name:    "invalid email",
-			user:    User{Email: "not-an-email", Role: "ADMIN"},
+			user:    User{Email: "not-an-email", Role: "OWNER"},
 			wantErr: true,
 		},
 	}

--- a/backend/internal/model/validations.go
+++ b/backend/internal/model/validations.go
@@ -8,37 +8,11 @@ import (
 // use of map enables O(1) vs O(N) as would be the case with slices.Contains([]string)
 // it also avoids the complexity of using constants as enums
 //
-// New multi-OpDiv role constants live alongside the legacy ADMIN /
-// READONLY_ADMIN values during the Stage B -> Stage C transition. The legacy
-// values stay valid so controllers that still recognize them keep working
-// until Stage C flips the predicate logic. Stage D removes ADMIN and
-// READONLY_ADMIN from this map.
-//
-// Stage D removal checklist (touch every item before dropping the legacy
-// keys below, otherwise tests and authn flows break):
-//
-//  1. THIS FILE: remove the two trailing map entries below.
-//  2. backend/internal/model/users.go: drop "ADMIN" / "READONLY_ADMIN" from
-//     HasUnscopedRead, IsAdmin, IsReadOnlyAdmin (5 references total).
-//  3. backend/cmd/api/internal/auth/middleware.go: local-dev auto-create
-//     uses Role: "ADMIN". Change to "OWNER" (or whatever the equivalent
-//     unscoped-write tier is at that time).
-//  4. backend/_test_data.sql: change role='ADMIN' / 'READONLY_ADMIN' rows
-//     to the new tier names.
-//  5. backend/_test_data_empire.sql: same.
-//  6. backend/emberfall_tests.yml: GET /users/current expects role='ADMIN'
-//     for the Test.User fixture. Update to match the new value.
-//  7. backend/internal/model/validations_test.go: TestIsValidRole asserts
-//     the two legacy roles are still valid. Flip those assertions to
-//     false and update the comment block.
-//  8. backend/openapi.yaml: User schema role enum drops ADMIN and
-//     READONLY_ADMIN; update the description that mentions them.
-//  9. Prod data: confirm zero rows still carry the legacy values
-//     (SELECT count(*) FROM users WHERE role IN ('ADMIN','READONLY_ADMIN'))
-//     before this migration runs. The Stage B swap should have already
-//     emptied these, but verify.
-// 10. Stage D migration file (0037rolecleanup.go) should add a CHECK
-//     constraint or DB-level guard rejecting legacy values post-cleanup.
+// This is the multi-OpDiv role taxonomy. The legacy ADMIN / READONLY_ADMIN
+// values were removed in Stage D (see migration 0040rolecleanup.go), which
+// also added a CHECK constraint rejecting any new write that carries a legacy
+// value. The Stage B swap (0036usersroleswap.go) mapped ADMIN -> OWNER and
+// READONLY_ADMIN -> HHS_READONLY_ADMIN before this cleanup landed.
 var roles = map[string]interface{}{
 	"OWNER":                nil, // platform / dev team, unscoped across OpDivs
 	"HHS_ADMIN":            nil, // department tier, all OpDivs
@@ -47,8 +21,6 @@ var roles = map[string]interface{}{
 	"OPDIV_READONLY_ADMIN": nil, // single-OpDiv read-only, scoped via users_opdivs
 	"ISSO":                 nil, // system-scoped via users_fismasystems
 	"ISSM":                 nil, // system-scoped via users_fismasystems
-	"ADMIN":                nil, // legacy; removed in Stage D
-	"READONLY_ADMIN":       nil, // legacy; removed in Stage D
 }
 
 var datacenterenvironments = map[string]interface{}{

--- a/backend/internal/model/validations_test.go
+++ b/backend/internal/model/validations_test.go
@@ -19,9 +19,9 @@ func TestIsValidRole(t *testing.T) {
 		{"OPDIV_ADMIN is valid", "OPDIV_ADMIN", true},
 		{"OPDIV_READONLY_ADMIN is valid", "OPDIV_READONLY_ADMIN", true},
 
-		// Legacy roles retained through transition; Stage D removes them.
-		{"ADMIN is valid", "ADMIN", true},
-		{"READONLY_ADMIN is valid", "READONLY_ADMIN", true},
+		// Legacy roles removed in Stage D; now rejected.
+		{"legacy ADMIN is invalid", "ADMIN", false},
+		{"legacy READONLY_ADMIN is invalid", "READONLY_ADMIN", false},
 
 		// System-scoped roles, unchanged across the transition.
 		{"ISSO is valid", "ISSO", true},

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1167,7 +1167,7 @@ paths:
   /events:
     get:
       summary: Get events
-      description: Returns the audit trail of write operations (ADMIN and READONLY_ADMIN only)
+      description: Returns the audit trail of write operations (admin tiers only)
       operationId: getEvents
       security:
         - bearerAuth: []
@@ -1211,7 +1211,7 @@ paths:
   /systemenrichment/{fisma_uuid}:
     get:
       summary: Get system enrichment payload by FISMA UUID
-      description: Returns the generic enrichment payload for a FISMA system by its UUID. Admins and READONLY_ADMINs can access any system; ISSOs can only access systems they are assigned to. The payload is an opaque JSON document owned by the enrichment pipeline; systems with no enrichment data return 404.
+      description: Returns the generic enrichment payload for a FISMA system by its UUID. Admin and read-only admin tiers can access any system; ISSOs can only access systems they are assigned to. The payload is an opaque JSON document owned by the enrichment pipeline; systems with no enrichment data return 404.
       operationId: getSystemEnrichment
       security:
         - bearerAuth: []
@@ -1383,9 +1383,9 @@ components:
         role:
           type: string
           description: |
-            Multi-OpDiv role taxonomy. Legacy values ADMIN and READONLY_ADMIN
-            remain valid through Stage D of the multi-OpDiv migration to
-            preserve back-compat; they are removed in a follow-up release.
+            Multi-OpDiv role taxonomy. The legacy values ADMIN and
+            READONLY_ADMIN were removed in Stage D of the multi-OpDiv
+            migration; they map to OWNER and HHS_READONLY_ADMIN respectively.
           enum:
             - OWNER
             - HHS_ADMIN
@@ -1394,8 +1394,6 @@ components:
             - OPDIV_READONLY_ADMIN
             - ISSO
             - ISSM
-            - ADMIN
-            - READONLY_ADMIN
         deleted:
           type: boolean
         identity_provider:
@@ -1523,8 +1521,6 @@ components:
           # validations.go in lockstep -- openapi has drifted from code
           # twice in this repo, so this comment is the canary.
           enum:
-            - ADMIN
-            - READONLY_ADMIN
             - OWNER
             - HHS_ADMIN
             - HHS_READONLY_ADMIN


### PR DESCRIPTION
## Summary

Stage D follow-up cleanup for the multi-OpDiv role swap. Closes #314.

The Stage B swap (`0036usersroleswap.go`) already migrated prod rows `ADMIN -> OWNER` and `READONLY_ADMIN -> HHS_READONLY_ADMIN`, so the legacy values are dead. This PR removes them everywhere they were still recognized and adds a DB-level guard rejecting any new write that carries one.

**Canonical mapping** (matches the Stage B migration): `ADMIN → OWNER`, `READONLY_ADMIN → HHS_READONLY_ADMIN`.

## Changes

**Production code**
- `internal/model/validations.go` — drop both legacy keys from the `roles` map so `isValidRole` rejects them.
- `internal/model/users.go` — drop legacy values from `HasUnscopedRead`, `IsAdmin`, `IsReadOnlyAdmin`.
- `cmd/api/internal/auth/middleware.go` — local-dev auto-create now stamps `OWNER`.
- `internal/model/massemails.go` — drop legacy `ADMIN` from the admin-recipient role list. The `"ADMIN"` mass-email **audience-group** key is an API contract and is intentionally kept.
- `cmd/api/internal/controller/fismasystems.go` — refresh a now-stale scope comment.

**Migration**
- `migrations/0040rolecleanup.go` — adds `CHECK (role NOT IN ('ADMIN','READONLY_ADMIN'))` as defense in depth. Down migration drops the constraint so the prior release can roll back during the soak window (the validation map / helper values are restored by redeploying the prior binary).

**Fixtures / spec / tests**
- `_test_data.sql`, `_test_data_empire.sql`, `emberfall_tests.yml`, `openapi.yaml` updated to the new tier names (legacy values removed from both role enums).
- `validations_test.go` flips the legacy-role assertions from valid → invalid.
- `users_test.go`, `authorization_test.go`, `events_test.go`, `scores_test.go`, `scores_integration_test.go` updated to the new tier names.

## Acceptance criteria

- [x] `isValidRole("ADMIN")` / `isValidRole("READONLY_ADMIN")` return false
- [x] All test fixtures use new-tier role names
- [x] OpenAPI role enum no longer lists `ADMIN` / `READONLY_ADMIN`
- [x] Local-dev auto-create middleware emits a new-tier role (`OWNER`)
- [x] Down migration drops the guard so a rollback to the prior release works during the soak window
- [x] `CHECK` constraint rejects legacy role values (defense in depth)
- [ ] Pre-flight (operational, not in this diff): `SELECT count(*) FROM users WHERE role IN ('ADMIN','READONLY_ADMIN')` returns 0 at the moment of merge

## Testing

`go build ./...` and `go test -short ./...` green in `golang:1.25`. Both YAML files re-parse cleanly.

> Note: this branch is from a fork without repo secrets, so Snyk / secret-dependent CI checks will show red — expected; re-run after pulling.