### PR TITLE
chore(infra): enable Entra dual-IdP in dev (entra_enabled = true)

### DIFF
--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -4,11 +4,12 @@ domain_name_prefix     = "dev."
 ecs_service_task_count = 1
 # job_code = "ZTMF_SCORING_USER"
 
-# Entra dual-IdP. Keep false until both secrets are seeded in the dev
-# account (scripts/bootstrap-entra-secrets.sh), then flip to true to add the
-# per-IdP ALB rules, move /api/* off ALB OIDC to backend session validation,
-# and inject the Entra + session env into the API task.
-entra_enabled = false
+# Entra dual-IdP. Both secrets (ztmf_entra_oidc, ztmf_session_signing_key) are
+# seeded and verified in the dev account, so flipping this to true adds the
+# per-IdP ALB rules, moves /api/* off ALB OIDC to backend session validation,
+# and injects the Entra + session env into the API task. Okta login is
+# unchanged. Activates the dormant infra from #341 for the dev Entra pilot.
+entra_enabled = true
 
 
 # TLS cert rotation Lambda


### PR DESCRIPTION
Flips `entra_enabled = true` for dev, activating the dormant dual-IdP infra from #341: the per-IdP ALB listener rules (`/api/v1/auth/lookup` forward, `/login/entra` Entra OIDC, `/login` Okta), `/api/*` moved off ALB OIDC to backend session validation, and the Entra + session env injected into the API task. Okta login is unchanged.

This is the in-repo version of #347 by @voidspooks, moved onto a CMS-Enterprise branch so the infrastructure deploy (terraform apply, which needs the org OIDC role) runs; that does not run on a fork PR. The single commit and authorship are unchanged.

## Why now

The frontend landing page (ztmf-ui#404) is deployed to dev and calls `GET /api/v1/auth/lookup` on submit, but that ALB rule only exists when `entra_enabled = true`. With the flag still false, the lookup falls through to the OIDC-gated `/api/*` rule, fails for a logged-out visitor, and the page shows "We can't determine an identity provider" for everyone, including Okta users. This flip routes the lookup and unblocks dev testing.

## Scope

- dev only. `infrastructure/tfvars/dev.tfvars`, one line plus a comment. prod (`prod.tfvars`) stays `false`.
- Preconditions met: `ztmf_entra_oidc` and `ztmf_session_signing_key` are seeded and verified in the dev account.

## Deploy behavior

Once this is non-draft, orchestration-dev applies it to dev. It only persists across later dev applies once merged to main, so merge after the dev login is validated end to end.

Refs #347
