### PR TITLE
fix(users): let HHS-wide admins set identity_provider on create

### DIFF
--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -104,10 +104,13 @@ func SaveUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// identity_provider is derived from OpDiv on grant and is only overridable
-	// by an OWNER. Ignore any client-supplied value from a non-OWNER so it
-	// cannot be used to misroute a user's login.
-	if !authdUser.IsOwner() {
+	// identity_provider is derived from OpDiv membership (see deriveIdentityProvider).
+	// An explicit override is only honored from an HHS-wide actor (OWNER, HHS_ADMIN,
+	// HHS_READONLY_ADMIN); OpDiv-scoped admins are confined to their own scope and
+	// cannot set it. Ignore any client-supplied value from a scoped actor so it
+	// cannot be used to misroute a user's login. When left blank, Save derives it
+	// from the new user's OpDiv set on create.
+	if !authdUser.HasUnscopedRead() {
 		user.IdentityProvider = ""
 	}
 

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -695,7 +695,11 @@ tests:
         json:
           data:
             <<: *userData
-  
+            # No explicit IdP supplied on create, so it defaults to the CMS
+            # baseline (okta). HHS users are routed to entra by an HHS-wide actor
+            # passing an explicit identity_provider (see the override gate).
+            identity_provider: "okta"
+
   - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
     method: PUT
     headers:

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -213,11 +213,13 @@ func (u *User) Save(ctx context.Context) (*User, error) {
 	// deleted column is intentionally left out as it cannot be set by an update, and on create it defaults to false
 	// it must be set via explicit delete. See DeleteUser below
 	if creating {
-		// identity_provider is NOT NULL on the table. Caller may pass an
-		// explicit value (HHS users from the onboarding workbook get 'entra';
-		// CMS contractor exceptions can be set explicitly). Falls back to
-		// 'okta' so the existing CMS admin-panel create-user flow keeps
-		// working without a forced column add on the request body.
+		// identity_provider is NOT NULL on the table. ZTMF is CMS-origin, so
+		// Okta is the baseline; Entra is the exception for HHS users. An HHS-wide
+		// actor (OWNER, HHS_ADMIN, HHS_READONLY_ADMIN) may pass an explicit value
+		// to route an HHS user to Entra - the controller blanks the field for any
+		// OpDiv-scoped actor, whose users are CMS and stay on Okta. When blank,
+		// default to okta. A later CMS OpDiv grant (or an HHS one) re-derives the
+		// value through deriveIdentityProvider (usersopdivs.go).
 		idp := u.IdentityProvider
 		if idp == "" {
 			idp = "okta"


### PR DESCRIPTION
Backend half of letting an admin choose a new user's identity provider. Opened as a draft so it does not deploy to dev until the frontend add-user form is ready; on its own this change is inert because nothing sends `identity_provider` on create yet.

## Change

ZTMF is CMS-origin, so Okta stays the create default and Entra is the exception for HHS users. The gate that lets an actor set an explicit `identity_provider` on create was OWNER-only, so when an HHS_ADMIN chose Entra for an HHS user the value was blanked and the user defaulted to Okta - then the pre-auth lookup routed them to Okta until an OpDiv grant was toggled to re-derive it.

Widen the override gate from `IsOwner()` to `HasUnscopedRead()` (OWNER, HHS_ADMIN, HHS_READONLY_ADMIN). OpDiv-scoped admins still cannot set it, so their CMS users stay on Okta. `HHS_READONLY_ADMIN` is already write-blocked on `/users` by `IsAdmin()`, so in practice only `HHS_ADMIN` newly gains the override. The Okta create default and the OpDiv-grant derivation are unchanged.

## Depends on

Frontend work to send `identity_provider` (and OpDiv assignment) from the add-user form, shown only to HHS-wide admins: ztmf-ui#406 (CMS-Enterprise/ztmf-ui#406). This PR stays a draft until that lands so they deploy together.

## Test plan

- [x] `go build ./...`
- [x] `make test-e2e` passes 117/0, including an assertion that a created user with no explicit IdP defaults to `okta`
- [x] Independent review (gate widening confirmed safe; HHS_READONLY_ADMIN cannot reach the write path)

Refs #150
