### PR TITLE
chore(ci): move backend workflow actions to Node.js 24, pin to SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current. Without this, pinned digests
+  # rot and only land security/feature fixes when someone bumps them by hand.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore(ci)

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,7 +91,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24.1'
+          # Read the required Go from go.mod rather than hardcoding it. setup-go
+          # v6 sets GOTOOLCHAIN=local, so a pinned version below go.mod's
+          # requirement no longer auto-downloads and the Lambda builds fail.
+          go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
       - name: Lambda - Build (Kion Key Rotate)

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,10 +20,10 @@ jobs:
       shaShort: ${{ steps.revParse.outputs.shaShort }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       
       - name: Get Commit SHA
         id: revParse
@@ -33,7 +33,7 @@ jobs:
         run: docker buildx build --platform linux/amd64 --tag ${{ secrets.ECR_REPO_URL }}:${{ steps.revParse.outputs.shaShort }} --load ./backend 
 
       - name: Snyk - Test Image
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@8e119fbb6c251787721d34ba683ed48eba792766 # snyk/actions has no tagged releases; pinned master @ 2026-06-16
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -41,7 +41,7 @@ jobs:
           args: --severity-threshold=high --file=./backend/Dockerfile --policy-path=./backend/.snyk
       
       - name: Start API and Postgres Containers
-        uses: hoverkraft-tech/compose-action@v2.0.2
+        uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
         with:
           compose-file: ./backend/actions-compose.yml
         env:
@@ -70,13 +70,13 @@ jobs:
           WORKSPACE: ${{ github.workspace }}
 
       - name: Emberfall Smoke Tests
-        uses: aquia-inc/emberfall@main
+        uses: aquia-inc/emberfall@90b0381a446bb7ba326af24153bb0518e49fb279 # main @ 2026-06-16 (composite; binary version set via `version` below)
         with:
           version: 0.4.1
           file: ./backend/emberfall_tests.yml
 
       - name: AWS - Get Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.ROLEARN }}
           role-duration-seconds: 900
@@ -89,9 +89,10 @@ jobs:
         run: docker push ${{ secrets.ECR_REPO_URL }}:${{ steps.revParse.outputs.shaShort }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.24.1'
+          cache-dependency-path: backend/go.sum
 
       - name: Lambda - Build (Kion Key Rotate)
         # Kion rotate Lambda runs on Graviton (arm64) with provided.al2023 runtime.

--- a/.github/workflows/orchestration-dev.yml
+++ b/.github/workflows/orchestration-dev.yml
@@ -24,20 +24,23 @@ jobs:
       backend: ${{ steps.backend.outputs.backend }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
-      - name: Check for changes in backend/
+      # Run the backend job when backend code OR the backend workflow itself
+      # changes, so edits to backend.yml (e.g. action version bumps) are
+      # validated by the smoke test rather than shipping unexercised.
+      - name: Check for changes in backend/ or its workflow
         id: backend
-        run: echo "backend=$(git --no-pager diff --name-only origin/main backend/ | grep ".go\|.sum\|Dockerfile" | head -n 1)" >> $GITHUB_OUTPUT
+        run: echo "backend=$(git --no-pager diff --name-only origin/main -- backend/ .github/workflows/backend.yml | grep -E '\.go$|\.sum$|Dockerfile|workflows/backend.yml' | head -n 1)" >> $GITHUB_OUTPUT
 
   backend:
     name: Backend
     needs:
       - analysis
       - diff
-    if: ${{ github.event.pull_request.draft == false && contains(needs.diff.outputs.backend, 'backend/') && !failure() && !cancelled() }}
+    if: ${{ github.event.pull_request.draft == false && needs.diff.outputs.backend != '' && !failure() && !cancelled() }}
     uses: ./.github/workflows/backend.yml
     with:
       environment: DEV


### PR DESCRIPTION
First slice of #317, scoped to the backend workflow. GitHub is forcing Actions runners off Node.js 20, so every run currently emits the deprecation warning. This moves the backend workflow's Node-based actions to their latest Node.js 24 releases, which clears the warnings, and SHA-pins the rest as a security hardening pass while we are in the file.

## Node.js 24 bumps (the actual warning fix)

These five were running on Node 20; each is now on its latest Node 24 release:

- `actions/checkout` v4 -> v6.0.3
- `docker/setup-buildx-action` v3 -> v4.1.0
- `hoverkraft-tech/compose-action` v2.0.2 -> v3.0.0
- `aws-actions/configure-aws-credentials` v4 -> v6.2.0
- `actions/setup-go` v5 -> v6.4.0

`orchestration-dev.yml` also had `actions/checkout@v4` in the change-detection job; bumped to v6.0.3 so that job stops warning too.

## SHA pinning (security bonus)

Every third-party action in `backend.yml` is now pinned to a commit SHA with a `# vX.Y.Z` comment. This drops the two floating refs that were the worst case:

- `snyk/actions/docker@master` -> pinned SHA (no tagged releases upstream)
- `aquia-inc/emberfall@main` -> pinned SHA (composite action; the emberfall binary version still comes from the `version` input)

## Also

- `actions/setup-go` now sets `cache-dependency-path: backend/go.sum`, so the dependency cache restores instead of missing on every run (go.sum lives under `backend/`, not repo root).
- `orchestration-dev.yml` now runs the backend smoke test when `backend.yml` itself changes, not only when `backend/**` code changes, so workflow edits like this one are exercised by CI instead of shipping unvalidated. That is what lets this PR test its own bumps.
- Added `.github/dependabot.yml` with a grouped `github-actions` entry so the SHA pins receive automated update PRs and do not rot.

## Scope

Backend workflow only, as the pilot. The remaining workflows in #317 (`analysis.yml`, `infrastructure.yml`, `orchestration-impl.yml`, `ops-image.yml`) are follow-ups once this pattern is proven green.

## Test plan

- [ ] Backend smoke-test job runs on this PR (via the new workflow-change trigger) and passes
- [ ] No Node.js 20 deprecation warning in the backend job logs
- [ ] `compose-action` v3 still starts the API + Postgres e2e stack; emberfall smoke tests pass
- [ ] `configure-aws-credentials` v6 still assumes the role and the image pushes to ECR
- [ ] setup-go cache restores from `backend/go.sum` (no cache-miss warning)

Refs #317
