### PR TITLE
fix(#328): refresh DB credentials and retry on auth failure after secret rotation

### DIFF
--- a/backend/internal/db/conn.go
+++ b/backend/internal/db/conn.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sync"
 
@@ -21,7 +22,38 @@ type dbCreds struct {
 	Password string
 }
 
+// Conn opens a fresh connection to the database. RDS-managed credentials in
+// Secrets Manager auto-rotate (7-day schedule); the secret we cache at startup
+// goes stale at each rotation and the next connect fails SASL auth (28P01).
+// Rather than let that take the process down, an auth failure forces a re-fetch
+// of the secret and a single retry, so a routine rotation is ridden out in
+// place instead of relying on an ECS task restart to recover. A genuinely wrong
+// password (not a rotation) fails the retry too and surfaces as a normal error.
 func Conn(ctx context.Context) (*pgx.Conn, error) {
+	conn, err := connect(ctx)
+	if err == nil {
+		return conn, nil
+	}
+
+	// Only the secret-backed path can recover by refreshing; local env-var
+	// credentials have nothing to re-fetch, so do not retry there.
+	if !isAuthError(err) || config.GetInstance().Db.SecretId == "" {
+		return nil, err
+	}
+
+	log.Println("db authentication failed; refreshing credentials and retrying once")
+	if rerr := refreshDbCreds(ctx); rerr != nil {
+		log.Println("could not refresh db credentials", rerr)
+		return nil, err
+	}
+
+	return connect(ctx)
+}
+
+// connect builds the connection config from the current credentials and opens a
+// single connection. Split out from Conn so the credential-refresh retry can
+// re-run the whole path against the freshly fetched secret.
+func connect(ctx context.Context) (*pgx.Conn, error) {
 	creds, err := getDbCreds()
 	if err != nil {
 		log.Println("could not get db credentials")
@@ -49,7 +81,30 @@ func Conn(ctx context.Context) (*pgx.Conn, error) {
 		return nil, err
 	}
 
-	return conn, err
+	return conn, nil
+}
+
+// isAuthError reports whether err is a PostgreSQL password-authentication
+// failure (SQLSTATE 28P01), the signature of a connection opened with
+// credentials that no longer match - e.g. a rotated-away cached secret.
+func isAuthError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "28P01"
+}
+
+// refreshDbCreds forces a re-read of the cached secret from Secrets Manager so
+// the next connect picks up the post-rotation password. Caches the secret on
+// first use if startup somehow skipped it.
+func refreshDbCreds(ctx context.Context) error {
+	if dbSecret == nil {
+		if _, err := getDbCreds(); err != nil {
+			return err
+		}
+		if dbSecret == nil {
+			return errors.New("no db secret configured to refresh")
+		}
+	}
+	return dbSecret.Refresh(ctx)
 }
 
 func getDbCreds() (*dbCreds, error) {

--- a/backend/internal/db/conn.go
+++ b/backend/internal/db/conn.go
@@ -47,7 +47,15 @@ func Conn(ctx context.Context) (*pgx.Conn, error) {
 		return nil, err
 	}
 
-	return connect(ctx)
+	conn, err = connect(ctx)
+	if err != nil {
+		// Distinct from connect()'s generic "could not connect to db" so a
+		// rotation-boundary incident is legible in CloudWatch: the refresh
+		// happened but the retry still failed (wrong credentials, or the new
+		// secret has not propagated to the cluster yet).
+		log.Println("db connection still failing after credential refresh", err)
+	}
+	return conn, err
 }
 
 // connect builds the connection config from the current credentials and opens a
@@ -116,15 +124,21 @@ func getDbCreds() (*dbCreds, error) {
 		return &dbCreds{cfg.Db.User, cfg.Db.Pass}, nil
 	}
 
-	// otherwise pull user/pass from the secret
+	// otherwise pull user/pass from the secret. Call once.Do unconditionally (no
+	// bare dbSecret nil-check first): once.Do is what establishes the happens-
+	// before for the dbSecret write, so reading the pointer outside it - from
+	// concurrent request goroutines at startup - would be an unsynchronized read.
+	// err is set only on the goroutine that ran the init, so re-check dbSecret
+	// afterward to surface a failed init to every caller.
 	var err error
+	once.Do(func() {
+		dbSecret, err = secrets.NewSecret(cfg.Db.SecretId)
+	})
+	if err != nil {
+		return nil, err
+	}
 	if dbSecret == nil {
-		once.Do(func() {
-			dbSecret, err = secrets.NewSecret(cfg.Db.SecretId)
-		})
-		if err != nil {
-			return nil, err
-		}
+		return nil, errors.New("db secret initialization failed")
 	}
 
 	creds := &dbCreds{}

--- a/backend/internal/db/conn_test.go
+++ b/backend/internal/db/conn_test.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+// isAuthError is what decides whether Conn refreshes the cached secret and
+// retries: only a 28P01 (password authentication failed) should trigger the
+// re-fetch, and it must still be recognized when pgx wraps the PgError.
+func TestIsAuthError(t *testing.T) {
+	authErr := &pgconn.PgError{Code: "28P01", Message: `password authentication failed for user "ztmfAdmin"`}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"bare 28P01", authErr, true},
+		{"wrapped 28P01", fmt.Errorf("failed to connect: %w", authErr), true},
+		{"other pg error (unique violation)", &pgconn.PgError{Code: "23505"}, false},
+		{"non-pg error", errors.New("dial tcp: connection refused"), false},
+		{"nil error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAuthError(tt.err))
+		})
+	}
+}

--- a/backend/internal/model/errors.go
+++ b/backend/internal/model/errors.go
@@ -72,9 +72,13 @@ func trapError(e error) error {
 			return ErrNoReference
 
 		case "28P01":
-			// failed to connect, password authentication failed
-			// TODO refactor DB secret caching/refreshing to avoid needing this!
-			log.Fatal(pgErr.Error())
+			// password authentication failed. db.Conn already re-fetches the
+			// rotated secret and retries the connection once on this error, so
+			// a 28P01 reaching here means even the retry failed (e.g. genuinely
+			// wrong credentials, not a routine rotation). Surface it as a
+			// connection error instead of exiting the process, which used to
+			// turn every secret rotation into a self-healing-but-real outage.
+			return ErrDbConnection
 		}
 	}
 

--- a/backend/internal/model/errors_test.go
+++ b/backend/internal/model/errors_test.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+// trapError converts driver errors into the package's generic errors. The 28P01
+// case is the important regression guard: it used to log.Fatal (killing the
+// process on every RDS secret rotation). db.Conn now refreshes and retries on
+// 28P01, so a 28P01 reaching trapError must return a normal connection error
+// rather than exiting - if this test even completes, the process did not die.
+func TestTrapError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   error
+		want error
+	}{
+		{"nil passes through", nil, nil},
+		{"no rows", pgx.ErrNoRows, ErrNoData},
+		{"too many rows", pgx.ErrTooManyRows, ErrTooMuchData},
+		{"foreign key violation", &pgconn.PgError{Code: "23503"}, ErrNoReference},
+		{"auth failure is not fatal", &pgconn.PgError{Code: "28P01", Message: "password authentication failed"}, ErrDbConnection},
+		{"wrapped auth failure is not fatal", fmt.Errorf("connect: %w", &pgconn.PgError{Code: "28P01"}), ErrDbConnection},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trapError(tt.in)
+			if tt.want == nil {
+				assert.NoError(t, got)
+				return
+			}
+			assert.ErrorIs(t, got, tt.want)
+		})
+	}
+}
+
+// A unique violation is wrapped with detail, so it satisfies errors.Is against
+// ErrNotUnique rather than being equal to it.
+func TestTrapError_UniqueViolation(t *testing.T) {
+	got := trapError(&pgconn.PgError{Code: "23505", Detail: "Key (email)=(x@y.z) already exists."})
+	assert.ErrorIs(t, got, ErrNotUnique)
+}

--- a/backend/internal/secrets/secrets.go
+++ b/backend/internal/secrets/secrets.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -26,6 +27,11 @@ type Secret struct {
 	secret   *secretsmanager.GetSecretValueOutput
 	metadata *secretsmanager.DescribeSecretOutput
 	client   *secretsmanager.Client
+	// mu guards secret/metadata. Conn() now refreshes reactively on a 28P01 from
+	// the per-request path, so during a rotation many goroutines can read (Value)
+	// and write (Refresh) these fields concurrently. The lock is held across the
+	// fetch RPC so a refresh storm serializes instead of racing the pointers.
+	mu sync.Mutex
 }
 
 // Value returns the current secret string. If AWS Secrets Manager has rotated
@@ -33,13 +39,16 @@ type Secret struct {
 // past, with a 23-hour grace window to tolerate rotation lead time), the value
 // is refreshed transparently. The provided context is used for the refresh RPC.
 func (s *Secret) Value(ctx context.Context) (*string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.metadata.NextRotationDate != nil {
 		// Secrets Manager may rotate several hours before the NextRotationDate
 		// advertised in metadata. Subtract 23h to widen the stale window and
 		// avoid serving a rotated-away value.
 		now := time.Now().Add(time.Duration(-23) * time.Hour).UTC()
 		if now.After(*s.metadata.NextRotationDate) {
-			if err := s.Refresh(ctx); err != nil {
+			if err := s.refreshLocked(ctx); err != nil {
 				return nil, err
 			}
 		}
@@ -50,6 +59,14 @@ func (s *Secret) Value(ctx context.Context) (*string, error) {
 // Refresh updates the secret and metadata from Secrets Manager using ctx for
 // the RPC timeout and cancellation.
 func (s *Secret) Refresh(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.refreshLocked(ctx)
+}
+
+// refreshLocked performs the fetch-and-assign; the caller must hold s.mu. Split
+// out so Value can refresh inline without re-locking (which would deadlock).
+func (s *Secret) refreshLocked(ctx context.Context) error {
 	getSecretValueOutput, describeSecretOutput, err := s.fetchSecretData(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Re-homes #335 (originally authored by @voidspooks) onto an org branch so the full CI pipeline runs, and merges current main. Fork PRs do not get the org secrets Snyk and the build/deploy steps need.

## What this fixes (ztmf#328)

The API caches the RDS-managed DB secret at startup. RDS rotates it on a ~7-day schedule; afterward the cached password is stale, the next connection fails SASL auth (28P01), and the old code `log.Fatal`'d on 28P01 - so every rotation took the process down until ECS restarted it.

Cameron's change:
- `db/conn.go`: `Conn()` retries once on a 28P01 auth error when a secret is configured, re-fetching the secret first (`refreshDbCreds` -> `Secret.Refresh`), so a routine rotation is ridden out in place. Env-var (local) credentials are not retried since there is nothing to re-fetch.
- `model/errors.go`: the 28P01 case returns `ErrDbConnection` instead of `log.Fatal`, so a genuinely-wrong password surfaces as a normal connection error rather than killing the process.
- Adds unit tests for the error classification (`isAuthError`, `trapError`), including wrapped-error cases.

## Added during re-home: synchronize the cached secret

Making the refresh reactive on the per-request path means a rotation can have many goroutines reading (`Value`/`Unmarshal`) and writing (`Refresh`) the cached `Secret` at once, and those fields had no synchronization (a read race already existed in `Value`'s proactive-refresh path; the reactive trigger widens it). Added a mutex on `Secret` guarding `secret`/`metadata` across the fetch RPC, so a refresh storm serializes instead of racing the pointers. `Value`/`Refresh` lock and delegate to an unexported `refreshLocked` to avoid re-locking.

## Testing

- `go build`, `go vet`, and the touched-package unit tests pass under `-race`.
- Error-classification regression is covered; the live refresh-and-retry flow and the concurrent-refresh path are not yet unit-tested (they need an injectable Secrets Manager / connect seam) - tracked as a follow-up under ztmf#328.

## Note

A single retry rides out the modeled failure. Right at a rotation boundary a refreshed secret can still briefly mismatch the cluster, so expect the occasional single failed request at rotation time - the process stays up, which is the goal.

Closes #335.