### PR TITLE
chore(infra): enable Entra dual-IdP in dev (entra_enabled = true)

### DIFF
--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -4,11 +4,12 @@ domain_name_prefix     = "dev."
 ecs_service_task_count = 1
 # job_code = "ZTMF_SCORING_USER"
 
-# Entra dual-IdP. Keep false until both secrets are seeded in the dev
-# account (scripts/bootstrap-entra-secrets.sh), then flip to true to add the
-# per-IdP ALB rules, move /api/* off ALB OIDC to backend session validation,
-# and inject the Entra + session env into the API task.
-entra_enabled = false
+# Entra dual-IdP. Both secrets (ztmf_entra_oidc, ztmf_session_signing_key) are
+# seeded and verified in the dev account, so flipping this to true adds the
+# per-IdP ALB rules, moves /api/* off ALB OIDC to backend session validation,
+# and injects the Entra + session env into the API task. Okta login is
+# unchanged. Activates the dormant infra from #341 for the dev Entra pilot.
+entra_enabled = true
 
 
 # TLS cert rotation Lambda


### PR DESCRIPTION
## Summary

Flip `entra_enabled = true` for the **dev** account to activate the dual-IdP (HHS Entra) infrastructure that landed dormant in #341. This is the lever for the dev Entra pilot login.

CMS/Okta login is unchanged — this only adds the second IdP path. Dev only; prod stays `false` until the dev pilot is validated.

## What flipping the flag does (on apply)

- Creates the per-IdP `/login/entra*` ALB listener rule (with its distinct session cookie name) and the forward-only rule for `/api/v1/auth/lookup`.
- Moves `/api/*` off ALB OIDC onto backend session validation.
- Injects the Entra + session-signing env into the API task (the `data` sources for `ztmf_entra_oidc` / `ztmf_session_signing_key` go live).

## Why it's ready

- Both Secrets Manager values (`ztmf_entra_oidc`, `ztmf_session_signing_key`) are **seeded and verified in dev** (client secret confirmed authenticating to the HHS tenant).
- Both dev + prod **redirect URIs are already registered** on the HHS Entra app registration.
- The backend code + ALB rules merged in #341.

## Draft — do not merge yet

Held as a draft on purpose so the DEV orchestration does **not** auto-apply (the orchestration jobs gate on `draft == false`). Merge/ready-for-review only once:

- [ ] Frontend email landing page (CMS-Enterprise/ztmf-ui#328) is ready
- [ ] HHS / test pilot users are provisioned in ZTMF (`identity_provider = entra`)
- [ ] We're ready to run the end-to-end dev pilot login (confirms the two remaining HHS-side unknowns: Conditional Access allowlist + v2 token setting, which only surface on a real login)

## Rollback

Revert to `entra_enabled = false` and re-apply; restores today's Okta-only behavior.

Refs #341, #264, CMS-Enterprise/ztmf-misc#170
