### PR TITLE
Pool DB connections with pgxpool (fixes Aurora connection exhaustion under normal use)

### DIFF
--- a/backend/cmd/api/internal/migrations/migrations.go
+++ b/backend/cmd/api/internal/migrations/migrations.go
@@ -53,7 +53,7 @@ func Run() {
 func getMigrator() *migrate.Migrator {
 	if migrator == nil {
 		once.Do(func() {
-			conn, err := db.Conn(context.Background())
+			conn, err := db.MigrationConn(context.Background())
 			if err != nil {
 				log.Fatal(err)
 				return

--- a/backend/cmd/api/internal/migrations/populate.go
+++ b/backend/cmd/api/internal/migrations/populate.go
@@ -21,7 +21,7 @@ func populate(path string) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close(ctx)
+	defer conn.Release()
 	_, err = conn.Exec(ctx, string(sql))
 	return err
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
 	github.com/stretchr/testify v1.11.1
 	github.com/xuri/excelize/v2 v2.9.0
+	golang.org/x/time v0.15.0
 )
 
 require (
@@ -50,6 +51,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -65,8 +67,8 @@ require (
 	github.com/xuri/nfp v0.0.0-20240318013403-ab9948c2c4a7 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend/internal/db/conn.go
+++ b/backend/internal/db/conn.go
@@ -5,16 +5,34 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"time"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/secrets"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 var (
 	once     sync.Once
 	dbSecret *secrets.Secret
+
+	pool     *pgxpool.Pool
+	poolOnce sync.Once
+	poolErr  error
+)
+
+// Pool bounds the number of open connections and, crucially, the maximum the
+// cluster ever sees. A 0.5-1.0 ACU Aurora Serverless instance allows only a
+// small number of connections, and the auth handshake (TLS + SCRAM) is
+// CPU-heavy server-side. MaxConns is therefore set well under that ceiling.
+const (
+	maxConns        = 16
+	minConns        = 2
+	maxConnLifetime = 50 * time.Minute
+	maxConnIdleTime = 5 * time.Minute
+	healthCheck     = time.Minute
 )
 
 type dbCreds struct {
@@ -22,15 +40,28 @@ type dbCreds struct {
 	Password string
 }
 
-// Conn opens a fresh connection to the database. RDS-managed credentials in
-// Secrets Manager auto-rotate (7-day schedule); the secret we cache at startup
-// goes stale at each rotation and the next connect fails SASL auth (28P01).
-// Rather than let that take the process down, an auth failure forces a re-fetch
-// of the secret and a single retry, so a routine rotation is ridden out in
-// place instead of relying on an ECS task restart to recover. A genuinely wrong
-// password (not a rotation) fails the retry too and surfaces as a normal error.
-func Conn(ctx context.Context) (*pgx.Conn, error) {
-	conn, err := connect(ctx)
+// Conn acquires a connection from the shared pool. Callers MUST call
+// conn.Release() (typically deferred) to return it to the pool when done;
+// releasing reuses the connection rather than tearing it down, which is the
+// whole point of the pool. The previous implementation opened a brand-new
+// connection per call, so under any concurrency the cluster's connection limit
+// was exhausted and new connections died mid-handshake. The pool caps and
+// reuses connections, so a burst of concurrent queries no longer opens a
+// connection each.
+//
+// RDS-managed credentials rotate on a 7-day schedule; the secret cached at
+// startup goes stale at each rotation and a connection opened with it fails
+// SASL auth (28P01). Acquiring a connection can surface that error when the
+// pool opens a new connection, so an auth failure refreshes the secret and
+// retries once. The pool supplies credentials per new connection (see
+// BeforeConnect), so the retry picks up the refreshed secret.
+func Conn(ctx context.Context) (*pgxpool.Conn, error) {
+	p, err := Pool(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := p.Acquire(ctx)
 	if err == nil {
 		return conn, nil
 	}
@@ -47,21 +78,96 @@ func Conn(ctx context.Context) (*pgx.Conn, error) {
 		return nil, err
 	}
 
-	conn, err = connect(ctx)
-	if err != nil {
-		// Distinct from connect()'s generic "could not connect to db" so a
-		// rotation-boundary incident is legible in CloudWatch: the refresh
-		// happened but the retry still failed (wrong credentials, or the new
-		// secret has not propagated to the cluster yet).
-		log.Println("db connection still failing after credential refresh", err)
+	conn, aerr := p.Acquire(ctx)
+	if aerr != nil {
+		log.Println("db connection still failing after credential refresh", aerr)
+		return nil, aerr
 	}
-	return conn, err
+	return conn, nil
 }
 
-// connect builds the connection config from the current credentials and opens a
-// single connection. Split out from Conn so the credential-refresh retry can
-// re-run the whole path against the freshly fetched secret.
-func connect(ctx context.Context) (*pgx.Conn, error) {
+// Pool lazily builds the shared connection pool and returns it. The pool is
+// built once for the process; subsequent calls return the same pool.
+func Pool(ctx context.Context) (*pgxpool.Pool, error) {
+	poolOnce.Do(func() {
+		poolErr = initPool()
+	})
+	if poolErr != nil {
+		return nil, poolErr
+	}
+	return pool, nil
+}
+
+func initPool() error {
+	cfg := config.GetInstance()
+
+	poolCfg, err := pgxpool.ParseConfig("host=" + cfg.Db.Host + " port=" + cfg.Db.Port + " dbname=" + cfg.Db.Name + " sslmode=allow")
+	if err != nil {
+		log.Println("could not parse db pool config", err)
+		return err
+	}
+
+	poolCfg.MaxConns = maxConns
+	poolCfg.MinConns = minConns
+	poolCfg.MaxConnLifetime = maxConnLifetime
+	poolCfg.MaxConnIdleTime = maxConnIdleTime
+	poolCfg.HealthCheckPeriod = healthCheck
+
+	// Supply credentials per new connection rather than baking them into the
+	// connection string, so each connection the pool opens uses the current
+	// secret value. Combined with MaxConnLifetime recycling connections, a
+	// rotated credential is picked up without a process restart.
+	poolCfg.BeforeConnect = func(_ context.Context, cc *pgx.ConnConfig) error {
+		creds, err := getDbCreds()
+		if err != nil {
+			return err
+		}
+		cc.User = creds.Username
+		cc.Password = creds.Password
+		return nil
+	}
+
+	// Surface PostgreSQL NOTICE messages (e.g. RAISE NOTICE in migration DO
+	// blocks) in the application log instead of the silent default.
+	poolCfg.ConnConfig.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
+		log.Printf("pg notice [%s]: %s", n.Severity, n.Message)
+	}
+
+	// Build the pool with a background context, not the first caller's request
+	// context: pool creation happens once for the process, and a request that
+	// is canceled mid-init must not poison the pool for every later caller.
+	pool, err = pgxpool.NewWithConfig(context.Background(), poolCfg)
+	if err != nil {
+		log.Println("could not create db pool", err)
+		return err
+	}
+	return nil
+}
+
+// MigrationConn opens a single dedicated connection for the schema migrator.
+// The tern Migrator owns a *pgx.Conn for the lifetime of the migration run and
+// is not pool-managed, so it gets its own connection here rather than holding a
+// pooled one. Startup-only; callers close it when the migration run completes
+// (or leave it for the process, as the migrator currently does).
+func MigrationConn(ctx context.Context) (*pgx.Conn, error) {
+	conn, err := connectOne(ctx)
+	if err == nil {
+		return conn, nil
+	}
+	if !isAuthError(err) || config.GetInstance().Db.SecretId == "" {
+		return nil, err
+	}
+	log.Println("db authentication failed; refreshing credentials and retrying once")
+	if rerr := refreshDbCreds(ctx); rerr != nil {
+		log.Println("could not refresh db credentials", rerr)
+		return nil, err
+	}
+	return connectOne(ctx)
+}
+
+// connectOne builds the connection config from the current credentials and
+// opens a single (non-pooled) connection. Used by the migrator.
+func connectOne(ctx context.Context) (*pgx.Conn, error) {
 	creds, err := getDbCreds()
 	if err != nil {
 		log.Println("could not get db credentials")
@@ -75,10 +181,6 @@ func connect(ctx context.Context) (*pgx.Conn, error) {
 		return nil, err
 	}
 
-	// Surface PostgreSQL NOTICE messages (e.g. RAISE NOTICE in migration DO
-	// blocks) in the application log instead of the silent default. Without
-	// this, migration diagnostics only land in the RDS PostgreSQL log group
-	// in CloudWatch, which is not where deploys are normally watched.
 	connConfig.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
 		log.Printf("pg notice [%s]: %s", n.Severity, n.Message)
 	}
@@ -88,7 +190,6 @@ func connect(ctx context.Context) (*pgx.Conn, error) {
 		log.Println("could not connect to db", err)
 		return nil, err
 	}
-
 	return conn, nil
 }
 
@@ -101,7 +202,7 @@ func isAuthError(err error) bool {
 }
 
 // refreshDbCreds forces a re-read of the cached secret from Secrets Manager so
-// the next connect picks up the post-rotation password. Caches the secret on
+// the next connection picks up the post-rotation password. Caches the secret on
 // first use if startup somehow skipped it.
 func refreshDbCreds(ctx context.Context) error {
 	if dbSecret == nil {

--- a/backend/internal/db/conn.go
+++ b/backend/internal/db/conn.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -38,6 +39,17 @@ const (
 type dbCreds struct {
 	Username string
 	Password string
+}
+
+// sslMode selects the libpq sslmode for the connection. Deployed environments
+// require TLS to RDS/Aurora with no plaintext fallback. Local and test run
+// against a Docker Postgres with no TLS configured, where "require" would fail
+// the connection, so they use "allow".
+func sslMode() string {
+	if config.GetInstance().IsLocalOrTest() {
+		return "allow"
+	}
+	return "require"
 }
 
 // Conn acquires a connection from the shared pool. Callers MUST call
@@ -101,7 +113,8 @@ func Pool(ctx context.Context) (*pgxpool.Pool, error) {
 func initPool() error {
 	cfg := config.GetInstance()
 
-	poolCfg, err := pgxpool.ParseConfig("host=" + cfg.Db.Host + " port=" + cfg.Db.Port + " dbname=" + cfg.Db.Name + " sslmode=allow")
+	// No credentials in the DSN: BeforeConnect supplies them per connection.
+	poolCfg, err := pgxpool.ParseConfig(fmt.Sprintf("host=%s port=%s dbname=%s sslmode=%s", cfg.Db.Host, cfg.Db.Port, cfg.Db.Name, sslMode()))
 	if err != nil {
 		log.Println("could not parse db pool config", err)
 		return err
@@ -175,11 +188,15 @@ func connectOne(ctx context.Context) (*pgx.Conn, error) {
 	}
 
 	cfg := config.GetInstance()
-	connConfig, err := pgx.ParseConfig("host=" + cfg.Db.Host + " port=" + cfg.Db.Port + " dbname=" + cfg.Db.Name + " user=" + creds.Username + " password=" + creds.Password + " sslmode=allow")
+	connConfig, err := pgx.ParseConfig(fmt.Sprintf("host=%s port=%s dbname=%s sslmode=%s", cfg.Db.Host, cfg.Db.Port, cfg.Db.Name, sslMode()))
 	if err != nil {
 		log.Println("could not parse db config", err)
 		return nil, err
 	}
+	// Set credentials as fields rather than concatenating them into the DSN, so
+	// a username or password containing special characters cannot break parsing.
+	connConfig.User = creds.Username
+	connConfig.Password = creds.Password
 
 	connConfig.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
 		log.Printf("pg notice [%s]: %s", n.Severity, n.Message)

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -303,7 +303,7 @@ func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSy
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
-		conn.Close(ctx)
+		conn.Release()
 		return nil, trapError(err)
 	}
 	// Resolve the transaction and then close the dedicated connection in a single
@@ -311,7 +311,7 @@ func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSy
 	// is a no-op once the transaction has committed.
 	defer func() {
 		tx.Rollback(ctx)
-		conn.Close(ctx)
+		conn.Release()
 	}()
 
 	var decommissioned bool

--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -45,10 +45,10 @@ func query[T any](ctx context.Context, sqlb SqlBuilder, fn pgx.RowToFunc[T]) ([]
 	if err != nil {
 		return nil, trapError(err)
 	}
-	// db.Conn opens a dedicated connection (there is no shared pool); it must be
-	// closed when the query completes or the connection leaks. Without this every
-	// call accumulates an open connection until the cluster's limit is reached.
-	defer conn.Close(ctx)
+	// Return the connection to the pool when the query completes. Without this
+	// the pooled connection is never released and the pool is exhausted under
+	// any concurrency.
+	defer conn.Release()
 
 	sql, args, _ := sqlb.ToSql()
 	rows, err := conn.Query(ctx, sql, args...)
@@ -74,8 +74,8 @@ func queryRow[T any](ctx context.Context, sqlb SqlBuilder, fn pgx.RowToFunc[T]) 
 	if err != nil {
 		return nil, trapError(err)
 	}
-	// Close the dedicated connection on return; see query() above.
-	defer conn.Close(ctx)
+	// Release the connection back to the pool on return; see query() above.
+	defer conn.Release()
 
 	sql, args, _ := sqlb.ToSql()
 

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -174,7 +174,7 @@ func scoreUpdateIsNoOp(ctx context.Context, incoming *Score) (bool, *Score, erro
 	if err != nil {
 		return false, nil, trapError(err)
 	}
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	current := &Score{}
 	err = conn.QueryRow(ctx, `
@@ -226,7 +226,7 @@ func lookupScoreAudit(ctx context.Context, scoreID int32) (*time.Time, *AuditRef
 		log.Println("lookupScoreAudit: db.Conn:", err)
 		return nil, nil
 	}
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	const q = `
 		SELECT e.createdat, u.userid, u.fullname, u.email, u.role
@@ -730,7 +730,7 @@ func copyPreviousScores(dataCallID int32) {
 	if err != nil {
 		return
 	}
-	defer conn.Close(context.TODO())
+	defer conn.Release()
 
 	sql, args, _ := sqlb.ToSql()
 

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
-	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +44,7 @@ func purgeIntegrationTestRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("purge: db.Conn: %v", err)
 	}
-	defer conn.Close(ctx)
+	defer conn.Release()
 	_, err = conn.Exec(ctx,
 		`DELETE FROM datacalls WHERE datacall LIKE $1`,
 		integrationTestPrefix+"%",
@@ -73,7 +73,7 @@ func TestFindScoresAggregateIntegration(t *testing.T) {
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	t.Run("ShapeInvariants_AllAggregates", func(t *testing.T) {
 		// Pull every aggregate from the DB. Don't filter — we want to
@@ -181,7 +181,7 @@ func TestScoreSaveValidationIntegration(t *testing.T) {
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	// Find a datacall whose deadline is in the past, plus one whose
 	// deadline is in the future. The seeded datacalls do not guarantee
@@ -280,7 +280,7 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	// Insert two datacalls explicitly ordered so copyPreviousScores'
 	// "latest-1 is previous" logic finds the right one. Each row gets
@@ -367,7 +367,7 @@ func ensureFutureDataCall(t *testing.T, ctx context.Context) int32 {
 	t.Helper()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	var dataCallID int32
 	err = conn.QueryRow(ctx, `
@@ -393,7 +393,7 @@ func anyExistingFunctionOption(t *testing.T, ctx context.Context) (int32, int32)
 	t.Helper()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	var fismaSystemID, functionOptionID int32
 	require.NoError(t, conn.QueryRow(ctx, `
@@ -422,7 +422,7 @@ func TestScoreSaveStampsAuditFieldsIntegration(t *testing.T) {
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	fismaSystemID, functionOptionID := anyExistingFunctionOption(t, ctx)
 	dataCallID := ensureFutureDataCall(t, ctx)
@@ -482,7 +482,7 @@ func TestFindScoresIncludesAuditFieldsIntegration(t *testing.T) {
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	fismaSystemID, functionOptionID := anyExistingFunctionOption(t, ctx)
 	dataCallID := ensureFutureDataCall(t, ctx)
@@ -611,7 +611,7 @@ func TestScoreSaveNoOpPreservesPriorEditorIntegration(t *testing.T) {
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	fismaSystemID, functionOptionID := anyExistingFunctionOption(t, ctx)
 	dataCallID := ensureFutureDataCall(t, ctx)
@@ -703,7 +703,7 @@ func TestScoreSaveNoOpPreservesPriorEditorIntegration(t *testing.T) {
 
 // countScoreEvents is a small helper used by the no-op preservation test
 // to assert that read-through Saves do not append event rows.
-func countScoreEvents(t *testing.T, ctx context.Context, conn *pgx.Conn, scoreID int32) int {
+func countScoreEvents(t *testing.T, ctx context.Context, conn *pgxpool.Conn, scoreID int32) int {
 	t.Helper()
 	var n int
 	require.NoError(t, conn.QueryRow(ctx, `
@@ -735,7 +735,7 @@ func TestFindScoresISSOScopeRetainsAuditFieldsIntegration(t *testing.T) {
 	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
-	defer conn.Close(ctx)
+	defer conn.Release()
 
 	const krennicUUID = "44444444-4444-4444-4444-444444444444"
 	const krennicFisma = int32(1003)

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -434,7 +434,7 @@ func RestoreUser(ctx context.Context, userid string) (*User, error) {
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
-		conn.Close(ctx)
+		conn.Release()
 		return nil, trapError(err)
 	}
 	// Resolve the transaction and then close the dedicated connection in a single
@@ -442,7 +442,7 @@ func RestoreUser(ctx context.Context, userid string) (*User, error) {
 	// is a no-op once the transaction has committed.
 	defer func() {
 		tx.Rollback(ctx)
-		conn.Close(ctx)
+		conn.Release()
 	}()
 
 	var deleted bool


### PR DESCRIPTION
## Summary

The data layer had no connection pool. db.Conn() opened a brand-new connection (TCP, TLS, SCRAM auth) on every query. Once the OpDiv RBAC and dual-IdP work made every authenticated request run a DB user lookup, normal use opened a burst of concurrent connections that hit the Aurora connection limit. New connections then died mid-handshake (failed SASL auth: context canceled), which showed in the UI as the OpDiv column going empty and edits failing to save. One active user was enough to trigger it, so this is a design problem, not load.

This replaces the per-call connection model with a shared, bounded pgxpool.

## What changed

- db.Conn acquires a connection from a shared pool and returns it; callers release it back to the pool when done instead of closing it. The pool caps connections at 16, well under the cluster limit, and reuses them, so a burst of concurrent requests no longer opens a connection each.
- Credentials are supplied per new connection, so the 7-day RDS secret rotation is picked up as connections recycle (MaxConnLifetime 50m). An auth failure on acquire refreshes the secret and retries once, preserving the rotation handling from the earlier credential-refresh fix.
- The tern migrator keeps a dedicated single connection (MigrationConn), since it needs a plain connection and is not pool-managed.
- Pool is built once with a background context so a canceled request cannot poison the one-time init.

## Relationship to the earlier fix

The previous change (#342) added a close to every connection site to stop a slow leak. That was necessary but did not stop the concurrent burst, because closing a connection after use does nothing about many connections being opened at the same time. The pool is what actually bounds and reuses connections. With the pool, connections are released back rather than closed, which is the correct pattern.

## Validation

- make test-integration (isolated DB) passes
- make test-e2e (Emberfall) passes
- go build, staticcheck, and go vet are clean
- Reviewed for pgx pool correctness: every acquire has a matching release on all paths including the transaction error paths, the transaction sites release exactly once, rows are fully read before release, MaxConns is a hard cap, and the rotation path recovers across the 7-day cycle

## Sizing notes

MaxConns 16 against the observed cluster connection limit leaves headroom for the migrator connection, the ops task, and pgAdmin sessions. MinConns 2 keeps a warm pair so the first requests after idle do not each pay a full handshake. These are conservative for a low-traffic app and can be tuned later if needed.
