### PR TITLE
fix(#328): refresh DB credentials and retry on auth failure after secret rotation

### DIFF
--- a/backend/internal/db/conn.go
+++ b/backend/internal/db/conn.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sync"
 
@@ -21,7 +22,38 @@ type dbCreds struct {
 	Password string
 }
 
+// Conn opens a fresh connection to the database. RDS-managed credentials in
+// Secrets Manager auto-rotate (7-day schedule); the secret we cache at startup
+// goes stale at each rotation and the next connect fails SASL auth (28P01).
+// Rather than let that take the process down, an auth failure forces a re-fetch
+// of the secret and a single retry, so a routine rotation is ridden out in
+// place instead of relying on an ECS task restart to recover. A genuinely wrong
+// password (not a rotation) fails the retry too and surfaces as a normal error.
 func Conn(ctx context.Context) (*pgx.Conn, error) {
+	conn, err := connect(ctx)
+	if err == nil {
+		return conn, nil
+	}
+
+	// Only the secret-backed path can recover by refreshing; local env-var
+	// credentials have nothing to re-fetch, so do not retry there.
+	if !isAuthError(err) || config.GetInstance().Db.SecretId == "" {
+		return nil, err
+	}
+
+	log.Println("db authentication failed; refreshing credentials and retrying once")
+	if rerr := refreshDbCreds(ctx); rerr != nil {
+		log.Println("could not refresh db credentials", rerr)
+		return nil, err
+	}
+
+	return connect(ctx)
+}
+
+// connect builds the connection config from the current credentials and opens a
+// single connection. Split out from Conn so the credential-refresh retry can
+// re-run the whole path against the freshly fetched secret.
+func connect(ctx context.Context) (*pgx.Conn, error) {
 	creds, err := getDbCreds()
 	if err != nil {
 		log.Println("could not get db credentials")
@@ -49,7 +81,30 @@ func Conn(ctx context.Context) (*pgx.Conn, error) {
 		return nil, err
 	}
 
-	return conn, err
+	return conn, nil
+}
+
+// isAuthError reports whether err is a PostgreSQL password-authentication
+// failure (SQLSTATE 28P01), the signature of a connection opened with
+// credentials that no longer match - e.g. a rotated-away cached secret.
+func isAuthError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "28P01"
+}
+
+// refreshDbCreds forces a re-read of the cached secret from Secrets Manager so
+// the next connect picks up the post-rotation password. Caches the secret on
+// first use if startup somehow skipped it.
+func refreshDbCreds(ctx context.Context) error {
+	if dbSecret == nil {
+		if _, err := getDbCreds(); err != nil {
+			return err
+		}
+		if dbSecret == nil {
+			return errors.New("no db secret configured to refresh")
+		}
+	}
+	return dbSecret.Refresh(ctx)
 }
 
 func getDbCreds() (*dbCreds, error) {

--- a/backend/internal/db/conn_test.go
+++ b/backend/internal/db/conn_test.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+// isAuthError is what decides whether Conn refreshes the cached secret and
+// retries: only a 28P01 (password authentication failed) should trigger the
+// re-fetch, and it must still be recognized when pgx wraps the PgError.
+func TestIsAuthError(t *testing.T) {
+	authErr := &pgconn.PgError{Code: "28P01", Message: `password authentication failed for user "ztmfAdmin"`}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"bare 28P01", authErr, true},
+		{"wrapped 28P01", fmt.Errorf("failed to connect: %w", authErr), true},
+		{"other pg error (unique violation)", &pgconn.PgError{Code: "23505"}, false},
+		{"non-pg error", errors.New("dial tcp: connection refused"), false},
+		{"nil error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAuthError(tt.err))
+		})
+	}
+}

--- a/backend/internal/model/errors.go
+++ b/backend/internal/model/errors.go
@@ -72,9 +72,13 @@ func trapError(e error) error {
 			return ErrNoReference
 
 		case "28P01":
-			// failed to connect, password authentication failed
-			// TODO refactor DB secret caching/refreshing to avoid needing this!
-			log.Fatal(pgErr.Error())
+			// password authentication failed. db.Conn already re-fetches the
+			// rotated secret and retries the connection once on this error, so
+			// a 28P01 reaching here means even the retry failed (e.g. genuinely
+			// wrong credentials, not a routine rotation). Surface it as a
+			// connection error instead of exiting the process, which used to
+			// turn every secret rotation into a self-healing-but-real outage.
+			return ErrDbConnection
 		}
 	}
 

--- a/backend/internal/model/errors_test.go
+++ b/backend/internal/model/errors_test.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+// trapError converts driver errors into the package's generic errors. The 28P01
+// case is the important regression guard: it used to log.Fatal (killing the
+// process on every RDS secret rotation). db.Conn now refreshes and retries on
+// 28P01, so a 28P01 reaching trapError must return a normal connection error
+// rather than exiting - if this test even completes, the process did not die.
+func TestTrapError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   error
+		want error
+	}{
+		{"nil passes through", nil, nil},
+		{"no rows", pgx.ErrNoRows, ErrNoData},
+		{"too many rows", pgx.ErrTooManyRows, ErrTooMuchData},
+		{"foreign key violation", &pgconn.PgError{Code: "23503"}, ErrNoReference},
+		{"auth failure is not fatal", &pgconn.PgError{Code: "28P01", Message: "password authentication failed"}, ErrDbConnection},
+		{"wrapped auth failure is not fatal", fmt.Errorf("connect: %w", &pgconn.PgError{Code: "28P01"}), ErrDbConnection},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trapError(tt.in)
+			if tt.want == nil {
+				assert.NoError(t, got)
+				return
+			}
+			assert.ErrorIs(t, got, tt.want)
+		})
+	}
+}
+
+// A unique violation is wrapped with detail, so it satisfies errors.Is against
+// ErrNotUnique rather than being equal to it.
+func TestTrapError_UniqueViolation(t *testing.T) {
+	got := trapError(&pgconn.PgError{Code: "23505", Detail: "Key (email)=(x@y.z) already exists."})
+	assert.ErrorIs(t, got, ErrNotUnique)
+}


### PR DESCRIPTION
## Summary

Closes #328.

The API caches its database credentials once at process startup (`sync.Once` in `backend/internal/db/conn.go`) and never refreshes them. When the RDS-managed master secret auto-rotates (7-day schedule), the running task still holds the old password. The next connection fails SASL auth (`SQLSTATE 28P01`), and the error path (`trapError`, added in #161) called `log.Fatal`, exiting the process. ECS then restarted the task and re-fetched the now-current secret, so each rotation became a brief self-healing outage.

## What changed

**`internal/db/conn.go` — reactive refresh + single retry**
- Connect logic is split into a `connect(ctx)` helper; `Conn(ctx)` wraps it. On an auth-failure connect, `Conn` forces a re-fetch of the secret from Secrets Manager and retries the connection **once**.
- `isAuthError(err)` matches `28P01` via `errors.As`, so it's recognized even when pgx wraps the `*pgconn.PgError`.
- `refreshDbCreds(ctx)` calls `Secret.Refresh(ctx)` to re-read the post-rotation password.
- The retry only runs on the secret-backed path (`Db.SecretId != ""`); local env-var credentials have nothing to re-fetch. A genuinely wrong password fails the retry too and surfaces as a normal error.

**`internal/model/errors.go` — stop killing the process**
- The `28P01` case no longer `log.Fatal`s (there was a literal TODO there pointing at this). With `Conn` handling rotation reactively, a `28P01` reaching `trapError` means even the retry failed, so it now returns `ErrDbConnection`.

## Tests

- `internal/db/conn_test.go` — `isAuthError` matrix (bare/wrapped 28P01 → true; other pg codes, non-pg, nil → false).
- `internal/model/errors_test.go` — `trapError` mappings, including the regression guard that `28P01 → ErrDbConnection` (the test completing at all proves the process no longer exits).

`go build ./...`, `go vet`, and `go test -short ./...` all green locally (run in the `golang:1.25.11` container).

## Acceptance criteria

- [x] DB credentials are re-fetched from Secrets Manager on an auth failure rather than cached for the full process lifetime
- [x] A `28P01` triggers a single re-fetch + retry rather than a process exit
- [ ] Verified against an environment after a real or forced rotation — **remaining manual step** (needs AWS access; see issue)

## Notes

Draft pending the live-rotation verification. CI checks that depend on repo secrets (Snyk, etc.) will show red on a fork PR — expected per our workflow; maintainers re-run after pulling the branch.