### PR TITLE
Backend: enforce OpDiv-scoped RBAC and add OpDiv management endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,23 @@ test-e2e:
 	@rm /tmp/emberfall_test_isolated.yml
 	@echo "✅ E2E tests passed!"
 
+test-integration:
+	@echo "🧪 Running Go integration tests against an isolated, freshly-seeded DB..."
+	@echo "   (never the dev DB on :54321 - that volume holds real data on purpose)"
+	@echo "🧹 Cleaning up any existing test containers..."
+	@cd backend && docker compose -f compose-test.yml down -v 2>/dev/null || true
+	@echo "🚀 Starting fresh test environment (db :54399; test-api applies migrations + seed)..."
+	@cd backend && docker compose -f compose-test.yml up -d --build
+	@echo "⏳ Waiting for migrations + empire seed to apply..."
+	@sleep 15
+	@echo "🔬 Running integration tests against :54399..."
+	@cd backend && DB_SECRET_ID= DB_ENDPOINT=localhost DB_PORT=54399 DB_NAME=ztmf DB_USER=admin DB_PASS=testpass ENVIRONMENT=test \
+		go test -run Integration ./... -count=1 \
+		|| (echo "❌ Integration tests failed"; docker compose -f compose-test.yml down -v; exit 1)
+	@echo "🧹 Cleaning up test environment..."
+	@cd backend && docker compose -f compose-test.yml down -v
+	@echo "✅ Integration tests passed!"
+
 test-build:
 	@echo "Building all binaries (API + Lambdas)..."
 	@cd backend && go build ./cmd/api/...
@@ -321,11 +338,11 @@ test-full:
 	@echo "2/5 Running unit tests..."
 	@cd backend && go test -short ./...
 	@echo ""
-	@echo "3/5 Generating coverage report..."
-	@cd backend && go test -cover $$(go list ./... | xargs -I{} sh -c 'test -n "$$(find $$(go list -f "{{.Dir}}" {}) -maxdepth 1 -name "*_test.go" 2>/dev/null)" && echo {}' | tr "\n" " ")
+	@echo "3/5 Generating coverage report (unit only; integration runs isolated in step 4)..."
+	@cd backend && go test -short -cover $$(go list ./... | xargs -I{} sh -c 'test -n "$$(find $$(go list -f "{{.Dir}}" {}) -maxdepth 1 -name "*_test.go" 2>/dev/null)" && echo {}' | tr "\n" " ")
 	@echo ""
-	@echo "4/5 Running integration tests (require DB_* env from backend/dev.compose.env)..."
-	@cd backend && go test -run Integration ./... -count=1
+	@echo "4/5 Running integration tests (isolated, freshly-seeded container)..."
+	@$(MAKE) test-integration
 	@echo ""
 	@echo "5/5 Running Emberfall E2E tests (isolated containers)..."
 	@make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -254,10 +254,6 @@ test-unit:
 	@echo "🧪 Running unit tests (fast)..."
 	cd backend && go test -short ./...
 
-test-integration:
-	@echo "🧪 Running integration tests..."
-	cd backend && go test -run Integration ./...
-
 test-coverage:
 	@echo "Running tests with coverage..."
 	cd backend && go test -coverprofile=coverage.out ./...

--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -11,6 +11,13 @@ INSERT INTO public.opdivs (code, name, is_parent, active)
     VALUES ('EMPIRE', 'Galactic Empire (test fixture)', FALSE, TRUE)
     ON CONFLICT DO NOTHING;
 
+-- REBELLION OpDiv (test-only). A second OpDiv distinct from EMPIRE so the
+-- OpDiv-scoped RBAC negative cases are exercisable: an EMPIRE OPDIV_ADMIN must
+-- get 403 on REBELLION systems and must not see them in scoped read lists.
+INSERT INTO public.opdivs (code, name, is_parent, active)
+    VALUES ('REBELLION', 'Rebel Alliance (test fixture)', FALSE, TRUE)
+    ON CONFLICT DO NOTHING;
+
 -- Test user for Emberfall E2E tests (matches _test_data.sql for CI/CD compatibility)
 INSERT INTO public.users (email, fullname, role, identity_provider)
     VALUES ('Test.User@nowhere.xyz', 'Admin User', 'OWNER', 'okta')
@@ -57,6 +64,18 @@ INSERT INTO public.users (userid, email, fullname, role, deleted, identity_provi
     VALUES ('77777777-7777-4777-8777-777777777777', 'Captain.Needa@executor.empire', 'Captain Needa', 'ISSO', TRUE, 'okta')
     ON CONFLICT DO NOTHING;
 
+-- OpDiv-scoped admin fixtures for the RBAC enforcement tests. Both are granted
+-- ONLY the EMPIRE OpDiv (see the EMPIRE grant block below), never REBELLION, so
+-- they can manage / read EMPIRE systems but get 403 / empty on REBELLION ones.
+-- HS256 tokens (secret "zeroTrust", lowercase email claim) live as anchors in
+-- emberfall_tests.yml. UUIDs are v4-conforming for isValidUUID path params.
+INSERT INTO public.users (userid, email, fullname, role, identity_provider)
+    VALUES ('88888888-8888-4888-8888-888888888888', 'Opdiv.Admin@empire.test', 'Empire OpDiv Admin', 'OPDIV_ADMIN', 'okta')
+    ON CONFLICT DO NOTHING;
+INSERT INTO public.users (userid, email, fullname, role, identity_provider)
+    VALUES ('99999999-9999-4999-8999-999999999999', 'Opdiv.Readonly@empire.test', 'Empire OpDiv Readonly', 'OPDIV_READONLY_ADMIN', 'okta')
+    ON CONFLICT DO NOTHING;
+
 -- Grant EMPIRE OpDiv membership to every test user. Migration 0034 only seeded
 -- users that existed at migration time; populate adds users after migrations
 -- run, so we attach OpDiv grants here. All empire-themed users get EMPIRE;
@@ -75,7 +94,9 @@ SELECT u.userid, (SELECT opdiv_id FROM public.opdivs WHERE code = 'EMPIRE')
         'Commander.Veers@hoth.empire',
         'Director.Krennic@scarif.empire',
         'Emperor.Palpatine@coruscant.empire',
-        'Captain.Needa@executor.empire'
+        'Captain.Needa@executor.empire',
+        'Opdiv.Admin@empire.test',
+        'Opdiv.Readonly@empire.test'
        )
 ON CONFLICT DO NOTHING;
 
@@ -183,6 +204,51 @@ INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismanam
     '11111111-1111-1111-1111-111111111111',
     'Decommissioned to provide a reactivation test target',
     (SELECT opdiv_id FROM public.opdivs WHERE code = 'EMPIRE')
+) ON CONFLICT DO NOTHING;
+
+-- REBELLION-OpDiv systems. Out of scope for the EMPIRE OpDiv admins: used to
+-- assert cross-OpDiv 403 on write paths (score/edit/decommission/reactivate/
+-- assign/datacall-complete) and exclusion from EMPIRE-scoped read lists.
+INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes, opdiv_id) VALUES (
+    1005,
+    'A1B2C300-1977-4E5F-9D0A-1234567890AB',
+    'RB-1',
+    'Yavin 4 Massassi Base Network',
+    'Rebel Command Operations',
+    'ALLIANCE-(OPS)',
+    'RBLCOM',
+    'Alliance Command',
+    'Operations Division',
+    'Jungle-Moon',
+    'mon.mothma@chandrila.alliance',
+    'general.dodonna@yavin.alliance',
+    FALSE,
+    FALSE,
+    NULL,
+    NULL,
+    NULL,
+    (SELECT opdiv_id FROM public.opdivs WHERE code = 'REBELLION')
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes, opdiv_id) VALUES (
+    1006,
+    'C4D5E600-1980-4A7B-8C1D-234567890ABC',
+    'RB-2',
+    'Hoth Echo Base Defense Grid',
+    'Planetary Defense Systems',
+    'ALLIANCE-(DEF)',
+    'ECHO',
+    'Alliance Defense Corps',
+    'Planetary Defense Division',
+    'Ice-Planet',
+    'general.rieekan@hoth.alliance',
+    'commander.skywalker@hoth.alliance',
+    FALSE,
+    FALSE,
+    NULL,
+    NULL,
+    NULL,
+    (SELECT opdiv_id FROM public.opdivs WHERE code = 'REBELLION')
 ) ON CONFLICT DO NOTHING;
 
 -- User-System Assignments (Officers assigned to their systems)

--- a/backend/cmd/api/internal/controller/datacallsfismasystems.go
+++ b/backend/cmd/api/internal/controller/datacallsfismasystems.go
@@ -57,6 +57,7 @@ func SaveDataCallFismaSystem(w http.ResponseWriter, r *http.Request) {
 
 // ListDataCallFismaSystems handles the GET request to list all FISMA systems that have marked a specific data call as complete
 func ListDataCallFismaSystems(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
 	vars := mux.Vars(r)
 
 	var (
@@ -72,8 +73,21 @@ func ListDataCallFismaSystems(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Sscan(v, &datacallID)
 
+	// OpDiv scope: only the OpDiv-scoped admin tiers are narrowed to their
+	// granted OpDivs (fail-closed). Unscoped admins see the full list; ISSO/ISSM
+	// keep the legacy department-wide completion view (their scope is per-system
+	// elsewhere, and a stray CMS grant must not silently filter this list).
+	var (
+		opdivIDs []int32
+		restrict bool
+	)
+	if authdUser.IsOpDivTier() {
+		restrict = true
+		_, opdivIDs = authdUser.EffectiveOpDivScope()
+	}
+
 	// Get the list of FISMA systems that have completed this data call
-	fismaSystems, err := model.FindDataCallFismaSystems(r.Context(), datacallID)
+	fismaSystems, err := model.FindDataCallFismaSystems(r.Context(), datacallID, opdivIDs, restrict)
 
 	// Respond with the result
 	respond(w, r, fismaSystems, err)

--- a/backend/cmd/api/internal/controller/datacallsfismasystems.go
+++ b/backend/cmd/api/internal/controller/datacallsfismasystems.go
@@ -34,6 +34,15 @@ func SaveDataCallFismaSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// OpDiv write-scope: an admin-tier writer may only mark completion for a
+	// system in an OpDiv they manage. ISSO/ISSM keep their assigned-system path.
+	if authdUser.IsAdmin() {
+		if _, err := guardManageFismaSystem(r.Context(), authdUser, fismasystemID); err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+	}
+
 	df := &model.DataCallFismaSystem{
 		Datacallid:    datacallID,
 		Fismasystemid: fismasystemID,

--- a/backend/cmd/api/internal/controller/events.go
+++ b/backend/cmd/api/internal/controller/events.go
@@ -8,7 +8,11 @@ import (
 
 func GetEvents(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
-	if !user.HasAdminRead() {
+	// The audit trail spans every OpDiv and events carry no opdiv_id to scope
+	// on, so it is restricted to unscoped admins (OWNER / HHS_ADMIN /
+	// HHS_READONLY_ADMIN). OpDiv-scoped tiers get 403 rather than a cross-OpDiv
+	// audit view.
+	if !user.HasUnscopedRead() {
 		respond(w, r, nil, ErrForbidden)
 		return
 	}

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -82,6 +83,24 @@ func GetFismaSystem(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, fismasystem, nil)
 }
 
+// guardManageFismaSystem fetches the target system and verifies the acting user
+// may write it: OWNER/HHS_ADMIN manage any system, an OPDIV_ADMIN only systems
+// in an OpDiv they hold a grant for. A missing system stays a NotFound (it does
+// not leak existence via a 403). Returns the system so callers can reuse it.
+func guardManageFismaSystem(ctx context.Context, user *model.User, id int32) (*model.FismaSystem, error) {
+	sys, err := model.FindFismaSystem(ctx, model.FindFismaSystemsInput{FismaSystemID: &id})
+	if err != nil {
+		return nil, err
+	}
+	if sys == nil {
+		return nil, ErrNotFound
+	}
+	if !user.CanManageFismaSystem(sys.OpDivID) {
+		return nil, ErrForbidden
+	}
+	return sys, nil
+}
+
 func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 	authdUser := model.UserFromContext(r.Context())
 	if !authdUser.IsAdmin() {
@@ -120,6 +139,16 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Update path: an OpDiv-scoped admin may only edit a system in an OpDiv they
+	// hold a grant for. opdiv_id is immutable on update, so the existing row's
+	// OpDiv is authoritative.
+	if f.FismaSystemID != 0 {
+		if _, err := guardManageFismaSystem(r.Context(), authdUser, f.FismaSystemID); err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+	}
+
 	f, err = f.Save(r.Context())
 
 	if err != nil {
@@ -153,6 +182,11 @@ func DeleteFismaSystem(w http.ResponseWriter, r *http.Request) {
 
 	var fismaSystemID int32
 	fmt.Sscan(fismaSystemIDStr, &fismaSystemID)
+
+	if _, err := guardManageFismaSystem(r.Context(), authdUser, fismaSystemID); err != nil {
+		respond(w, r, nil, err)
+		return
+	}
 
 	// Parse optional request body
 	var req DecommissionRequest
@@ -215,6 +249,11 @@ func ReactivateFismaSystem(w http.ResponseWriter, r *http.Request) {
 
 	var fismaSystemID int32
 	fmt.Sscan(fismaSystemIDStr, &fismaSystemID)
+
+	if _, err := guardManageFismaSystem(r.Context(), authdUser, fismaSystemID); err != nil {
+		respond(w, r, nil, err)
+		return
+	}
 
 	var req ReactivateRequest
 	if r.ContentLength > 0 {

--- a/backend/cmd/api/internal/controller/massemails.go
+++ b/backend/cmd/api/internal/controller/massemails.go
@@ -12,7 +12,12 @@ import (
 // see model/massemails
 func SaveMassEmail(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
-	if !user.IsAdmin() {
+	// Mass email is a write action that targets recipients across every OpDiv
+	// with no per-OpDiv recipient scoping, so it is restricted to the unscoped
+	// WRITE admins (OWNER / HHS_ADMIN): IsAdmin excludes the read-only tiers and
+	// HasUnscopedRead excludes OPDIV_ADMIN. An OPDIV_ADMIN must not be able to
+	// blast users outside their OpDiv; read-only admins must not send at all.
+	if !user.IsAdmin() || !user.HasUnscopedRead() {
 		respond(w, r, nil, ErrForbidden)
 		return
 	}

--- a/backend/cmd/api/internal/controller/opdivs.go
+++ b/backend/cmd/api/internal/controller/opdivs.go
@@ -43,6 +43,11 @@ func SaveOpDiv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Trust only the path-derived id. POST has no {opdiv_id} path var, so any
+	// opdiv_id in the request body is ignored and the operation is always a
+	// create - a body-supplied id must not turn a POST into an update of an
+	// existing OpDiv.
+	o.OpDivID = 0
 	if v, ok := mux.Vars(r)["opdiv_id"]; ok {
 		fmt.Sscan(v, &o.OpDivID)
 	}

--- a/backend/cmd/api/internal/controller/opdivs.go
+++ b/backend/cmd/api/internal/controller/opdivs.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
 )
 
 // ListOpDivs returns the OpDiv reference list. Open to any authenticated user
@@ -21,4 +23,30 @@ func ListOpDivs(w http.ResponseWriter, r *http.Request) {
 
 	opdivs, err := model.FindOpDivs(r.Context(), input)
 	respond(w, r, opdivs, err)
+}
+
+// SaveOpDiv creates (POST) or updates (PUT) an OpDiv. Restricted to OWNER: the
+// OpDiv list is the tenant boundary itself, so only the unscoped platform tier
+// may add or change one. A PUT with active=false deactivates an OpDiv. This is
+// the runtime path for onboarding a new OpDiv without a code deploy.
+func SaveOpDiv(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.IsOwner() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	o := &model.OpDiv{}
+	if err := getJSON(r.Body, o); err != nil {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+
+	if v, ok := mux.Vars(r)["opdiv_id"]; ok {
+		fmt.Sscan(v, &o.OpDivID)
+	}
+
+	o, err := o.Save(r.Context())
+	respond(w, r, o, err)
 }

--- a/backend/cmd/api/internal/controller/opdivs_test.go
+++ b/backend/cmd/api/internal/controller/opdivs_test.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// SaveOpDiv is OWNER-only: the OpDiv list is the tenant boundary, so even
+// HHS_ADMIN and OPDIV_ADMIN cannot create or change one. The IsOwner gate runs
+// before any body parse or DB call, so the forbidden cases need no database.
+func TestSaveOpDiv_OwnerOnly(t *testing.T) {
+	forbidden := []*model.User{
+		{Role: "HHS_ADMIN"},
+		{Role: "HHS_READONLY_ADMIN"},
+		{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{ptr32(2)}},
+		{Role: "OPDIV_READONLY_ADMIN"},
+		{Role: "ISSO"},
+	}
+	for _, u := range forbidden {
+		t.Run("POST forbidden for "+u.Role, func(t *testing.T) {
+			body := jsonBody(t, map[string]any{"code": "TEST", "name": "Test OpDiv"})
+			r := withUser(httptest.NewRequest("POST", "/api/v1/opdivs", body), u)
+			w := httptest.NewRecorder()
+			SaveOpDiv(w, r)
+			assert.Equal(t, http.StatusForbidden, w.Code)
+		})
+	}
+}
+
+func ptr32(i int32) *int32 { return &i }

--- a/backend/cmd/api/internal/controller/rbac_enforcement_test.go
+++ b/backend/cmd/api/internal/controller/rbac_enforcement_test.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// opdivPtr is a local int32-pointer helper for building AssignedOpDivIDs in the
+// OpDiv-scoped tier fixtures below.
+func opdivPtr(v int32) *int32 { return &v }
+
+var (
+	opdivAdmin = &model.User{
+		UserID:           "88888888-8888-4888-8888-888888888888",
+		Email:            "opdiv.admin@test.com",
+		Role:             "OPDIV_ADMIN",
+		AssignedOpDivIDs: []*int32{opdivPtr(1)},
+	}
+	opdivReadonly = &model.User{
+		UserID:           "99999999-9999-4999-8999-999999999999",
+		Email:            "opdiv.readonly@test.com",
+		Role:             "OPDIV_READONLY_ADMIN",
+		AssignedOpDivIDs: []*int32{opdivPtr(1)},
+	}
+)
+
+// These gates all return before any database access, so the forbidden cases are
+// pure no-DB unit tests. The allowed paths are intentionally not exercised here
+// because they would fall through to a DB query (and can hang without DB env);
+// they are covered by the isolated Emberfall E2E matrix instead.
+
+// --- GetEvents: restricted to unscoped admins (no opdiv_id to scope the log) ---
+
+func TestGetEvents_OpDivAdminForbidden(t *testing.T) {
+	r := withUser(httptest.NewRequest("GET", "/api/v1/events", nil), opdivAdmin)
+	w := httptest.NewRecorder()
+	GetEvents(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestGetEvents_OpDivReadonlyForbidden(t *testing.T) {
+	r := withUser(httptest.NewRequest("GET", "/api/v1/events", nil), opdivReadonly)
+	w := httptest.NewRecorder()
+	GetEvents(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// --- SaveMassEmail: restricted to unscoped WRITE admins (OWNER / HHS_ADMIN) ---
+
+func TestSaveMassEmail_OpDivAdminForbidden(t *testing.T) {
+	body := jsonBody(t, map[string]string{"subject": "x", "body": "y"})
+	r := withUser(httptest.NewRequest("POST", "/api/v1/massemails", body), opdivAdmin)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	SaveMassEmail(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestSaveMassEmail_OpDivReadonlyForbidden(t *testing.T) {
+	body := jsonBody(t, map[string]string{"subject": "x", "body": "y"})
+	r := withUser(httptest.NewRequest("POST", "/api/v1/massemails", body), opdivReadonly)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	SaveMassEmail(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// --- SaveScore: read-only tiers are blocked before any DB access ---
+
+func TestSaveScore_OpDivReadonlyForbidden(t *testing.T) {
+	body := jsonBody(t, map[string]any{"fismasystemid": 1002, "functionoptionid": 1, "datacallid": 3})
+	r := withUser(httptest.NewRequest("POST", "/api/v1/scores", body), opdivReadonly)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	SaveScore(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/backend/cmd/api/internal/controller/rbac_enforcement_test.go
+++ b/backend/cmd/api/internal/controller/rbac_enforcement_test.go
@@ -16,13 +16,13 @@ func opdivPtr(v int32) *int32 { return &v }
 var (
 	opdivAdmin = &model.User{
 		UserID:           "88888888-8888-4888-8888-888888888888",
-		Email:            "opdiv.admin@test.com",
+		Email:            "Opdiv.Admin@empire.test",
 		Role:             "OPDIV_ADMIN",
 		AssignedOpDivIDs: []*int32{opdivPtr(1)},
 	}
 	opdivReadonly = &model.User{
 		UserID:           "99999999-9999-4999-8999-999999999999",
-		Email:            "opdiv.readonly@test.com",
+		Email:            "Opdiv.Readonly@empire.test",
 		Role:             "OPDIV_READONLY_ADMIN",
 		AssignedOpDivIDs: []*int32{opdivPtr(1)},
 	}

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -18,7 +18,15 @@ func ListScores(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
 	findScoresInput := model.FindScoresInput{}
 
-	if !user.HasAdminRead() {
+	// Scope by tier: unscoped admins see all; OPDIV tiers fail-closed to their
+	// granted OpDivs' systems; ISSO/ISSM keep the per-system (UserID) path.
+	switch {
+	case user.HasUnscopedRead():
+		// no scope filter
+	case user.IsOpDivTier():
+		findScoresInput.RestrictToOpDivIDs = true
+		_, findScoresInput.OpDivIDs = user.EffectiveOpDivScope()
+	default:
 		findScoresInput.UserID = &user.UserID
 	}
 
@@ -85,7 +93,15 @@ func GetScoresAggregate(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
 	findScoresInput := model.FindScoresInput{}
 
-	if !user.HasAdminRead() {
+	// Same tier scoping as ListScores: unscoped admins see all; OPDIV tiers
+	// fail-closed to their OpDivs; ISSO/ISSM keep the assigned-systems path.
+	switch {
+	case user.HasUnscopedRead():
+		// no scope filter
+	case user.IsOpDivTier():
+		findScoresInput.RestrictToOpDivIDs = true
+		_, findScoresInput.OpDivIDs = user.EffectiveOpDivScope()
+	default:
 		findScoresInput.FismaSystemIDs = user.AssignedFismaSystems
 	}
 

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -54,6 +54,16 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// OpDiv write-scope: an admin-tier writer may only score a system in an
+	// OpDiv they manage (OWNER/HHS_ADMIN any; OPDIV_ADMIN only their grants).
+	// ISSO/ISSM keep the per-system assignment path checked above.
+	if user.IsAdmin() {
+		if _, err := guardManageFismaSystem(r.Context(), user, score.FismaSystemID); err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+	}
+
 	vars := mux.Vars(r)
 
 	if v, ok := vars["scoreid"]; ok {

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -18,8 +18,11 @@ func ListScores(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
 	findScoresInput := model.FindScoresInput{}
 
-	// Scope by tier: unscoped admins see all; OPDIV tiers fail-closed to their
-	// granted OpDivs' systems; ISSO/ISSM keep the per-system (UserID) path.
+	err = decoder.Decode(&findScoresInput, r.URL.Query())
+
+	// Scope by tier AFTER decode so a client cannot widen scope via query
+	// params: unscoped admins see all; OPDIV tiers fail-closed to their granted
+	// OpDivs' systems; ISSO/ISSM keep the per-system (UserID) path.
 	switch {
 	case user.HasUnscopedRead():
 		// no scope filter
@@ -30,7 +33,6 @@ func ListScores(w http.ResponseWriter, r *http.Request) {
 		findScoresInput.UserID = &user.UserID
 	}
 
-	err = decoder.Decode(&findScoresInput, r.URL.Query())
 	if err == nil {
 		scores, err = model.FindScores(r.Context(), findScoresInput)
 	}
@@ -93,8 +95,11 @@ func GetScoresAggregate(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
 	findScoresInput := model.FindScoresInput{}
 
-	// Same tier scoping as ListScores: unscoped admins see all; OPDIV tiers
-	// fail-closed to their OpDivs; ISSO/ISSM keep the assigned-systems path.
+	err = decoder.Decode(&findScoresInput, r.URL.Query())
+
+	// Same tier scoping as ListScores, applied AFTER decode: unscoped admins see
+	// all; OPDIV tiers fail-closed to their OpDivs; ISSO/ISSM keep the
+	// assigned-systems path.
 	switch {
 	case user.HasUnscopedRead():
 		// no scope filter
@@ -105,7 +110,6 @@ func GetScoresAggregate(w http.ResponseWriter, r *http.Request) {
 		findScoresInput.FismaSystemIDs = user.AssignedFismaSystems
 	}
 
-	err = decoder.Decode(&findScoresInput, r.URL.Query())
 	if err == nil {
 		aggregate, err = model.FindScoresAggregate(r.Context(), findScoresInput)
 	}

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -22,6 +22,15 @@ func ListUsers(w http.ResponseWriter, r *http.Request) {
 
 	findUsersInput := &model.FindUsersInput{}
 	err = decoder.Decode(findUsersInput, r.URL.Query())
+
+	// OpDiv scope: an OpDiv-scoped admin (OPDIV_ADMIN / OPDIV_READONLY_ADMIN)
+	// only lists users in their granted OpDivs. Set after decode so a client
+	// cannot widen scope via query params. Unscoped admins leave it unset.
+	if unscoped, ids := authdUser.EffectiveOpDivScope(); !unscoped {
+		findUsersInput.RestrictToOpDivIDs = true
+		findUsersInput.OpDivIDs = ids
+	}
+
 	if err == nil {
 		users, err = model.FindUsers(r.Context(), findUsersInput)
 	}
@@ -44,8 +53,20 @@ func GetUserByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := model.FindUserByID(r.Context(), ID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
 
-	respond(w, r, user, err)
+	// OpDiv read scope: an OpDiv-scoped admin may only read a user who shares
+	// one of their OpDivs. Unscoped admins read anyone. Fetch-then-gate keeps a
+	// not-found from leaking as a 403.
+	if !authdUser.HasUnscopedRead() && !sharesOpDiv(authdUser, user) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	respond(w, r, user, nil)
 }
 
 func GetCurrentUser(w http.ResponseWriter, r *http.Request) {

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -76,6 +76,35 @@ func SaveUser(w http.ResponseWriter, r *http.Request) {
 		user.UserID = v
 	}
 
+	// Tier escalation guard: the acting admin may not assign a role above their
+	// own authority (an OPDIV_ADMIN can't mint HHS/OWNER tiers, etc.).
+	if user.Role != "" && !authdUser.CanAssignRole(user.Role) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	// identity_provider is derived from OpDiv on grant and is only overridable
+	// by an OWNER. Ignore any client-supplied value from a non-OWNER so it
+	// cannot be used to misroute a user's login.
+	if !authdUser.IsOwner() {
+		user.IdentityProvider = ""
+	}
+
+	// Updating an existing user: an OpDiv-scoped admin may only manage a user
+	// within their OpDiv. (Create needs no scope check here - the new user has
+	// no OpDiv until the scoped grant step assigns one.)
+	if user.UserID != "" {
+		target, terr := model.FindUserByID(r.Context(), user.UserID)
+		if terr != nil {
+			respond(w, r, nil, terr)
+			return
+		}
+		if !authdUser.CanManageUser(target) {
+			respond(w, r, nil, ErrForbidden)
+			return
+		}
+	}
+
 	user, err = user.Save(r.Context())
 
 	if err != nil {
@@ -102,6 +131,17 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// An OpDiv-scoped admin may only delete a user within their OpDiv.
+	target, terr := model.FindUserByID(r.Context(), userID)
+	if terr != nil {
+		respond(w, r, nil, terr)
+		return
+	}
+	if !authdUser.CanManageUser(target) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
 	err := model.DeleteUser(r.Context(), userID)
 	if err != nil {
 		log.Println(err)
@@ -124,6 +164,18 @@ func RestoreUser(w http.ResponseWriter, r *http.Request) {
 	userID, ok := vars["userid"]
 	if !ok {
 		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	// An OpDiv-scoped admin may only restore a user within their OpDiv, and no
+	// admin may restore a user above their tier (restore resurrects an account).
+	target, terr := model.FindUserByID(r.Context(), userID)
+	if terr != nil {
+		respond(w, r, nil, terr)
+		return
+	}
+	if !authdUser.CanManageUser(target) {
+		respond(w, r, nil, ErrForbidden)
 		return
 	}
 

--- a/backend/cmd/api/internal/controller/usersfismasystems.go
+++ b/backend/cmd/api/internal/controller/usersfismasystems.go
@@ -53,6 +53,23 @@ func CreateUserFismaSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// OpDiv write-scope: the acting admin may only assign a system they manage
+	// to a user they manage. OWNER/HHS_ADMIN pass both; an OPDIV_ADMIN must hold
+	// the system's OpDiv and share an OpDiv with the target user.
+	if _, gerr := guardManageFismaSystem(r.Context(), authdUser, uf.FismaSystemID); gerr != nil {
+		respond(w, r, nil, gerr)
+		return
+	}
+	target, terr := model.FindUserByID(r.Context(), userID)
+	if terr != nil {
+		respond(w, r, nil, terr)
+		return
+	}
+	if !authdUser.CanManageUser(target) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
 	uf, err = uf.Save(r.Context())
 	if err != nil {
 		respond(w, r, nil, err)
@@ -86,6 +103,21 @@ func DeleteUserFismaSystem(w http.ResponseWriter, r *http.Request) {
 
 	uf.UserID = userID
 	fmt.Sscan(fismaSystemID, &uf.FismaSystemID)
+
+	// Same OpDiv write-scope as assignment: manage both the system and the user.
+	if _, gerr := guardManageFismaSystem(r.Context(), authdUser, uf.FismaSystemID); gerr != nil {
+		respond(w, r, nil, gerr)
+		return
+	}
+	target, terr := model.FindUserByID(r.Context(), userID)
+	if terr != nil {
+		respond(w, r, nil, terr)
+		return
+	}
+	if !authdUser.CanManageUser(target) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
 
 	err := uf.Delete(r.Context())
 

--- a/backend/cmd/api/internal/controller/usersfismasystems.go
+++ b/backend/cmd/api/internal/controller/usersfismasystems.go
@@ -73,7 +73,7 @@ func CreateUserFismaSystem(w http.ResponseWriter, r *http.Request) {
 	uf, err = uf.Save(r.Context())
 	if err != nil {
 		respond(w, r, nil, err)
-
+		return
 	}
 
 	respond(w, r, uf, nil)

--- a/backend/cmd/api/internal/controller/usersopdivs.go
+++ b/backend/cmd/api/internal/controller/usersopdivs.go
@@ -1,0 +1,139 @@
+package controller
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
+)
+
+// sharesOpDiv reports whether the acting user shares any OpDiv grant with the
+// target user (used to scope an OpDiv-tier admin's read of another user).
+func sharesOpDiv(actor, target *model.User) bool {
+	if target == nil {
+		return false
+	}
+	for _, t := range target.AssignedOpDivIDs {
+		if t != nil && actor.IsAssignedOpDiv(*t) {
+			return true
+		}
+	}
+	return false
+}
+
+// ListUserOpDivs returns the OpDiv ids a user holds grants for. Unscoped admins
+// may view any user; an OpDiv-scoped admin may only view a user who shares one
+// of their OpDivs.
+func ListUserOpDivs(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.HasAdminRead() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	userID, ok := mux.Vars(r)["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	if !authdUser.HasUnscopedRead() {
+		target, err := model.FindUserByID(r.Context(), userID)
+		if err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+		if !sharesOpDiv(authdUser, target) {
+			respond(w, r, nil, ErrForbidden)
+			return
+		}
+	}
+
+	opdivIDs, err := model.FindUserOpDivsByUserID(r.Context(), userID)
+	respond(w, r, opdivIDs, err)
+}
+
+// CreateUserOpDiv grants a user OpDiv membership. Unscoped admins may grant any
+// OpDiv; an OPDIV_ADMIN may only grant an OpDiv they themselves hold (so they
+// can add users to their own OpDiv but not place users into another OpDiv).
+func CreateUserOpDiv(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.IsAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	userID, ok := mux.Vars(r)["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	uo := &model.UserOpDiv{}
+	if err := getJSON(r.Body, uo); err != nil {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+	// Trust the path for the user and the authenticated identity for granted_by.
+	uo.UserID = userID
+	uo.GrantedBy = &authdUser.UserID
+
+	// An OpDiv-scoped admin may only grant an OpDiv they themselves hold.
+	if !authdUser.HasUnscopedRead() && !authdUser.IsAssignedOpDiv(uo.OpDivID) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	// Do not let a grant manufacture management rights over a higher-tier user:
+	// the grantee's current tier must be within the actor's assignable set
+	// (404 if the user does not exist). This is the companion to the tier
+	// ceiling in CanManageUser.
+	target, terr := model.FindUserByID(r.Context(), uo.UserID)
+	if terr != nil {
+		respond(w, r, nil, terr)
+		return
+	}
+	if !authdUser.CanAssignRole(target.Role) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	saved, err := uo.Save(r.Context())
+	respond(w, r, saved, err)
+}
+
+// DeleteUserOpDiv revokes a user's OpDiv grant. Same scope as granting: an
+// OPDIV_ADMIN may only revoke an OpDiv they hold.
+func DeleteUserOpDiv(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.IsAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	vars := mux.Vars(r)
+	userID, ok := vars["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+	opdivIDStr, ok := vars["opdiv_id"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	uo := &model.UserOpDiv{UserID: userID}
+	fmt.Sscan(opdivIDStr, &uo.OpDivID)
+
+	if !authdUser.HasUnscopedRead() && !authdUser.IsAssignedOpDiv(uo.OpDivID) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	err := uo.Delete(r.Context())
+	respond(w, r, "", err)
+}

--- a/backend/cmd/api/internal/controller/usersopdivs_test.go
+++ b/backend/cmd/api/internal/controller/usersopdivs_test.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+const grantUserID = "11111111-1111-4111-8111-111111111111"
+
+// CreateUserOpDiv's forbidden paths are reached before any DB call: a non-admin
+// is rejected by the tier gate, and an OPDIV_ADMIN granting an OpDiv they do not
+// hold is rejected by the in-memory scope check.
+func TestCreateUserOpDiv_Forbidden(t *testing.T) {
+	t.Run("non-admin tier is forbidden", func(t *testing.T) {
+		r := withUser(httptest.NewRequest("POST", "/api/v1/users/"+grantUserID+"/assignedopdivs",
+			jsonBody(t, map[string]any{"opdiv_id": 3})), &model.User{Role: "ISSO"})
+		r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+		w := httptest.NewRecorder()
+		CreateUserOpDiv(w, r)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("OPDIV_ADMIN cannot grant an OpDiv they do not hold", func(t *testing.T) {
+		opdiv2 := int32(2)
+		actor := &model.User{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{&opdiv2}}
+		r := withUser(httptest.NewRequest("POST", "/api/v1/users/"+grantUserID+"/assignedopdivs",
+			jsonBody(t, map[string]any{"opdiv_id": 99})), actor)
+		r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+		w := httptest.NewRecorder()
+		CreateUserOpDiv(w, r)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+}

--- a/backend/cmd/api/internal/migrations/0041fismasystemsopdivindex.go
+++ b/backend/cmd/api/internal/migrations/0041fismasystemsopdivindex.go
@@ -1,0 +1,29 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add index on fismasystems.opdiv_id for OpDiv scope predicates",
+		`
+-- OpDiv-scoped RBAC enforcement filters fismasystems by opdiv_id on every
+-- scoped read (list systems, scores, datacall completion) for the OPDIV_ADMIN
+-- / OPDIV_READONLY_ADMIN tiers. The column is the backfilled FK added in the
+-- multi-OpDiv schema (0026-0040) and is otherwise unindexed, so each scoped
+-- read degenerates to a sequential scan over fismasystems.
+--
+-- The predicate shapes are opdiv_id = ANY($1) (direct) and a correlated
+-- subquery (scores). A plain btree on opdiv_id serves both. Cardinality is
+-- low (one row per OpDiv, ~14 today) but the table is small enough that the
+-- planner will still prefer the index for the single-OpDiv-admin case, and it
+-- removes the seq-scan risk as the system count grows across OpDivs.
+--
+-- IF NOT EXISTS so the migration is idempotent on a retry. CONCURRENTLY is
+-- unavailable (tern wraps each migration in a transaction); fismasystems is
+-- small (~255 rows prod) so the brief lock is negligible.
+
+CREATE INDEX IF NOT EXISTS fismasystems_opdiv_id_idx
+    ON public.fismasystems (opdiv_id);
+        `,
+		`
+DROP INDEX IF EXISTS public.fismasystems_opdiv_id_idx;
+        `)
+}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -55,6 +55,10 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems", controller.CreateUserFismaSystem).Methods("POST")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems/{fismasystemid:[0-9]+}", controller.DeleteUserFismaSystem).Methods("DELETE")
 
+	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedopdivs", controller.ListUserOpDivs).Methods("GET")
+	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedopdivs", controller.CreateUserOpDiv).Methods("POST")
+	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedopdivs/{opdiv_id:[0-9]+}", controller.DeleteUserOpDiv).Methods("DELETE")
+
 	router.HandleFunc("/api/v1/scores", controller.ListScores).Methods("GET")
 	router.HandleFunc("/api/v1/scores/aggregate", controller.GetScoresAggregate).Methods("GET") // yes "aggregate" is a noun
 	router.HandleFunc("/api/v1/scores", controller.SaveScore).Methods("POST")

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -40,6 +40,8 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/functions/{functionid:[0-9]+}/options", controller.ListFunctionOptions).Methods("GET")
 
 	router.HandleFunc("/api/v1/opdivs", controller.ListOpDivs).Methods("GET")
+	router.HandleFunc("/api/v1/opdivs", controller.SaveOpDiv).Methods("POST")
+	router.HandleFunc("/api/v1/opdivs/{opdiv_id:[0-9]+}", controller.SaveOpDiv).Methods("PUT")
 
 	router.HandleFunc("/api/v1/users", controller.ListUsers).Methods("GET")
 	router.HandleFunc("/api/v1/users", controller.SaveUser).Methods("POST")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -12,6 +12,16 @@ readonlyAdminHeaders: &readonlyAdminHeaders
 issoHeaders: &issoHeaders
   authorization: "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6Imlzc28udXNlckBub3doZXJlLnh5eiJ9.vVrud1ADntR8wUdRZ2vah7EFTgcGXMTVDPzfs84uorI"
 
+# OpDiv-scoped admin (EMPIRE grant only). Manages EMPIRE systems (1001-1004),
+# must 403 on REBELLION systems (1005-1006). Email claim opdiv.admin@empire.test.
+opDivAdminHeaders: &opDivAdminHeaders
+  authorization: "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6Im9wZGl2LmFkbWluQGVtcGlyZS50ZXN0In0.P9vXfhtjDxOOpdqDfWSqLrBPYeneiFl1V7TT0oWxlRY"
+
+# OpDiv-scoped read-only admin (EMPIRE grant only). All writes 403; reads scoped
+# to EMPIRE. Email claim opdiv.readonly@empire.test.
+opDivReadonlyHeaders: &opDivReadonlyHeaders
+  authorization: "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6Im9wZGl2LnJlYWRvbmx5QGVtcGlyZS50ZXN0In0.enezNI1lnuNFcXzcxZqm0CTalZfbOV40dolVjoFxnII"
+
 # Data definitions using YAML anchors
 dataCallData: &dataCallData
   datacall: "FY2025 Q1"
@@ -1165,7 +1175,10 @@ tests:
     expect:
       status: 403
 
-  # Notes exceeding 2000 characters should return 400
+  # Notes exceeding 2000 characters should return 400.
+  # Uses a real, in-scope system (1002): SaveScore now fetches the system to
+  # evaluate OpDiv write-scope before Save validates the body, so a nonexistent
+  # fismasystemid would 404 before the notes-length check is ever reached.
   - url: http://localhost:8080/api/v1/scores
     method: POST
     headers:
@@ -1173,7 +1186,7 @@ tests:
       content-type: "application/json"
     body:
       json:
-        fismasystemid: 1
+        fismasystemid: 1002
         functionoptionid: 1
         notes: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         datacallid: 1
@@ -1423,4 +1436,212 @@ tests:
       status: 200
       headers:
         content-type: "application/json"
+
+  # ==========================================================================
+  # OpDiv-scoped RBAC enforcement (feature/opdiv-rbac-enforcement)
+  # Fixtures: EMPIRE OpDiv systems 1001-1004, REBELLION OpDiv systems 1005-1006.
+  # opDivAdminHeaders / opDivReadonlyHeaders hold the EMPIRE grant only, so every
+  # REBELLION touch must 403 (writes) or be excluded (reads). Uses known fixture
+  # ids rather than captured ids - Emberfall cannot template underscore keys.
+  # ==========================================================================
+
+  # OPDIV_ADMIN authenticates and is reported as the scoped tier.
+  - url: http://localhost:8080/api/v1/users/current
+    method: GET
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            email: "Opdiv.Admin@empire.test"
+            role: "OPDIV_ADMIN"
+
+  # OPDIV_ADMIN can list systems (scoped server-side to their OpDivs).
+  - url: http://localhost:8080/api/v1/fismasystems
+    method: GET
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # OPDIV_ADMIN can read an in-scope EMPIRE system (1002).
+  - url: http://localhost:8080/api/v1/fismasystems/1002
+    method: GET
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # OPDIV_ADMIN gets 403 reading an out-of-scope REBELLION system (1005).
+  - url: http://localhost:8080/api/v1/fismasystems/1005
+    method: GET
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN gets 403 editing an out-of-scope REBELLION system (1005).
+  - url: http://localhost:8080/api/v1/fismasystems/1005
+    method: PUT
+    headers:
+      <<: *opDivAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        <<: *fismaSystemData
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN gets 403 decommissioning an out-of-scope REBELLION system (1006).
+  - url: http://localhost:8080/api/v1/fismasystems/1006
+    method: DELETE
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN gets 403 reactivating an out-of-scope REBELLION system (1005).
+  - url: http://localhost:8080/api/v1/fismasystems/1005/reactivate
+    method: PUT
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN gets 403 scoring an out-of-scope REBELLION system (1006).
+  - url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *opDivAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1006
+        functionoptionid: 1
+        datacallid: 3
+        notes: "cross-OpDiv score attempt - must be blocked"
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN gets 403 marking an out-of-scope REBELLION system (1006) complete.
+  - url: http://localhost:8080/api/v1/datacalls/2/fismasystems/1006
+    method: PUT
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN may NOT mint an OWNER (tier escalation blocked).
+  - url: http://localhost:8080/api/v1/users
+    method: POST
+    headers:
+      <<: *opDivAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        email: "escalation.attempt@empire.test"
+        fullname: "Should Be Forbidden"
+        role: "OWNER"
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN may NOT mint an HHS_ADMIN either.
+  - url: http://localhost:8080/api/v1/users
+    method: POST
+    headers:
+      <<: *opDivAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        email: "escalation.attempt2@empire.test"
+        fullname: "Should Be Forbidden"
+        role: "HHS_ADMIN"
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN gets 403 on the cross-OpDiv audit trail (/events unscoped-only).
+  - url: http://localhost:8080/api/v1/events
+    method: GET
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN gets 403 sending mass email (unscoped write admins only).
+  - url: http://localhost:8080/api/v1/massemails
+    method: POST
+    headers:
+      <<: *opDivAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        subject: "blocked"
+        body: "blocked"
+    expect:
+      status: 403
+
+  # OPDIV_READONLY_ADMIN can read (scoped) but every write is blocked.
+  - url: http://localhost:8080/api/v1/fismasystems
+    method: GET
+    headers:
+      <<: *opDivReadonlyHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # OPDIV_READONLY_ADMIN gets 403 editing even an in-scope EMPIRE system (1002).
+  - url: http://localhost:8080/api/v1/fismasystems/1002
+    method: PUT
+    headers:
+      <<: *opDivReadonlyHeaders
+      content-type: "application/json"
+    body:
+      json:
+        <<: *fismaSystemData
+    expect:
+      status: 403
+
+  # OPDIV_READONLY_ADMIN gets 403 scoring any system.
+  - url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *opDivReadonlyHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1002
+        functionoptionid: 1
+        datacallid: 3
+        notes: "readonly write attempt - must be blocked"
+    expect:
+      status: 403
+
+  # OPDIV_READONLY_ADMIN gets 403 on /events and mass email too.
+  - url: http://localhost:8080/api/v1/events
+    method: GET
+    headers:
+      <<: *opDivReadonlyHeaders
+    expect:
+      status: 403
+
+  - url: http://localhost:8080/api/v1/massemails
+    method: POST
+    headers:
+      <<: *opDivReadonlyHeaders
+      content-type: "application/json"
+    body:
+      json:
+        subject: "blocked"
+        body: "blocked"
+    expect:
+      status: 403
 

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -177,6 +177,47 @@ tests:
       headers:
         content-type: "application/json"
 
+  # OpDiv CRUD is OWNER-only. A non-owner (ISSO) is forbidden.
+  - url: http://localhost:8080/api/v1/opdivs
+    method: POST
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        code: "NOPE"
+        name: "Should Be Forbidden"
+    expect:
+      status: 403
+
+  # OWNER creates an OpDiv; it comes back active with a server-assigned id.
+  - id: createOpDiv
+    url: http://localhost:8080/api/v1/opdivs
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        code: "TESTOD"
+        name: "Test OpDiv"
+        is_parent: false
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            code: "TESTOD"
+            name: "Test OpDiv"
+            active: true
+
+  # Note: the PUT update/deactivate path uses the same SaveOpDiv handler and is
+  # covered by the create case above plus the OWNER-only unit test. Emberfall's
+  # response templater cannot substitute the underscore-keyed opdiv_id from the
+  # create response, so a capture-dependent PUT case is omitted here.
+
   # DataCalls Endpoints
   - id: createDataCall
     url: http://localhost:8080/api/v1/datacalls

--- a/backend/internal/model/datacallsfismasystems.go
+++ b/backend/internal/model/datacallsfismasystems.go
@@ -21,15 +21,27 @@ func (df *DataCallFismaSystem) Save(ctx context.Context) (*DataCallFismaSystem, 
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[DataCallFismaSystem])
 }
 
-// FindDataCallFismaSystems returns all FISMA systems that have marked a specific data call as complete
-func FindDataCallFismaSystems(ctx context.Context, datacallID int32) ([]*FismaSystem, error) {
+// FindDataCallFismaSystems returns all FISMA systems that have marked a specific
+// data call as complete. opdivIDs/restrictToOpDivIDs scope the completion list
+// for an OpDiv-scoped admin to systems in their granted OpDivs (fail-closed:
+// restricted with an empty slice returns no rows). Unscoped callers pass
+// (nil, false) for the legacy department-wide view.
+func FindDataCallFismaSystems(ctx context.Context, datacallID int32, opdivIDs []int32, restrictToOpDivIDs bool) ([]*FismaSystem, error) {
 	cols := append(fismaSystemColumns[1:], "fs.fismasystemid")
 	sqlb := stmntBuilder.
 		Select(cols...).
 		From("fismasystems fs").
 		InnerJoin("datacalls_fismasystems dcfs ON fs.fismasystemid = dcfs.fismasystemid").
-		Where("dcfs.datacallid = ?", datacallID).
-		OrderBy("fs.fismaacronym ASC")
+		Where("dcfs.datacallid = ?", datacallID)
+
+	switch {
+	case restrictToOpDivIDs && len(opdivIDs) == 0:
+		sqlb = sqlb.Where("FALSE")
+	case len(opdivIDs) > 0:
+		sqlb = sqlb.Where("fs.opdiv_id = ANY(?)", opdivIDs)
+	}
+
+	sqlb = sqlb.OrderBy("fs.fismaacronym ASC")
 
 	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[FismaSystem])
 }

--- a/backend/internal/model/opdivs.go
+++ b/backend/internal/model/opdivs.go
@@ -43,13 +43,17 @@ func FindOpDivs(ctx context.Context, input FindOpDivsInput) ([]*OpDiv, error) {
 }
 
 func (o *OpDiv) validate() error {
-	inputErr := InvalidInputError{data: map[string]any{}}
+	// Canonicalize before checking AND storing so the length bound can't be
+	// bypassed with padding and the active-code uniqueness index (LOWER(code),
+	// not trimmed) cannot be defeated by leading/trailing whitespace.
+	o.Code = strings.TrimSpace(o.Code)
+	o.Name = strings.TrimSpace(o.Name)
 
-	code := strings.TrimSpace(o.Code)
-	if code == "" || len(code) > 16 {
+	inputErr := InvalidInputError{data: map[string]any{}}
+	if o.Code == "" || len(o.Code) > 16 {
 		inputErr.data["code"] = "1-16 characters required"
 	}
-	if name := strings.TrimSpace(o.Name); name == "" || len(name) > 128 {
+	if o.Name == "" || len(o.Name) > 128 {
 		inputErr.data["name"] = "1-128 characters required"
 	}
 

--- a/backend/internal/model/opdivs.go
+++ b/backend/internal/model/opdivs.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -38,4 +40,61 @@ func FindOpDivs(ctx context.Context, input FindOpDivsInput) ([]*OpDiv, error) {
 	}
 
 	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[OpDiv])
+}
+
+func (o *OpDiv) validate() error {
+	inputErr := InvalidInputError{data: map[string]any{}}
+
+	code := strings.TrimSpace(o.Code)
+	if code == "" || len(code) > 16 {
+		inputErr.data["code"] = "1-16 characters required"
+	}
+	if name := strings.TrimSpace(o.Name); name == "" || len(name) > 128 {
+		inputErr.data["name"] = "1-128 characters required"
+	}
+
+	if len(inputErr.data) > 0 {
+		return &inputErr
+	}
+	return nil
+}
+
+// Save inserts a new OpDiv or updates an existing one (OpDivID > 0). A new
+// OpDiv is always created active; deactivation is done by updating an existing
+// row with active=false. The partial unique index on LOWER(code) WHERE active
+// means inserting a second active row with an existing code returns ErrNotUnique.
+func (o *OpDiv) Save(ctx context.Context) (*OpDiv, error) {
+	if err := o.validate(); err != nil {
+		return nil, err
+	}
+
+	var sqlb SqlBuilder
+	if o.OpDivID == 0 {
+		sqlb = stmntBuilder.
+			Insert("public.opdivs").
+			Columns("code", "name", "is_parent", "active").
+			Values(o.Code, o.Name, o.IsParent, true).
+			Suffix("RETURNING opdiv_id, code, name, is_parent, active")
+	} else {
+		sqlb = stmntBuilder.
+			Update("public.opdivs").
+			Set("code", o.Code).
+			Set("name", o.Name).
+			Set("is_parent", o.IsParent).
+			Set("active", o.Active).
+			Where("opdiv_id=?", o.OpDivID).
+			Suffix("RETURNING opdiv_id, code, name, is_parent, active")
+	}
+
+	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByName[OpDiv])
+	if err != nil {
+		// The only unique constraint on opdivs is the active-code index, so map
+		// a uniqueness violation to a clear field-level message the frontend can
+		// show inline rather than leaking the raw constraint detail.
+		if errors.Is(err, ErrNotUnique) {
+			return nil, &InvalidInputError{data: map[string]any{"code": "an OpDiv with this code already exists"}}
+		}
+		return nil, err
+	}
+	return saved, nil
 }

--- a/backend/internal/model/opdivs.go
+++ b/backend/internal/model/opdivs.go
@@ -13,8 +13,13 @@ type OpDiv struct {
 	OpDivID  int32  `json:"opdiv_id" db:"opdiv_id"`
 	Code     string `json:"code"`
 	Name     string `json:"name"`
-	IsParent bool   `json:"is_parent" db:"is_parent"`
-	Active   bool   `json:"active"`
+	// IsParent and Active are pointers so an update can distinguish "not supplied"
+	// (nil, leave the column untouched) from an explicit false. With a non-pointer
+	// bool, any update that omits the field defaults to false: omitting is_parent
+	// would demote the HHS parent OpDiv (which drives HHS-wide authorization), and
+	// omitting active would silently deactivate an active OpDiv.
+	IsParent *bool `json:"is_parent" db:"is_parent"`
+	Active   *bool `json:"active"`
 }
 
 // FindOpDivsInput holds optional filters for listing OpDivs.
@@ -74,18 +79,28 @@ func (o *OpDiv) Save(ctx context.Context) (*OpDiv, error) {
 
 	var sqlb SqlBuilder
 	if o.OpDivID == 0 {
+		// Create: a new OpDiv is always active; is_parent defaults to false when
+		// the optional field is omitted.
+		isParent := o.IsParent != nil && *o.IsParent
 		sqlb = stmntBuilder.
 			Insert("public.opdivs").
 			Columns("code", "name", "is_parent", "active").
-			Values(o.Code, o.Name, o.IsParent, true).
+			Values(o.Code, o.Name, isParent, true).
 			Suffix("RETURNING opdiv_id, code, name, is_parent, active")
 	} else {
-		sqlb = stmntBuilder.
+		ub := stmntBuilder.
 			Update("public.opdivs").
 			Set("code", o.Code).
-			Set("name", o.Name).
-			Set("is_parent", o.IsParent).
-			Set("active", o.Active).
+			Set("name", o.Name)
+		// Only touch is_parent / active when the caller explicitly supplied them;
+		// omitting a field (nil) must leave the current value intact.
+		if o.IsParent != nil {
+			ub = ub.Set("is_parent", *o.IsParent)
+		}
+		if o.Active != nil {
+			ub = ub.Set("active", *o.Active)
+		}
+		sqlb = ub.
 			Where("opdiv_id=?", o.OpDivID).
 			Suffix("RETURNING opdiv_id, code, name, is_parent, active")
 	}

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -339,6 +339,11 @@ type FindScoresInput struct {
 	DataCallID     *int32 `schema:"datacallid"`
 	UserID         *string
 	IncludePillars *bool `schema:"include_pillars"`
+	// OpDiv scope for OpDiv-scoped admin tiers. Restricts scores to systems in
+	// the admin's granted OpDivs; RestrictToOpDivIDs with an empty slice fails
+	// closed. Not schema-tagged - the controller sets them from the auth'd user.
+	OpDivIDs           []int32
+	RestrictToOpDivIDs bool
 }
 
 func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
@@ -363,6 +368,17 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 
 	if input.DataCallID != nil {
 		sqlb = sqlb.Where("datacallid=?", *input.DataCallID)
+	}
+
+	// OpDiv scope (fail-closed): restrict to scores whose system belongs to one
+	// of the admin's granted OpDivs. Empty grants under RestrictToOpDivIDs ->
+	// no rows. Expressed as a subquery predicate so it composes with the audit
+	// joins below without disturbing their arg ordering.
+	switch {
+	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
+		sqlb = sqlb.Where("FALSE")
+	case len(input.OpDivIDs) > 0:
+		sqlb = sqlb.Where("scores.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY(?))", input.OpDivIDs)
 	}
 
 	// Attach last-edit audit info. The lateral subquery picks the most recent
@@ -584,6 +600,17 @@ func buildPillarScoresSQL(input FindScoresInput) (string, []any) {
 			argN++
 		}
 		conds = append(conds, fmt.Sprintf("fs.fismasystemid IN (%s)", strings.Join(placeholders, ",")))
+	}
+
+	// OpDiv scope (fail-closed) on the expected CTE, which already joins
+	// fismasystems as fs. Empty grants under RestrictToOpDivIDs -> FALSE.
+	switch {
+	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
+		conds = append(conds, "FALSE")
+	case len(input.OpDivIDs) > 0:
+		conds = append(conds, fmt.Sprintf("fs.opdiv_id = ANY($%d)", argN))
+		args = append(args, input.OpDivIDs)
+		argN++
 	}
 
 	var userJoin string

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -270,6 +270,54 @@ func TestFindScoresAggregate_ISSOwithSpecificSystem(t *testing.T) {
 	})
 }
 
+// TestBuildPillarScoresSQL_OpDivScope verifies the OpDiv read-scope predicate
+// added for the OPDIV_ADMIN / OPDIV_READONLY_ADMIN tiers: a non-empty grant set
+// emits fs.opdiv_id = ANY($N) and binds the slice; a restricted-but-empty set
+// fails closed by emitting FALSE so a scoped admin with zero grants matches no
+// rows rather than every row.
+func TestBuildPillarScoresSQL_OpDivScope(t *testing.T) {
+	t.Run("ScopedToGrantedOpDivs", func(t *testing.T) {
+		input := normalizeInput(FindScoresInput{
+			RestrictToOpDivIDs: true,
+			OpDivIDs:           []int32{7, 9},
+		})
+
+		sql, args := buildPillarScoresSQL(input)
+
+		assert.Contains(t, sql, "fs.opdiv_id = ANY($", "should scope the expected CTE by OpDiv")
+		assert.NotContains(t, sql, "FALSE", "non-empty grants should not fail closed")
+		found := false
+		for _, a := range args {
+			if ids, ok := a.([]int32); ok && len(ids) == 2 && ids[0] == 7 && ids[1] == 9 {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "the OpDiv id slice should be bound as a single ANY() arg")
+	})
+
+	t.Run("RestrictedWithNoGrantsFailsClosed", func(t *testing.T) {
+		input := normalizeInput(FindScoresInput{
+			RestrictToOpDivIDs: true,
+			OpDivIDs:           nil,
+		})
+
+		sql, _ := buildPillarScoresSQL(input)
+
+		assert.Contains(t, sql, "FALSE", "a scoped admin with no grants must match nothing")
+		assert.NotContains(t, sql, "fs.opdiv_id = ANY($", "should not bind an OpDiv predicate when there are no grants")
+	})
+
+	t.Run("UnscopedEmitsNoOpDivPredicate", func(t *testing.T) {
+		input := normalizeInput(FindScoresInput{})
+
+		sql, _ := buildPillarScoresSQL(input)
+
+		assert.NotContains(t, sql, "fs.opdiv_id = ANY($", "unscoped admins get no OpDiv filter")
+		assert.NotContains(t, sql, "FALSE", "unscoped admins do not fail closed")
+	})
+}
+
 // TestScoreAuditInfo verifies the Auditable contract: AuditInfo returns the
 // two pointers exactly as set on the struct. Pure accessor, no logic, but
 // the contract is what generic consumers (exports, admin views) will rely

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -154,6 +154,54 @@ func (u *User) CanManageFismaSystem(opdivID *int32) bool {
 	return opdivID != nil && u.IsAssignedOpDiv(*opdivID)
 }
 
+// CanAssignRole reports whether this user may assign the given role to another
+// user. Prevents tier escalation: an OPDIV_ADMIN can only mint roles at or below
+// the OpDiv tier, an HHS_ADMIN can mint anything except the platform OWNER tier,
+// and only an OWNER can mint another OWNER.
+func (u *User) CanAssignRole(role string) bool {
+	switch u.Role {
+	case "OWNER":
+		return true
+	case "HHS_ADMIN":
+		return role != "OWNER"
+	case "OPDIV_ADMIN":
+		switch role {
+		case "OPDIV_ADMIN", "OPDIV_READONLY_ADMIN", "ISSO", "ISSM":
+			return true
+		}
+	}
+	return false
+}
+
+// CanManageUser reports whether this user may modify the target user.
+// OWNER/HHS_ADMIN manage anyone; an OPDIV_ADMIN may only manage a user who
+// shares at least one of the admin's granted OpDivs. Used for update/delete of
+// an existing user (create is gated by CanAssignRole plus the scoped grant step,
+// since a brand-new user has no OpDiv yet).
+func (u *User) CanManageUser(target *User) bool {
+	if !u.IsAdmin() || target == nil {
+		return false
+	}
+	// Tier ceiling: you may only manage a user whose current role is within your
+	// assignable set. This stops an OPDIV_ADMIN from acting on a higher-tier
+	// account (e.g. HHS_ADMIN/OWNER) even if an OpDiv is shared, and stops an
+	// HHS_ADMIN from acting on an OWNER. Without this, granting one's own OpDiv
+	// onto a superior account would manufacture the overlap and bypass the tier.
+	if !u.CanAssignRole(target.Role) {
+		return false
+	}
+	if u.HasUnscopedRead() {
+		return true
+	}
+	// OPDIV_ADMIN: must also share an OpDiv with the target.
+	for _, t := range target.AssignedOpDivIDs {
+		if t != nil && u.IsAssignedOpDiv(*t) {
+			return true
+		}
+	}
+	return false
+}
+
 func (u *User) Save(ctx context.Context) (*User, error) {
 	if err := u.validate(); err != nil {
 		return nil, err

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -287,6 +287,13 @@ type FindUsersInput struct {
 	FullName *string `schema:"fullname"`
 	Role     *string `schema:"role"`
 	Deleted  bool    `schema:"deleted"`
+	// OpDivIDs / RestrictToOpDivIDs scope the list to users holding a grant in
+	// one of the acting admin's OpDivs. Mirror of FindFismaSystemsInput: when
+	// RestrictToOpDivIDs is set with an empty slice the query fails closed
+	// (WHERE FALSE) rather than returning every user. Not schema-tagged so a
+	// client cannot inject scope via query params - the controller sets them.
+	OpDivIDs           []int32
+	RestrictToOpDivIDs bool
 }
 
 func (fui *FindUsersInput) validate() error {
@@ -329,6 +336,16 @@ func FindUsers(ctx context.Context, fui *FindUsersInput) ([]*User, error) {
 
 	if fui.Role != nil {
 		sqlb = sqlb.Where("role=?", fui.Role)
+	}
+
+	// OpDiv scope (fail-closed): an OpDiv-scoped admin only sees users who hold
+	// a grant in one of their OpDivs. Empty grants under RestrictToOpDivIDs ->
+	// no rows. Unscoped admins set neither field and see everyone.
+	switch {
+	case fui.RestrictToOpDivIDs && len(fui.OpDivIDs) == 0:
+		sqlb = sqlb.Where("FALSE")
+	case len(fui.OpDivIDs) > 0:
+		sqlb = sqlb.Where("EXISTS (SELECT 1 FROM users_opdivs uod WHERE uod.userid = users.userid AND uod.opdiv_id = ANY(?))", fui.OpDivIDs)
 	}
 
 	return query(ctx, sqlb, pgx.RowToAddrOfStructByNameLax[User])

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -121,6 +121,39 @@ func (u *User) IsAssignedFismaSystem(fismasystemid int32) bool {
 	return false
 }
 
+// EffectiveOpDivScope describes the OpDiv visibility a query should grant this
+// user. unscoped is true for tiers that see every OpDiv (OWNER, HHS_ADMIN,
+// HHS_READONLY_ADMIN); for OpDiv-scoped tiers it returns the concrete OpDiv ids
+// the user holds grants for. Callers pass these straight into a Find*Input so
+// the scope predicate lives in one place. A scoped user with no grants yields
+// (false, nil) which the query layer treats as "match nothing" (fail closed).
+func (u *User) EffectiveOpDivScope() (unscoped bool, opdivIDs []int32) {
+	if u.HasUnscopedRead() {
+		return true, nil
+	}
+	for _, id := range u.AssignedOpDivIDs {
+		if id != nil {
+			opdivIDs = append(opdivIDs, *id)
+		}
+	}
+	return false, opdivIDs
+}
+
+// CanManageFismaSystem is the write-side counterpart to CanAccessFismaSystem.
+// A user may modify a system only if they hold an admin (write) tier AND either
+// see every OpDiv (OWNER, HHS_ADMIN) or hold a grant for the system's OpDiv
+// (OPDIV_ADMIN). Read-only admins and system-scoped ISSO/ISSM are not write
+// managers of a system regardless of OpDiv.
+func (u *User) CanManageFismaSystem(opdivID *int32) bool {
+	if !u.IsAdmin() {
+		return false
+	}
+	if u.HasUnscopedRead() {
+		return true
+	}
+	return opdivID != nil && u.IsAssignedOpDiv(*opdivID)
+}
+
 func (u *User) Save(ctx context.Context) (*User, error) {
 	if err := u.validate(); err != nil {
 		return nil, err

--- a/backend/internal/model/users_test.go
+++ b/backend/internal/model/users_test.go
@@ -12,14 +12,14 @@ import (
 // added to the enum surfaces here first (or fails compile when the column
 // shape changes).
 type roleMatrixRow struct {
-	role               string
-	isOwner            bool
-	isHHSTier          bool
-	isOpDivTier        bool
-	hasUnscopedRead    bool
-	isAdmin            bool
-	isReadOnlyAdmin    bool
-	hasAdminRead       bool
+	role            string
+	isOwner         bool
+	isHHSTier       bool
+	isOpDivTier     bool
+	hasUnscopedRead bool
+	isAdmin         bool
+	isReadOnlyAdmin bool
+	hasAdminRead    bool
 }
 
 var roleMatrix = []roleMatrixRow{
@@ -91,11 +91,11 @@ func TestUser_CanAccessFismaSystem(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		user       *User
+		name        string
+		user        *User
 		systemOpDiv *int32
-		systemID   int32
-		want       bool
+		systemID    int32
+		want        bool
 	}{
 		{"OWNER sees everything", withGrants("OWNER", nil, nil), &opdivCDC, system101, true},
 		{"HHS_ADMIN sees everything", withGrants("HHS_ADMIN", nil, nil), &opdivCDC, system101, true},
@@ -123,6 +123,66 @@ func TestUser_CanAccessFismaSystem(t *testing.T) {
 			assert.Equal(t, tt.want, tt.user.CanAccessFismaSystem(tt.systemOpDiv, tt.systemID))
 		})
 	}
+}
+
+func TestUser_CanManageFismaSystem(t *testing.T) {
+	cms := int32(2)
+	cdc := int32(3)
+	grant := func(role string, opdivs ...int32) *User {
+		u := &User{Role: role}
+		for i := range opdivs {
+			u.AssignedOpDivIDs = append(u.AssignedOpDivIDs, &opdivs[i])
+		}
+		return u
+	}
+
+	tests := []struct {
+		name  string
+		user  *User
+		opdiv *int32
+		want  bool
+	}{
+		{"OWNER manages any", grant("OWNER"), &cdc, true},
+		{"OWNER manages even nil opdiv", grant("OWNER"), nil, true},
+		{"HHS_ADMIN manages any", grant("HHS_ADMIN"), &cdc, true},
+		{"HHS_READONLY_ADMIN cannot manage (not write tier)", grant("HHS_READONLY_ADMIN"), &cdc, false},
+		{"OPDIV_ADMIN manages own opdiv", grant("OPDIV_ADMIN", cdc), &cdc, true},
+		{"OPDIV_ADMIN cannot manage other opdiv", grant("OPDIV_ADMIN", cdc), &cms, false},
+		{"OPDIV_ADMIN with no grant manages nothing", grant("OPDIV_ADMIN"), &cms, false},
+		{"OPDIV_ADMIN nil opdiv denied", grant("OPDIV_ADMIN", cdc), nil, false},
+		{"OPDIV_READONLY_ADMIN cannot manage", grant("OPDIV_READONLY_ADMIN", cdc), &cdc, false},
+		{"ISSO cannot manage", grant("ISSO"), &cdc, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.user.CanManageFismaSystem(tt.opdiv))
+		})
+	}
+}
+
+func TestUser_EffectiveOpDivScope(t *testing.T) {
+	a, b := int32(3), int32(7)
+
+	t.Run("unscoped tiers see all", func(t *testing.T) {
+		for _, role := range []string{"OWNER", "HHS_ADMIN", "HHS_READONLY_ADMIN"} {
+			unscoped, ids := (&User{Role: role}).EffectiveOpDivScope()
+			assert.True(t, unscoped, role)
+			assert.Nil(t, ids, role)
+		}
+	})
+
+	t.Run("opdiv admin returns granted ids", func(t *testing.T) {
+		u := &User{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{&a, nil, &b}}
+		unscoped, ids := u.EffectiveOpDivScope()
+		assert.False(t, unscoped)
+		assert.Equal(t, []int32{3, 7}, ids)
+	})
+
+	t.Run("opdiv admin with no grants is fail-closed empty", func(t *testing.T) {
+		unscoped, ids := (&User{Role: "OPDIV_ADMIN"}).EffectiveOpDivScope()
+		assert.False(t, unscoped)
+		assert.Empty(t, ids)
+	})
 }
 
 func TestUser_IsAssignedFismaSystem(t *testing.T) {

--- a/backend/internal/model/users_test.go
+++ b/backend/internal/model/users_test.go
@@ -185,6 +185,64 @@ func TestUser_EffectiveOpDivScope(t *testing.T) {
 	})
 }
 
+func TestUser_CanAssignRole(t *testing.T) {
+	tests := []struct {
+		actor, target string
+		want          bool
+	}{
+		{"OWNER", "OWNER", true},
+		{"OWNER", "HHS_ADMIN", true},
+		{"OWNER", "ISSO", true},
+		{"HHS_ADMIN", "OWNER", false}, // cannot mint platform tier
+		{"HHS_ADMIN", "HHS_ADMIN", true},
+		{"HHS_ADMIN", "OPDIV_ADMIN", true},
+		{"HHS_ADMIN", "ISSM", true},
+		{"OPDIV_ADMIN", "OWNER", false},
+		{"OPDIV_ADMIN", "HHS_ADMIN", false},
+		{"OPDIV_ADMIN", "HHS_READONLY_ADMIN", false},
+		{"OPDIV_ADMIN", "OPDIV_ADMIN", true},
+		{"OPDIV_ADMIN", "OPDIV_READONLY_ADMIN", true},
+		{"OPDIV_ADMIN", "ISSO", true},
+		{"OPDIV_ADMIN", "ISSM", true},
+		{"OPDIV_READONLY_ADMIN", "ISSO", false}, // read-only cannot assign at all
+		{"ISSO", "ISSO", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.actor+"->"+tt.target, func(t *testing.T) {
+			assert.Equal(t, tt.want, (&User{Role: tt.actor}).CanAssignRole(tt.target))
+		})
+	}
+}
+
+func TestUser_CanManageUser(t *testing.T) {
+	cdc, nih := int32(3), int32(4)
+	target := func(opdivs ...int32) *User {
+		u := &User{Role: "ISSO"}
+		for i := range opdivs {
+			u.AssignedOpDivIDs = append(u.AssignedOpDivIDs, &opdivs[i])
+		}
+		return u
+	}
+	opdivAdmin := &User{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{&cdc}}
+
+	assert.True(t, (&User{Role: "OWNER"}).CanManageUser(target(nih)), "OWNER manages anyone")
+	assert.True(t, (&User{Role: "HHS_ADMIN"}).CanManageUser(target(nih)), "HHS_ADMIN manages anyone")
+	assert.False(t, (&User{Role: "HHS_READONLY_ADMIN"}).CanManageUser(target(nih)), "read-only is not a manager")
+	assert.True(t, opdivAdmin.CanManageUser(target(cdc)), "opdiv admin manages a user in their opdiv")
+	assert.True(t, opdivAdmin.CanManageUser(target(cdc, nih)), "manages a user sharing one opdiv")
+	assert.False(t, opdivAdmin.CanManageUser(target(nih)), "cannot manage a user outside their opdiv")
+	assert.False(t, opdivAdmin.CanManageUser(target()), "cannot manage a user with no opdiv overlap")
+	assert.False(t, opdivAdmin.CanManageUser(nil), "nil target denied")
+
+	// Tier ceiling: a shared OpDiv does NOT let an OPDIV_ADMIN act on a
+	// higher-tier account, and an HHS_ADMIN cannot act on an OWNER.
+	superiorInOpDiv := &User{Role: "HHS_ADMIN", AssignedOpDivIDs: []*int32{&cdc}}
+	assert.False(t, opdivAdmin.CanManageUser(superiorInOpDiv), "shared opdiv must not bypass the tier ceiling")
+	ownerTarget := &User{Role: "OWNER", AssignedOpDivIDs: []*int32{&cdc}}
+	assert.False(t, (&User{Role: "HHS_ADMIN"}).CanManageUser(ownerTarget), "HHS_ADMIN cannot manage an OWNER")
+	assert.True(t, (&User{Role: "OWNER"}).CanManageUser(ownerTarget), "OWNER can manage an OWNER")
+}
+
 func TestUser_IsAssignedFismaSystem(t *testing.T) {
 	id1 := int32(100)
 	id2 := int32(200)

--- a/backend/internal/model/usersopdivs.go
+++ b/backend/internal/model/usersopdivs.go
@@ -1,0 +1,113 @@
+package model
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/jackc/pgx/v5"
+)
+
+// UserOpDiv is a grant of OpDiv membership to a user (the users_opdivs junction).
+type UserOpDiv struct {
+	UserID    string  `json:"userid"`
+	OpDivID   int32   `json:"opdiv_id" db:"opdiv_id"`
+	GrantedBy *string `json:"granted_by,omitempty" db:"granted_by"`
+}
+
+func (uo *UserOpDiv) validate() error {
+	inputErr := InvalidInputError{data: map[string]any{}}
+	if !isValidUUID(uo.UserID) {
+		inputErr.data["userid"] = "uuid required"
+	}
+	if uo.OpDivID == 0 {
+		inputErr.data["opdiv_id"] = "int required"
+	}
+	if len(inputErr.data) > 0 {
+		return &inputErr
+	}
+	return nil
+}
+
+// Save grants the user the OpDiv (idempotent via ON CONFLICT) and recomputes
+// the user's identity_provider from the resulting OpDiv set, so IdP routing
+// stays a function of OpDiv membership rather than a free-form field.
+func (uo *UserOpDiv) Save(ctx context.Context) (*UserOpDiv, error) {
+	if err := uo.validate(); err != nil {
+		return nil, err
+	}
+
+	sqlb := stmntBuilder.
+		Insert("users_opdivs").
+		Columns("userid", "opdiv_id", "granted_by").
+		Values(uo.UserID, uo.OpDivID, uo.GrantedBy).
+		Suffix("ON CONFLICT (userid, opdiv_id) DO NOTHING RETURNING userid, opdiv_id, granted_by")
+
+	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[UserOpDiv])
+	if err != nil {
+		// ON CONFLICT DO NOTHING returns no row when the grant already exists;
+		// that is an idempotent success, not an error.
+		if errors.Is(err, ErrNoData) {
+			saved = uo
+		} else {
+			return nil, err
+		}
+	}
+
+	if err := deriveIdentityProvider(ctx, uo.UserID); err != nil {
+		return nil, err
+	}
+	return saved, nil
+}
+
+// Delete revokes the grant (idempotent) and recomputes identity_provider.
+func (uo *UserOpDiv) Delete(ctx context.Context) error {
+	if err := uo.validate(); err != nil {
+		return err
+	}
+
+	sqlb := stmntBuilder.
+		Delete("users_opdivs").
+		Where("userid=? AND opdiv_id=?", uo.UserID, uo.OpDivID).
+		Suffix("RETURNING userid, opdiv_id")
+
+	if _, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[UserOpDiv]); err != nil {
+		if !errors.Is(err, ErrNoData) {
+			return err
+		}
+	}
+
+	return deriveIdentityProvider(ctx, uo.UserID)
+}
+
+// FindUserOpDivsByUserID returns the OpDiv ids a user holds grants for.
+func FindUserOpDivsByUserID(ctx context.Context, userID string) ([]int32, error) {
+	sqlb := stmntBuilder.
+		Select("opdiv_id").
+		From("users_opdivs").
+		Where("userid=?", userID).
+		OrderBy("opdiv_id")
+
+	return query(ctx, sqlb, pgx.RowTo[int32])
+}
+
+// deriveIdentityProvider sets a user's identity_provider from their OpDiv
+// grants: a CMS grant means Okta, anything else (including no grant) means
+// Entra. This is the default IdP routing rule; an OWNER may override the stored
+// value explicitly, but every grant change re-derives it. The CMS literal here
+// is the business rule for IdP selection, not an authorization scope check.
+func deriveIdentityProvider(ctx context.Context, userID string) error {
+	sqlb := stmntBuilder.
+		Update("users").
+		Set("identity_provider", squirrel.Expr(
+			"CASE WHEN EXISTS (SELECT 1 FROM users_opdivs uo JOIN opdivs o ON o.opdiv_id = uo.opdiv_id WHERE uo.userid = users.userid AND o.code = 'CMS') THEN 'okta' ELSE 'entra' END",
+		)).
+		Where("userid=?", userID).
+		Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider")
+
+	_, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
+	if errors.Is(err, ErrNoData) {
+		return nil
+	}
+	return err
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -895,6 +895,122 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  /users/{userid}/assignedopdivs:
+    get:
+      summary: List a user's OpDiv grants
+      description: |
+        Returns the OpDiv ids a user holds grants for. Unscoped admins may view
+        any user; an OpDiv-scoped admin may only view a user who shares one of
+        their OpDivs.
+      operationId: listUserOpDivs
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userid
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+'
+      responses:
+        '200':
+          description: A list of OpDiv ids
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: integer
+                      format: int32
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      summary: Grant a user OpDiv membership
+      description: |
+        Grants the user membership in an OpDiv (idempotent). Unscoped admins may
+        grant any OpDiv; an OPDIV_ADMIN may only grant an OpDiv they themselves
+        hold and only onto a user whose tier is within their assignable set.
+        Granting recomputes the user's identity_provider from their OpDiv set
+        (CMS -> okta, otherwise entra).
+      operationId: grantUserOpDiv
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userid
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                opdiv_id:
+                  type: integer
+                  format: int32
+              required:
+                - opdiv_id
+      responses:
+        '201':
+          description: OpDiv granted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/UserOpDiv'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /users/{userid}/assignedopdivs/{opdiv_id}:
+    delete:
+      summary: Revoke a user's OpDiv grant
+      description: |
+        Revokes a user's OpDiv membership (idempotent). Same scope as granting:
+        an OPDIV_ADMIN may only revoke an OpDiv they hold. Recomputes the user's
+        identity_provider afterward.
+      operationId: revokeUserOpDiv
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userid
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+'
+        - name: opdiv_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '204':
+          description: OpDiv grant revoked
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /scores:
     get:
       summary: List scores
@@ -1543,6 +1659,21 @@ components:
       required:
         - userid
         - fismasystemid
+    UserOpDiv:
+      type: object
+      properties:
+        userid:
+          type: string
+        opdiv_id:
+          type: integer
+          format: int32
+        granted_by:
+          type: string
+          nullable: true
+          description: userid of the admin who granted the membership.
+      required:
+        - userid
+        - opdiv_id
     Score:
       type: object
       properties:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -538,6 +538,71 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/ServerError'
+    post:
+      summary: Create an OpDiv
+      description: |
+        Creates a new Operating Division. OWNER only - the OpDiv list is the
+        tenant boundary. A new OpDiv is always created active. Returns 400 with
+        a field-level message (data.code) if the code is missing/too long or
+        already in use by another active OpDiv.
+      operationId: createOpDiv
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpDivInput'
+      responses:
+        '201':
+          description: Created OpDiv
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/OpDiv'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /opdivs/{opdiv_id}:
+    put:
+      summary: Update or deactivate an OpDiv
+      description: |
+        Updates an OpDiv's code/name/is_parent/active. OWNER only. Set
+        active=false to deactivate (soft) rather than delete. Returns 204.
+      operationId: updateOpDiv
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: opdiv_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpDivInput'
+      responses:
+        '204':
+          description: Updated (no body)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /users:
     get:
       summary: List users
@@ -1444,6 +1509,29 @@ components:
         - name
         - is_parent
         - active
+    OpDivInput:
+      type: object
+      description: Request body for creating or updating an OpDiv (OWNER only).
+      properties:
+        code:
+          type: string
+          maxLength: 16
+          description: Short code, 1-16 chars, unique among active OpDivs.
+        name:
+          type: string
+          maxLength: 128
+          description: Official division name, 1-128 chars.
+        is_parent:
+          type: boolean
+          description: TRUE only for a department/parent row.
+        active:
+          type: boolean
+          description: >-
+            Honored on update only (set false to deactivate). Ignored on create;
+            a new OpDiv is always created active.
+      required:
+        - code
+        - name
     UserFismaSystem:
       type: object
       properties:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -606,7 +606,7 @@ paths:
   /users:
     get:
       summary: List users
-      description: Returns a list of users
+      description: Returns a list of users. Unscoped admins (OWNER, HHS_ADMIN, HHS_READONLY_ADMIN) see all users; OpDiv-scoped tiers (OPDIV_ADMIN, OPDIV_READONLY_ADMIN) see only users holding a grant in one of their OpDivs (fail-closed - a scoped admin with no grants gets an empty list).
       operationId: listUsers
       security:
         - bearerAuth: []
@@ -1014,7 +1014,7 @@ paths:
   /scores:
     get:
       summary: List scores
-      description: Returns a list of scores
+      description: Returns a list of scores. Unscoped admins see all; OpDiv-scoped tiers (OPDIV_ADMIN, OPDIV_READONLY_ADMIN) see only scores for systems in their granted OpDivs (fail-closed); ISSO/ISSM see only their assigned systems' scores.
       operationId: listScores
       parameters:
         - name: fismasystemid
@@ -1348,7 +1348,7 @@ paths:
   /events:
     get:
       summary: Get events
-      description: Returns the audit trail of write operations (admin tiers only)
+      description: Returns the audit trail of write operations. Restricted to the unscoped admin tiers (OWNER, HHS_ADMIN, HHS_READONLY_ADMIN); OpDiv-scoped tiers (OPDIV_ADMIN, OPDIV_READONLY_ADMIN) receive 403 because audit events carry no OpDiv to scope the log on.
       operationId: getEvents
       security:
         - bearerAuth: []
@@ -1421,7 +1421,7 @@ paths:
   /massemails:
     post:
       summary: Send mass email
-      description: Sends a mass email
+      description: Sends a mass email to recipients across every OpDiv. Restricted to the unscoped write-admin tiers (OWNER, HHS_ADMIN); read-only admins and OpDiv-scoped tiers receive 403 (there is no per-OpDiv recipient scoping).
       operationId: sendMassEmail
       security:
         - bearerAuth: []


### PR DESCRIPTION
## Summary

Adds authorization enforcement for the multi-OpDiv role model on top of the
schema that already shipped (opdivs reference table, fismasystems.opdiv_id,
users_opdivs junction, the new role enum). Before this branch, reads were only
partially scoped and write paths were not scoped at all: an OPDIV_ADMIN could
edit or delete systems in any OpDiv, score any system, and manage any user, and
there was no endpoint to create an OpDiv or grant a user an OpDiv. This branch
closes those gaps so a scoped admin manages only their own OpDiv, while
OWNER/HHS tiers retain full cross-OpDiv access.

## What changed

**OpDiv administration (OWNER-only)**
- `POST /api/v1/opdivs`, `PUT /api/v1/opdivs/{opdiv_id}` to create / update / deactivate an OpDiv.

**OpDiv grants (user membership)**
- `GET/POST/DELETE /api/v1/users/{userid}/assignedopdivs[/{opdiv_id}]` to list, grant, and revoke OpDiv membership. An OPDIV_ADMIN may only grant/revoke an OpDiv they themselves hold, and only onto a user within their assignable tier.
- A user's `identity_provider` is derived from their OpDiv on grant/revoke (CMS to okta, otherwise entra) and is only overridable by an OWNER.

**Write-path scope**
- Editing, decommissioning, reactivating, and assigning a user to a system, scoring a system, and marking a data call complete are all gated so an OPDIV_ADMIN is limited to systems in an OpDiv they hold. OWNER/HHS_ADMIN are unrestricted; ISSO/ISSM keep their per-system assignment path.
- Role-escalation guard on user create/update: an OPDIV_ADMIN cannot mint or modify a user above the OpDiv tier, and cannot manage a user outside their OpDiv.

**Read-path scope (fail-closed)**
- User, score, and data-call-completion lists are scoped to the caller's OpDivs for OPDIV tiers. A scoped admin with zero grants matches nothing rather than falling through to an unscoped read.
- The audit trail (`GET /events`) and mass email (`POST /massemails`) are restricted to the unscoped admin tiers, since neither has a per-OpDiv scope to filter on.

**Migration**
- `0041` adds an idempotent index on `fismasystems.opdiv_id` to back the scope predicates. No data change.

**Docs and tests**
- OpenAPI updated for the new endpoints and the scoped / restricted behavior.
- Unit tests for the role helpers, the fail-closed SQL predicate, and the controller authorization gates; Emberfall E2E negative matrix asserting cross-OpDiv writes return 403 and scoped reads exclude out-of-OpDiv rows.

## Related issues

- Closes CMS-Enterprise/ztmf#313 (Backend: surface OpDiv / identity_provider fields and add scope predicates), and additionally delivers three items that issue had deferred (OpDiv scope on scores/events/datacalls, grant-management endpoints, and write-path scope beyond create) because the authorization layer must be complete before the dual-IdP work admits OpDiv-scoped users.
- Part of epic CMS-Enterprise/ztmf-misc#198 (HHS multi-OpDiv expansion).
- Builds on the database work in #311 / #312 and the role-value cleanup in #314, all already on `main`.

## Safety and rollout

A no-op for current production: no OPDIV_ADMIN users exist yet, and the
OWNER / HHS tiers short-circuit every new check. The only migration is an index
(idempotent up / reversible down). Rollback is a redeploy of the prior image.
Per team policy this branch is not deployed to a shared environment before merge.

## Testing

`make test-full` green: unit + isolated integration + 111 Emberfall E2E.

### How to verify

- The OpDiv negative matrix lives at the bottom of `backend/emberfall_tests.yml`: cross-OpDiv writes return 403, scoped reads exclude out-of-OpDiv rows, and `/events` + mass email are gated to unscoped admins.
- To poke it by hand, the seed adds an `OPDIV_ADMIN` (EMPIRE grant only) plus REBELLION systems 1005/1006 (token anchor `opDivAdminHeaders` in the test file). `PUT /fismasystems/1005` or `POST /scores` for 1006 returns 403; EMPIRE systems 1001-1004 succeed.
- The scope logic is centralized in `backend/internal/model/users.go` (`CanManageFismaSystem`, `CanManageUser`, `EffectiveOpDivScope`) and exercised in `backend/cmd/api/internal/controller/rbac_enforcement_test.go`, so the role/scope matrix is reviewable in one place.

## Sequencing

Lands before the dual-IdP branch, which rebases on top once this merges. A
paired ztmf-ui PR adds the matching UI gates (hide actions and views a scoped
admin would be 403'd on); the two land together so no admin loses UI in between.

