### PR TITLE
Close leaked DB connections (Aurora connection exhaustion in prod)

### DIFF
--- a/backend/cmd/api/internal/migrations/populate.go
+++ b/backend/cmd/api/internal/migrations/populate.go
@@ -21,6 +21,7 @@ func populate(path string) error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close(ctx)
 	_, err = conn.Exec(ctx, string(sql))
 	return err
 }

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -300,6 +300,10 @@ func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSy
 	if err != nil {
 		return nil, trapError(err)
 	}
+	// Close the dedicated connection last (after the tx rollback/commit). defers
+	// run LIFO, so declaring this before the tx defer guarantees the transaction
+	// is resolved before the connection is closed.
+	defer conn.Close(ctx)
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -300,16 +300,19 @@ func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSy
 	if err != nil {
 		return nil, trapError(err)
 	}
-	// Close the dedicated connection last (after the tx rollback/commit). defers
-	// run LIFO, so declaring this before the tx defer guarantees the transaction
-	// is resolved before the connection is closed.
-	defer conn.Close(ctx)
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
+		conn.Close(ctx)
 		return nil, trapError(err)
 	}
-	defer tx.Rollback(ctx)
+	// Resolve the transaction and then close the dedicated connection in a single
+	// defer, so the order cannot be broken by another defer added later. Rollback
+	// is a no-op once the transaction has committed.
+	defer func() {
+		tx.Rollback(ctx)
+		conn.Close(ctx)
+	}()
 
 	var decommissioned bool
 	err = tx.QueryRow(ctx,

--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -45,6 +45,10 @@ func query[T any](ctx context.Context, sqlb SqlBuilder, fn pgx.RowToFunc[T]) ([]
 	if err != nil {
 		return nil, trapError(err)
 	}
+	// db.Conn opens a dedicated connection (there is no shared pool); it must be
+	// closed when the query completes or the connection leaks. Without this every
+	// call accumulates an open connection until the cluster's limit is reached.
+	defer conn.Close(ctx)
 
 	sql, args, _ := sqlb.ToSql()
 	rows, err := conn.Query(ctx, sql, args...)
@@ -70,6 +74,8 @@ func queryRow[T any](ctx context.Context, sqlb SqlBuilder, fn pgx.RowToFunc[T]) 
 	if err != nil {
 		return nil, trapError(err)
 	}
+	// Close the dedicated connection on return; see query() above.
+	defer conn.Close(ctx)
 
 	sql, args, _ := sqlb.ToSql()
 

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -730,6 +730,7 @@ func copyPreviousScores(dataCallID int32) {
 	if err != nil {
 		return
 	}
+	defer conn.Close(context.TODO())
 
 	sql, args, _ := sqlb.ToSql()
 

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -418,15 +418,19 @@ func RestoreUser(ctx context.Context, userid string) (*User, error) {
 	if err != nil {
 		return nil, trapError(err)
 	}
-	// Close the dedicated connection last (after the tx resolves); defers run
-	// LIFO, so this is declared before the tx rollback defer.
-	defer conn.Close(ctx)
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
+		conn.Close(ctx)
 		return nil, trapError(err)
 	}
-	defer tx.Rollback(ctx)
+	// Resolve the transaction and then close the dedicated connection in a single
+	// defer, so the order cannot be broken by another defer added later. Rollback
+	// is a no-op once the transaction has committed.
+	defer func() {
+		tx.Rollback(ctx)
+		conn.Close(ctx)
+	}()
 
 	var deleted bool
 	err = tx.QueryRow(ctx,

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -418,6 +418,9 @@ func RestoreUser(ctx context.Context, userid string) (*User, error) {
 	if err != nil {
 		return nil, trapError(err)
 	}
+	// Close the dedicated connection last (after the tx resolves); defers run
+	// LIFO, so this is declared before the tx rollback defer.
+	defer conn.Close(ctx)
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes a database connection leak that exhausted the Aurora connection limit in prod today. db.Conn() opens a dedicated pgx connection on every call (there is no shared pool), and the central model helpers plus a few raw call sites never closed the connection, so every query leaked one. Two active users were enough to pile up around 197 open connections, peg CPU, and time out requests. In the UI that showed as intermittently missing or slow data, like the OpDiv column blanking on first load.

## Root cause

The leak has been in the data layer since the open-per-call, no-close pattern was first written (mid-2024). It stayed hidden because Aurora reaped idle connections faster than they leaked. The OpDiv RBAC work added more DB round trips per authenticated request (auth middleware, then the user lookup, then the OpDiv grant queries), which pushed the leak rate past the reap rate, so connections piled up until the cluster hit its limit. The recent multi-OpDiv change triggered it but was not the root.

## Fix

Added a deferred connection close at every runtime site that opens one:

- model.go query() and queryRow(), which back most request-path queries
- scores.go copyPreviousScores, an Exec site that leaked
- fismasystems.go and users.go transaction paths, which rolled back the tx but never closed the connection. The close is declared before the tx rollback defer so it runs after the transaction resolves (defers are LIFO)
- populate.go, the local seed path

The tern migrator connection in migrations.go is left open on purpose. It is a startup-only connection the migrator owns for the life of the process.

## Not included

A connection pool (pgxpool) is the real fix for the per-query connect cost, which is the remaining slowness and the high DB CPU, and it will matter at HHS scale. That change also touches the credential rotation path, so it is a separate follow-up. This PR only stops the leak.

## Testing

- make test-integration (isolated DB) passes
- make test-e2e (Emberfall) passes
- go build, staticcheck, and go vet are clean
- Confirmed every runtime connection site closes once, the tx ordering is correct, there is no double close or use after close, and closing on an already-canceled context still releases the socket in our pinned pgx version

## Context

Replaces the earlier partial fix that only closed connections in two scores functions (#322, refs #321). This closes the leak across the whole data layer.
