### PR TITLE
Bump Go to 1.25.11 for standard-library CVEs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 
 WORKDIR /src
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/CMS-Enterprise/ztmf/backend
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
## Summary

Snyk started failing the prod orchestration on two high-severity vulnerabilities in the Go standard library at 1.25.10:

- `std/mime`
- `std/crypto/x509`

Both are fixed in Go 1.25.11. The advisories surfaced after #329 had already passed its PR checks, so the same code that was green on the PR now blocks the prod pipeline at the analysis stage. Until this lands, every merge to main fails Snyk and nothing deploys.

## Change

- `backend/go.mod`: `go 1.25.10` -> `1.25.11`
- `backend/Dockerfile`: builder image `golang:1.25.10-bookworm` -> `golang:1.25.11-bookworm`

No code changes. Builds clean locally and the host unit tests pass.

## Note

The prod run failed at the analysis stage before the deploy step, so prod was not affected and is still running the prior image. This unblocks the pipeline so #329 (and subsequent work) can deploy.