### PR TITLE
fix(infra): route /login/* through CloudFront to the ALB for Entra login

### DIFF
--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -188,6 +188,37 @@ resource "aws_cloudfront_distribution" "ztmf" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  # Dual-IdP login subpaths (e.g. /login/entra) must reach the ALB origin. The
+  # exact "/login" behavior above does not match subpaths, so without this
+  # CloudFront serves the S3 default origin (AccessDenied) for /login/entra and
+  # Entra login is unreachable. Gated on entra_enabled to match the per-IdP ALB
+  # rules, which are created under the same flag (the /login/entra* listener
+  # rule). Okta keeps using the exact "/login" behavior above, unaffected.
+  dynamic "ordered_cache_behavior" {
+    for_each = var.entra_enabled ? [1] : []
+    content {
+      path_pattern               = "/login/*"
+      allowed_methods            = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+      cached_methods             = ["HEAD", "GET", "OPTIONS"]
+      target_origin_id           = "ztmf_api"
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.hsts_policy.id
+
+      forwarded_values {
+        query_string = true
+        headers      = ["*"]
+        cookies {
+          forward = "all"
+        }
+      }
+
+      min_ttl                = 0
+      default_ttl            = 0
+      max_ttl                = 0
+      compress               = true
+      viewer_protocol_policy = "redirect-to-https"
+    }
+  }
+
   # Serve static error page when the API origin returns 5xx errors.
   # The error page is deployed to S3 alongside the React app assets.
   # Short TTL (10s) so CloudFront picks up a recovered origin quickly.


### PR DESCRIPTION
Fixes the Entra login path being unreachable from the public CloudFront URL.

## Problem

CloudFront routes only the exact path `/login` to the ALB origin (`cloudfront.tf`); there is no `/login/*` behavior. So `/login/entra` does not match, falls through to the S3 default origin, and S3 returns an `AccessDenied` XML page. Entra login is unreachable for everyone, not specific to any user or email. Okta is unaffected because it lives at exactly `/login`.

The dual-IdP work added the `/login/entra*` rule on the ALB but never added the matching CloudFront behavior. The two layers are owned separately (the CloudFront login behavior was set up under #166 as an exact match), and the end-to-end "user lands at /login/entra" check was deferred to runtime, so the gap only surfaced once dev was flipped to `entra_enabled = true` and Entra login was first exercised.

## Fix

Add a `/login/*` ordered cache behavior pointing at the `ztmf_api` (ALB) origin, mirroring the existing `/login` behavior (same forwarding, no caching). It is gated with `dynamic ... for_each = var.entra_enabled ? [1] : []` so it exists only when Entra is enabled, matching the per-IdP ALB listener rules that are created under the same flag. The exact `/login` behavior is left untouched, so Okta keeps working exactly as before.

On dev (`entra_enabled = true`) this creates the behavior and `/login/entra` reaches the ALB. On prod (`entra_enabled = false`) nothing changes.

## Validation

- `terraform fmt` clean, `terraform validate` passes, `tflint` clean.
- After this applies to dev: `/login/entra` routes to the ALB (Entra OIDC) instead of returning S3 `AccessDenied`; `/login` (Okta) unchanged.

Refs #264
