### PR TITLE
Expand empire seed data: multi-OpDiv org, 3-year history, and audit trail

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -483,6 +483,313 @@ INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
     '2026-05-20 00:00:00+00'
 ) ON CONFLICT (fisma_uuid) DO NOTHING;
 
+-- ============================================================================
+-- EXPANDED EMPIRE FIXTURE (dev/demo): multi-OpDiv org, more systems and
+-- officers, a 4-cycle (FY2022-FY2025) data-call history with maturity that
+-- climbs over time, and three additional questionnaires (datacenterenvironments).
+--
+-- Everything below uses fresh ID ranges and NEW OpDivs only. It deliberately
+-- does not touch systems 1001-1006, datacalls 1-3, or scores 9001-9030, which
+-- the Emberfall E2E suite asserts against (aggregate on 1001, datacallid=3, the
+-- EMPIRE/REBELLION OpDiv-scoped read counts).
+-- ============================================================================
+
+-- Imperial branch OpDivs. The Imperial military was deliberately fragmented
+-- into competing branches with overlapping oversight bodies; each maps to an
+-- OpDiv so OpDiv-scoped RBAC can be exercised across a realistic org.
+INSERT INTO public.opdivs (code, name, is_parent, active) VALUES
+    ('IMPNAVY',   'Imperial Navy (test fixture)',                 FALSE, TRUE),
+    ('IMPARMY',   'Imperial Army (test fixture)',                 FALSE, TRUE),
+    ('STARCORPS', 'Imperial Starfighter Corps (test fixture)',    FALSE, TRUE),
+    ('ISB',       'Imperial Security Bureau (test fixture)',      FALSE, TRUE),
+    ('IMPINTEL',  'Imperial Intelligence (test fixture)',         FALSE, TRUE),
+    ('SIENAR',    'Sienar Fleet Systems / R&D (test fixture)',    FALSE, TRUE)
+ON CONFLICT DO NOTHING;
+
+-- Branch officers. Mix of ISSO, OPDIV_ADMIN, and OPDIV_READONLY_ADMIN, each
+-- scoped (via users_opdivs below) to a single branch so cross-OpDiv isolation
+-- is demoable. UUIDs are v4-conforming.
+INSERT INTO public.users (userid, email, fullname, role, identity_provider) VALUES
+    ('a0000001-0001-4001-8001-000000000001', 'Grand.Admiral.Thrawn@chimaera.empire', 'Grand Admiral Thrawn',  'OPDIV_ADMIN',          'okta'),
+    ('a0000002-0002-4002-8002-000000000002', 'Captain.Pellaeon@chimaera.empire',     'Captain Gilad Pellaeon','ISSO',                 'okta'),
+    ('a0000003-0003-4003-8003-000000000003', 'Admiral.Ozzel@fleet.empire',           'Admiral Kendal Ozzel',  'ISSO',                 'okta'),
+    ('b0000001-0001-4001-8001-000000000001', 'General.Romodi@army.empire',           'General Hurst Romodi',  'OPDIV_ADMIN',          'okta'),
+    ('b0000002-0002-4002-8002-000000000002', 'Major.Marquand@blizzard.empire',       'Major Marquand',        'ISSO',                 'okta'),
+    ('c0000001-0001-4001-8001-000000000001', 'Baron.Fel@starcorps.empire',           'Baron Soontir Fel',     'ISSO',                 'okta'),
+    ('d0000001-0001-4001-8001-000000000001', 'Colonel.Yularen@isb.empire',           'Colonel Wullf Yularen', 'OPDIV_ADMIN',          'okta'),
+    ('d0000002-0002-4002-8002-000000000002', 'Agent.Kallus@isb.empire',              'Agent Alexsandr Kallus','ISSO',                 'okta'),
+    ('e0000001-0001-4001-8001-000000000001', 'Director.Isard@intel.empire',          'Director Armand Isard', 'OPDIV_ADMIN',          'okta'),
+    ('e0000002-0002-4002-8002-000000000002', 'Analyst.Intel@intel.empire',           'Imperial Intel Analyst','OPDIV_READONLY_ADMIN', 'okta'),
+    ('f0000001-0001-4001-8001-000000000001', 'Raith.Sienar@sienar.empire',           'Raith Sienar',          'OPDIV_ADMIN',          'okta'),
+    ('f0000002-0002-4002-8002-000000000002', 'Bevel.Lemelisk@sienar.empire',         'Bevel Lemelisk',        'ISSO',                 'okta')
+ON CONFLICT DO NOTHING;
+
+-- Scope each branch officer to their OpDiv only.
+INSERT INTO public.users_opdivs (userid, opdiv_id)
+SELECT u.userid, o.opdiv_id
+  FROM (VALUES
+        ('Grand.Admiral.Thrawn@chimaera.empire', 'IMPNAVY'),
+        ('Captain.Pellaeon@chimaera.empire',     'IMPNAVY'),
+        ('Admiral.Ozzel@fleet.empire',           'IMPNAVY'),
+        ('General.Romodi@army.empire',           'IMPARMY'),
+        ('Major.Marquand@blizzard.empire',       'IMPARMY'),
+        ('Baron.Fel@starcorps.empire',           'STARCORPS'),
+        ('Colonel.Yularen@isb.empire',           'ISB'),
+        ('Agent.Kallus@isb.empire',              'ISB'),
+        ('Director.Isard@intel.empire',          'IMPINTEL'),
+        ('Analyst.Intel@intel.empire',           'IMPINTEL'),
+        ('Raith.Sienar@sienar.empire',           'SIENAR'),
+        ('Bevel.Lemelisk@sienar.empire',         'SIENAR')
+       ) AS m(email, code)
+  JOIN public.users u  ON u.email = m.email
+  JOIN public.opdivs o ON o.code  = m.code
+ON CONFLICT DO NOTHING;
+
+-- Extra questions for the three new questionnaires (one per pillar per env).
+-- Ground-Assault (Army): 8019-8024
+INSERT INTO public.questions VALUES
+    (8019, 'Does your ground-assault force maintain a verified inventory of every walker, speeder, and emplacement?', 'Detail how AT-AT, AT-ST, and artillery assets are tracked through deployment, battlefield loss, and salvage.', 1, 0),
+    (8020, 'How is targeting and fire-control software for ground assets secured against tampering?', 'Describe code-signing and change control for walker targeting and artillery fire-control applications.', 2, 0),
+    (8021, 'How are forward-operating-base tactical networks segmented from the wider Imperial net?', 'Describe field network segmentation, encryption, and how a captured relay is contained.', 3, 0),
+    (8022, 'How is battlefield intelligence classified, encrypted, and purged on capture risk?', 'Detail handling of ground-campaign maps, troop dispositions, and emergency data destruction.', 4, 0),
+    (8023, 'How are ground-campaign security policies enforced consistently across dispersed units?', 'Describe centralized policy push and compliance checks for units operating out of contact.', 5, 0),
+    (8024, 'How are field commissions and trooper credentials verified at forward positions?', 'Detail identity and clearance verification when reinforcements rotate through a front line.', 6, 0)
+ON CONFLICT DO NOTHING;
+-- Surveillance-Net (ISB / Intelligence): 8025-8030
+INSERT INTO public.questions VALUES
+    (8025, 'Does the surveillance network inventory every listening post, probe droid, and informant feed?', 'Detail asset tracking for covert collection devices and their chain of custody.', 1, 0),
+    (8026, 'How is the analysis tooling that processes intercepts protected and access-controlled?', 'Describe security testing and least-privilege for the applications that triage surveillance feeds.', 2, 0),
+    (8027, 'How is the collection network isolated so a compromised node cannot expose sources?', 'Detail segmentation and anonymization between collection, transport, and analysis tiers.', 3, 0),
+    (8028, 'How are informant identities and intercept archives classified and compartmented?', 'Describe encryption, need-to-know compartments, and retention for source-identifying data.', 4, 0),
+    (8029, 'How are collection-authority and oversight policies enforced across the bureau?', 'Detail policy governance preventing unauthorized surveillance and ensuring auditability.', 5, 0),
+    (8030, 'How are analyst and handler identities verified for access to compartmented intelligence?', 'Describe clearance-tiered authentication and continuous vetting for intelligence personnel.', 6, 0)
+ON CONFLICT DO NOTHING;
+-- Shipyard-RnD (Sienar / Kuat): 8031-8036
+INSERT INTO public.questions VALUES
+    (8031, 'Does the R&D program track every prototype, test article, and fabrication rig?', 'Detail inventory and provenance for experimental hulls, drives, and weapon prototypes.', 1, 0),
+    (8032, 'How is the design and simulation software for new weapon systems secured?', 'Describe secure development and integrity verification for CAD, simulation, and CAM toolchains.', 2, 0),
+    (8033, 'How is the shipyard design network isolated from production and external suppliers?', 'Detail segmentation between classified design, the build floor, and contractor links.', 3, 0),
+    (8034, 'How are classified schematics (e.g., superweapon plans) protected across their lifecycle?', 'Describe classification, encryption, and access logging for top-secret design data.', 4, 0),
+    (8035, 'How are export, contractor, and security policies enforced across the R&D enterprise?', 'Detail governance over contractor access and consistent policy across program sites.', 5, 0),
+    (8036, 'How are engineer, contractor, and service-account identities managed for design systems?', 'Describe provisioning, review, and deprovisioning for a mixed workforce on classified programs.', 6, 0)
+ON CONFLICT DO NOTHING;
+
+-- New FISMA systems (1101-1110) across the branch OpDivs.
+INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismaname, fismasubsystem, component, groupacronym, groupname, divisionname, datacenterenvironment, datacallcontact, issoemail, sdl_sync_enabled, decommissioned, decommissioned_date, decommissioned_by, decommissioned_notes, opdiv_id) VALUES
+    (1101, 'C111 AAEA-2022-4A01-8B01-000000001101', 'ISD-CHI', 'Star Destroyer Chimaera Command Systems', 'Flagship Tactical and Sensor Suite',  'IMPNAVY-(FLEET)',   'STARCOM',  'Imperial Starfleet Command',     'Naval Operations Division',   'Imperial-Fleet',   'Captain.Pellaeon@chimaera.empire', 'Captain.Pellaeon@chimaera.empire', TRUE,  FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='IMPNAVY')),
+    (1102, 'C111 AAEB-2022-4A02-8B02-000000001102', 'FLT-NET', 'Imperial Fleet HoloNet Relay Grid',        'Inter-Fleet Communications',          'IMPNAVY-(COMMS)',   'HOLONET', 'Imperial Communications Command','Naval Operations Division',   'Imperial-Fleet',   'Admiral.Ozzel@fleet.empire',       'Admiral.Ozzel@fleet.empire',       TRUE,  FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='IMPNAVY')),
+    (1103, 'B111 AAEC-2022-4A03-8B03-000000001103', 'ATAT-C2', 'AT-AT Blizzard Force Command and Control', 'Walker Assault Coordination',         'IMPARMY-(ARMOR)',   'BLIZZARD','Imperial Army Armor Command',    'Ground Assault Division',     'Ground-Assault',   'General.Romodi@army.empire',       'Major.Marquand@blizzard.empire',   FALSE, FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='IMPARMY')),
+    (1104, 'B111 AAED-2023-4A04-8B04-000000001104', 'GRND-HTH','Hoth Ground Assault Targeting Grid',        'Planetary Assault Fire Control',      'IMPARMY-(ARTY)',    'BLIZZARD','Imperial Army Armor Command',    'Ground Assault Division',     'Ground-Assault',   'General.Romodi@army.empire',       'Major.Marquand@blizzard.empire',   FALSE, FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='IMPARMY')),
+    (1105, 'C111 AAEE-2022-4A05-8B05-000000001105', 'TIE-181', '181st TIE Interceptor Wing Operations',    'Starfighter Squadron Management',     'STARCORPS-(OPS)',   'REDEYE',  'Imperial Starfighter Corps',     'Starfighter Operations Division','Imperial-Fleet', 'Baron.Fel@starcorps.empire',       'Baron.Fel@starcorps.empire',       TRUE,  FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='STARCORPS')),
+    (1106, 'D111 AAEF-2022-4A06-8B06-000000001106', 'ISB-SURV','ISB Surveillance and Listening Network',   'Signals and Sensor Collection',       'ISB-(SURVEIL)',     'WATCH',   'Imperial Security Bureau',       'Surveillance Division',       'Surveillance-Net', 'Colonel.Yularen@isb.empire',       'Agent.Kallus@isb.empire',          TRUE,  FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='ISB')),
+    (1107, 'D111 AAEG-2023-4A07-8B07-000000001107', 'ISB-INFO','ISB Informant and Dissident Registry',     'Source and Watchlist Management',     'ISB-(INTERNAL)',    'INFORM',  'Imperial Security Bureau',       'Internal Affairs Division',   'Surveillance-Net', 'Colonel.Yularen@isb.empire',       'Agent.Kallus@isb.empire',          TRUE,  FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='ISB')),
+    (1108, 'E111 AAEH-2022-4A08-8B08-000000001108', 'INT-VLT', 'Imperial Intelligence Data Vault',         'Strategic Intelligence Archive',      'IMPINTEL-(ANALYS)', 'CIPHER',  'Imperial Intelligence',          'Analysis Bureau',             'Surveillance-Net', 'Director.Isard@intel.empire',      'Analyst.Intel@intel.empire',       TRUE,  FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='IMPINTEL')),
+    (1109, 'F111 AAEI-2022-4A09-8B09-000000001109', 'SFS-TIE', 'Sienar TIE Development Program',           'Starfighter R&D and Prototyping',     'SIENAR-(RND)',      'SIENAR',  'Sienar Fleet Systems',           'Advanced Projects Division',  'Shipyard-RnD',     'Raith.Sienar@sienar.empire',       'Bevel.Lemelisk@sienar.empire',     FALSE, FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='SIENAR')),
+    (1110, 'F111 AAEJ-2023-4A10-8B10-000000001110', 'TARKIN-I','Tarkin Initiative Superweapon R&D',        'Classified Superweapon Engineering',  'SIENAR-(TARKIN)',   'TARKIN',  'Tarkin Initiative',              'Advanced Weapons Division',   'Shipyard-RnD',     'Raith.Sienar@sienar.empire',       'Bevel.Lemelisk@sienar.empire',     FALSE, FALSE, NULL, NULL, NULL, (SELECT opdiv_id FROM public.opdivs WHERE code='SIENAR'))
+ON CONFLICT DO NOTHING;
+
+-- Assign ISSO officers to the systems they own.
+INSERT INTO public.users_fismasystems
+SELECT u.userid, s.fismasystemid
+  FROM (VALUES
+        ('Captain.Pellaeon@chimaera.empire', 1101),
+        ('Admiral.Ozzel@fleet.empire',       1102),
+        ('Major.Marquand@blizzard.empire',   1103),
+        ('Major.Marquand@blizzard.empire',   1104),
+        ('Baron.Fel@starcorps.empire',       1105),
+        ('Agent.Kallus@isb.empire',          1106),
+        ('Agent.Kallus@isb.empire',          1107),
+        ('Analyst.Intel@intel.empire',       1108),
+        ('Bevel.Lemelisk@sienar.empire',     1109),
+        ('Bevel.Lemelisk@sienar.empire',     1110)
+       ) AS m(email, sysid)
+  JOIN public.users u ON u.email = m.email
+  JOIN public.fismasystems s ON s.fismasystemid = m.sysid
+ON CONFLICT DO NOTHING;
+
+-- Historical data-call cycles. FY2024 (1) and FY2025 (2) already exist; add the
+-- two prior fiscal years so the new systems have a 4-cycle maturity trend.
+INSERT INTO public.datacalls VALUES (4, 'FY2022 Imperial Security Review', '2022-01-01T00:00:00Z', '2022-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
+INSERT INTO public.datacalls VALUES (5, 'FY2023 Imperial Security Review', '2023-01-01T00:00:00Z', '2023-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
+
+-- Every new system participates in all four cycles (FY2022, FY2023, FY2024, FY2025).
+INSERT INTO public.datacalls_fismasystems (datacallid, fismasystemid)
+SELECT dc, s.fismasystemid
+  FROM generate_series(1, 1) g
+  CROSS JOIN (VALUES (4),(5),(1),(2)) AS d(dc)
+  JOIN public.fismasystems s ON s.fismasystemid BETWEEN 1101 AND 1110
+ON CONFLICT DO NOTHING;
+
+-- New questionnaires: one function per pillar for each new datacenterenvironment,
+-- each referencing the matching new question. functionids 7019-7036.
+INSERT INTO public.functions VALUES
+    -- Ground-Assault (7019-7024)
+    (7019, 'Ground Asset Management',        'Track walkers, speeders, and emplacements through their lifecycle',     'Ground-Assault',   8019, 1, 0),
+    (7020, 'Fire-Control Application Security','Secure walker targeting and artillery fire-control software',          'Ground-Assault',   8020, 2, 0),
+    (7021, 'Field Network Security',         'Segment and protect forward-operating-base tactical networks',          'Ground-Assault',   8021, 3, 0),
+    (7022, 'Battlefield Data Protection',    'Classify and protect ground-campaign intelligence and dispositions',    'Ground-Assault',   8022, 4, 0),
+    (7023, 'Ground Campaign Governance',     'Enforce security policy consistently across dispersed ground units',    'Ground-Assault',   8023, 5, 0),
+    (7024, 'Field Identity Verification',    'Verify field commissions and trooper credentials at forward positions', 'Ground-Assault',   8024, 6, 0),
+    -- Surveillance-Net (7025-7030)
+    (7025, 'Collection Asset Management',    'Inventory listening posts, probe droids, and informant feeds',          'Surveillance-Net', 8025, 1, 0),
+    (7026, 'Analysis Tooling Security',      'Protect and least-privilege the intercept-analysis applications',       'Surveillance-Net', 8026, 2, 0),
+    (7027, 'Collection Network Isolation',   'Isolate collection nodes so a compromise cannot expose sources',        'Surveillance-Net', 8027, 3, 0),
+    (7028, 'Source Data Protection',         'Compartment and encrypt informant identities and intercept archives',   'Surveillance-Net', 8028, 4, 0),
+    (7029, 'Collection Oversight Governance','Enforce collection-authority and oversight policy across the bureau',   'Surveillance-Net', 8029, 5, 0),
+    (7030, 'Intelligence Identity Verification','Verify analyst and handler identities for compartmented access',     'Surveillance-Net', 8030, 6, 0),
+    -- Shipyard-RnD (7031-7036)
+    (7031, 'Prototype Asset Management',     'Track prototypes, test articles, and fabrication rigs',                 'Shipyard-RnD',     8031, 1, 0),
+    (7032, 'Design Toolchain Security',      'Secure CAD, simulation, and fabrication software for new weapons',      'Shipyard-RnD',     8032, 2, 0),
+    (7033, 'Shipyard Network Isolation',     'Isolate classified design networks from build floor and suppliers',     'Shipyard-RnD',     8033, 3, 0),
+    (7034, 'Schematic Data Protection',      'Protect classified schematics across their full lifecycle',             'Shipyard-RnD',     8034, 4, 0),
+    (7035, 'R&D Enterprise Governance',      'Enforce export, contractor, and security policy across program sites',  'Shipyard-RnD',     8035, 5, 0),
+    (7036, 'Engineering Identity Management','Manage engineer, contractor, and service-account identities',           'Shipyard-RnD',     8036, 6, 0)
+ON CONFLICT DO NOTHING;
+
+-- Four maturity options (Traditional/Defined/Managed/Advanced) for each new
+-- function. functionoptionids 70-141, generated so every pillar has all four
+-- levels (unlike some legacy CrossCutting functions that skip Traditional).
+INSERT INTO public.functionoptions (functionoptionid, functionid, score, optionname, description)
+SELECT 70 + (f.functionid - 7019) * 4 + (lvl.score - 1),
+       f.functionid,
+       lvl.score,
+       lvl.name,
+       lvl.name || ' maturity for ' || f."function"
+  FROM public.functions f
+  CROSS JOIN (VALUES (1,'Traditional'),(2,'Defined'),(3,'Managed'),(4,'Advanced')) AS lvl(score, name)
+ WHERE f.functionid BETWEEN 7019 AND 7036
+ON CONFLICT DO NOTHING;
+
+-- Historical scores: for each new system, every pillar is scored in all four
+-- cycles, with maturity climbing year over year (a small per-system offset adds
+-- variety). The functionoption is resolved by the system's environment + pillar
+-- at the nearest available maturity, so it works whether the pillar has all four
+-- levels or skips one. scoreids start at 9100.
+DO $$
+DECLARE
+    sys        record;
+    p          int;
+    dc         record;
+    yr_index   int;
+    base_off   int;
+    target     int;
+    fo_id      int;
+    score_id   int := 9100;
+    score_dt   timestamptz;
+    egg        text;  -- environment+pillar assessment note (with a buried reference)
+    tier       text;  -- maturity-level flavor line (also a buried reference)
+BEGIN
+    FOR sys IN
+        SELECT fismasystemid, datacenterenvironment,
+               (fismasystemid - 1101) % 2 AS off  -- alternating 0/1 starting maturity
+          FROM public.fismasystems
+         WHERE fismasystemid BETWEEN 1101 AND 1110
+         ORDER BY fismasystemid
+    LOOP
+        base_off := sys.off;
+        FOR dc IN
+            SELECT * FROM (VALUES
+                (4, 0, TIMESTAMPTZ '2022-09-01 00:00:00+00'),
+                (5, 1, TIMESTAMPTZ '2023-09-01 00:00:00+00'),
+                (1, 2, TIMESTAMPTZ '2024-09-01 00:00:00+00'),
+                (2, 3, TIMESTAMPTZ '2025-02-15 00:00:00+00')
+            ) AS d(datacallid, yr, dt)
+        LOOP
+            yr_index := dc.yr;
+            score_dt := dc.dt;
+            FOR p IN 1..6 LOOP
+                target := LEAST(4, GREATEST(1, 1 + yr_index + base_off));
+                -- Resolve the functionoption for this system's environment + pillar
+                -- at the maturity nearest the target (handles pillars missing a level).
+                SELECT fo.functionoptionid INTO fo_id
+                  FROM public.functions f
+                  JOIN public.functionoptions fo ON fo.functionid = f.functionid
+                 WHERE f.datacenterenvironment = sys.datacenterenvironment
+                   AND f.pillarid = p
+                 ORDER BY abs(fo.score - target), fo.score
+                 LIMIT 1;
+
+                -- Buried-reference assessment note per environment + pillar.
+                egg := CASE sys.datacenterenvironment
+                    WHEN 'Imperial-Fleet' THEN CASE p
+                        WHEN 1 THEN 'Fleet asset registry now tracks every Star Destroyer down to the last TIE; no ship slips away like that freighter did off Tatooine.'
+                        WHEN 2 THEN 'Bridge fire-control software hardened after an officer altered the deflectors mid-battle. Apology accepted, Captain Needa.'
+                        WHEN 3 THEN 'Comm segmentation tightened so we never again hear "it''s a trap" on an open channel.'
+                        WHEN 4 THEN 'Tactical archives encrypted at rest; no Bothans required to keep these plans safe this time.'
+                        WHEN 5 THEN 'Fleet-wide policy enforced top down. The Emperor is not as forgiving as the Admiralty.'
+                        ELSE 'Access still leans on code cylinders; a wave of the hand should not pass as "the droids you''re looking for".'
+                    END
+                    WHEN 'Ground-Assault' THEN CASE p
+                        WHEN 1 THEN 'Every walker accounted for after Blizzard Force lost one to a tow cable; the registry now flags "AT-AT down".'
+                        WHEN 2 THEN 'Targeting software locked down so no gunner aims for the command bunker by mistake again.'
+                        WHEN 3 THEN 'Field relays segmented; the shield-generator channel stays off the open net this time.'
+                        WHEN 4 THEN 'Assault maps sealed; the back door to the bunker is no longer sitting in a shared drive.'
+                        WHEN 5 THEN 'Ground-campaign policy unified, because around the survivors a perimeter should be created.'
+                        ELSE 'Forward credentials verified; a local in a stolen scout-trooper helmet should not clear the checkpoint.'
+                    END
+                    WHEN 'Surveillance-Net' THEN CASE p
+                        WHEN 1 THEN 'Probe-droid fleet fully inventoried after one wandered off and tipped our hand on Hoth.'
+                        WHEN 2 THEN 'Intercept-analysis tooling least-privileged; analysts no longer see more than they were meant to.'
+                        WHEN 3 THEN 'Collection tiers isolated. Always two there are: a source and a handler, and never shall the link leak.'
+                        WHEN 4 THEN 'Informant identities compartmented. We have them, and we intend to keep them.'
+                        WHEN 5 THEN 'Collection oversight enforced; even the Bureau answers to someone who is always watching.'
+                        ELSE 'Handler identities continuously verified; you do not know the power of a stolen clearance.'
+                    END
+                    ELSE CASE p  -- Shipyard-RnD
+                        WHEN 1 THEN 'Every prototype tagged after a set of plans walked out to Scarif; nothing leaves the rig unlogged now.'
+                        WHEN 2 THEN 'Design toolchain integrity-checked so no exhaust-port-sized oversight survives review this cycle.'
+                        WHEN 3 THEN 'Design net air-gapped from the build floor; the Rebellion will not be downloading anything today.'
+                        WHEN 4 THEN 'Superweapon schematics sealed; the datatape vault is no longer a single point of failure.'
+                        WHEN 5 THEN 'Program governance tightened across Sienar and Kuat. Witness the firepower of a fully audited station.'
+                        ELSE 'Engineer access reviewed; one disgruntled designer should not hold the only key to the reactor.'
+                    END
+                END;
+                tier := CASE target
+                    WHEN 1 THEN 'I have a bad feeling about this.'
+                    WHEN 2 THEN 'The circle is not yet complete; we are still the learners.'
+                    WHEN 3 THEN 'Impressive. Most impressive.'
+                    ELSE 'This station is now fully operational.'
+                END;
+
+                IF fo_id IS NOT NULL THEN
+                    INSERT INTO public.scores (scoreid, fismasystemid, datecalculated, notes, functionoptionid, datacallid)
+                    VALUES (score_id, sys.fismasystemid, score_dt,
+                            egg || ' ' || tier,
+                            fo_id, dc.datacallid)
+                    ON CONFLICT DO NOTHING;
+                    score_id := score_id + 1;
+                END IF;
+            END LOOP;
+        END LOOP;
+    END LOOP;
+END $$;
+
+-- Audit trail for the seeded scores. last_edited_at / last_edited_by are NOT
+-- stored on scores; FindScores derives them from the events table (the most
+-- recent 'public.scores' write whose payload scoreid matches). Seed data
+-- inserted via SQL bypasses the app's recordEvent path, so without these rows
+-- the UI shows blank "last edited by" and the audit features cannot be
+-- exercised locally. Record one 'updated' event per new score, attributed to
+-- the system's assigned officer at the score's assessment date, matching the
+-- shape recordEvent writes (resource 'public.scores', payload carrying scoreid).
+INSERT INTO public.events (userid, action, resource, createdat, payload)
+SELECT DISTINCT ON (s.scoreid)
+       uf.userid,
+       'updated',
+       'public.scores',
+       s.datecalculated,
+       jsonb_build_object(
+           'scoreid', s.scoreid,
+           'fismasystemid', s.fismasystemid,
+           'functionoptionid', s.functionoptionid,
+           'datacallid', s.datacallid,
+           'notes', s.notes
+       )
+  FROM public.scores s
+  JOIN public.users_fismasystems uf ON uf.fismasystemid = s.fismasystemid
+ WHERE s.scoreid >= 9100
+ ORDER BY s.scoreid, uf.userid;
+
 -- Reset every SERIAL sequence to its current table max. Use
 -- pg_get_serial_sequence() so the right name is resolved at runtime: some
 -- environments have historically renamed tables (e.g. functionscores -> scores)

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -535,6 +535,57 @@ func TestFindScoresIncludesAuditFieldsIntegration(t *testing.T) {
 	assert.Equal(t, "ISSO", found.LastEditedBy.Role)
 }
 
+// TestFindScoresResolvesSeededAuditFieldsIntegration covers the historical
+// read path that the other audit tests do not: a score whose edit event was
+// recorded by seed data (not written in-test) must still resolve LastEditedBy
+// through the LATERAL join on events. This is exactly what a fresh local dev
+// environment and the dashboard "Last edited <when> by <who>" footer rely on
+// when nothing has been edited in the current session.
+//
+// The fixture is the expanded empire seed: system 1110 (Tarkin Initiative
+// Superweapon R&D), scored in datacall 2 (FY2025) with one seeded "updated"
+// event per score attributed to its assigned officer, Bevel Lemelisk. If the
+// seed audit events go missing or the join regresses, last_edited_by silently
+// returns to blank in the UI and this test fails.
+//
+// Empire fixtures only (see [[feedback_no_real_pii_in_tests]]); never
+// substitute real CMS users.
+func TestFindScoresResolvesSeededAuditFieldsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+
+	// Tarkin Initiative R&D system and the FY2025 cycle, both from the seed.
+	fismaSystemID := int32(1110)
+	dataCallID := int32(2)
+
+	scores, err := FindScores(ctx, FindScoresInput{
+		FismaSystemID: &fismaSystemID,
+		DataCallID:    &dataCallID,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, scores,
+		"expanded empire seed must score system 1110 in datacall 2 (FY2025)")
+
+	// Every seeded score for this system+cycle carries an event attributed to
+	// the system's assigned officer, so each row must resolve the same editor.
+	for _, sc := range scores {
+		require.NotNil(t, sc.LastEditedAt,
+			"lateral join must populate LastEditedAt from the seeded event")
+		require.NotNil(t, sc.LastEditedBy,
+			"lateral join must resolve the editor from the seeded event")
+		assert.Equal(t, "f0000002-0002-4002-8002-000000000002", sc.LastEditedBy.UserID)
+		assert.Equal(t, "Bevel Lemelisk", sc.LastEditedBy.Name)
+		assert.Equal(t, "Bevel.Lemelisk@sienar.empire", sc.LastEditedBy.Email)
+		assert.Equal(t, "ISSO", sc.LastEditedBy.Role)
+	}
+}
+
 // TestScoreSaveNoOpPreservesPriorEditorIntegration pins the
 // audit-preservation rule: re-saving a score with identical answer
 // fields must NOT overwrite the prior editor in the events trail.


### PR DESCRIPTION
Gives a fresh local dev environment realistic sample data and makes the OpDiv and audit features exercisable without pulling production data.

## What's added

- **Multi-OpDiv org.** Six Imperial-branch OpDivs (Navy, Army, Starfighter Corps, ISB, Intelligence, Sienar) with 10 new systems and 12 officers scoped across them as ISSO / OPDIV_ADMIN / OPDIV_READONLY_ADMIN, so OpDiv-scoped RBAC isolation can be seen in the UI (an OWNER sees all 16 systems; a branch OPDIV_ADMIN sees only their branch).
- **Three-year history.** Data calls FY2022-FY2025, with each new system scored every cycle and maturity climbing year over year (Traditional toward Advanced).
- **Richer questionnaire.** Three new `datacenterenvironment`s (Ground-Assault, Surveillance-Net, Shipyard-RnD), each a full six-pillar function set with four maturity options, plus per-pillar questions.
- **Audit trail.** `last_edited_at` / `last_edited_by` are derived from the events table, which raw SQL seed data bypasses, so seeded scores previously showed a blank "last edited by" in the dashboard footer. This seeds one `updated` event per new score, attributed to the system's assigned officer, so the audit display and features work on a fresh local DB.

## Tests

- `TestFindScoresResolvesSeededAuditFieldsIntegration` covers the read of audit fields from a pre-existing (seed) event. The existing audit tests all create the event in-test, so the historical read path that the seed and the UI footer depend on was untested.
- `make test-e2e` passes 111/111 and `make test-integration` passes. All data uses new IDs and new OpDivs only; existing systems (1001-1006), data calls (1-3), and scores (9001-9030) are untouched, so the OpDiv-scoped and aggregate E2E assertions are unaffected.

## Note

The score notes carry some lightly buried thematic flavor; they remain plausible as assessment text and contain no real data.