### PR TITLE
feat(#133): add scores diff endpoint to compare two data calls

### DIFF
--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -110,6 +110,50 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, score, err)
 }
 
+//	@Summary	Diff scores between two data calls
+//	@Description	Compares the score (functionoption) answers of two data calls and returns only the questionnaire functions whose answer changed, each annotated with who made the later change and when. Scoped to the caller's tier: unscoped admins see all systems, OpDiv-scoped admins their OpDivs' systems, and ISSO/ISSM their assigned systems.
+//	@Tags		scores
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		from			query		int	true	"Data call ID to compare from (earlier cycle)"
+//	@Param		to				query		int	true	"Data call ID to compare to (later cycle)"
+//	@Param		fismasystemid	query		int	false	"Limit the diff to a single FISMA system"
+//	@Success	200				{object}	apiResponse[[]model.ScoreDiff]
+//	@Failure	400				{object}	apiResponse[any]
+//	@Failure	500				{object}	apiResponse[any]
+//	@Router		/scores/diff [get]
+func GetScoresDiff(w http.ResponseWriter, r *http.Request) {
+	var (
+		diffs []*model.ScoreDiff
+		err   error
+	)
+
+	user := model.UserFromContext(r.Context())
+	input := model.FindScoreDiffInput{}
+
+	err = decoder.Decode(&input, r.URL.Query())
+
+	// Same tier scoping as ListScores, applied AFTER decode so a client cannot
+	// widen scope via query params: unscoped admins see all; OPDIV tiers
+	// fail-closed to their granted OpDivs' systems; ISSO/ISSM keep the
+	// per-system (UserID) path.
+	switch {
+	case user.HasUnscopedRead():
+		// no scope filter
+	case user.IsOpDivTier():
+		input.RestrictToOpDivIDs = true
+		_, input.OpDivIDs = user.EffectiveOpDivScope()
+	default:
+		input.UserID = &user.UserID
+	}
+
+	if err == nil {
+		diffs, err = model.FindScoreDiff(r.Context(), input)
+	}
+
+	respond(w, r, diffs, err)
+}
+
 //	@Summary	Get aggregated scores
 //	@Tags		scores
 //	@Produce	json

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -82,6 +82,7 @@ func Handler() http.Handler {
 
 	router.HandleFunc("/api/v1/scores", controller.ListScores).Methods("GET")
 	router.HandleFunc("/api/v1/scores/aggregate", controller.GetScoresAggregate).Methods("GET") // yes "aggregate" is a noun
+	router.HandleFunc("/api/v1/scores/diff", controller.GetScoresDiff).Methods("GET")
 	router.HandleFunc("/api/v1/scores", controller.SaveScore).Methods("POST")
 	router.HandleFunc("/api/v1/scores/{scoreid:[0-9]+}", controller.SaveScore).Methods("PUT")
 

--- a/backend/internal/model/scorediff.go
+++ b/backend/internal/model/scorediff.go
@@ -1,0 +1,272 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ScoreDiffSide is one cycle's answer to a single questionnaire function: the
+// selected functionoption (with its maturity score + label) and any notes.
+// One side may be nil on a ScoreDiff when that function was answered in only
+// one of the two data calls (a newly-answered or no-longer-answered function).
+type ScoreDiffSide struct {
+	ScoreID          int32   `json:"scoreid"`
+	FunctionOptionID int32   `json:"functionoptionid"`
+	OptionName       string  `json:"optionname"`
+	Score            int32   `json:"score"`
+	Notes            *string `json:"notes"`
+}
+
+// ScoreDiff is a single questionnaire function whose answer changed between two
+// data calls for one FISMA system. From is the answer in the earlier ("from")
+// cycle and To the answer in the later ("to") cycle; either may be nil when the
+// function was answered in only one cycle. ChangedAt/ChangedBy attribute the
+// write that produced the To answer (the change), resolved from the events
+// audit trail; both are nil when no write event exists for the To score (e.g.
+// seed data, or a function answered only in the From cycle).
+type ScoreDiff struct {
+	FismaSystemID int32          `json:"fismasystemid"`
+	FunctionID    int32          `json:"functionid"`
+	Function      string         `json:"function"`
+	Question      string         `json:"question"`
+	From          *ScoreDiffSide `json:"from"`
+	To            *ScoreDiffSide `json:"to"`
+	ChangedAt     *time.Time     `json:"changed_at,omitempty"`
+	ChangedBy     *AuditRef      `json:"changed_by,omitempty"`
+}
+
+type FindScoreDiffInput struct {
+	FismaSystemID  *int32 `schema:"fismasystemid"`
+	FromDataCallID *int32 `schema:"from"`
+	ToDataCallID   *int32 `schema:"to"`
+	// UserID restricts the diff to the requesting user's assigned systems
+	// (ISSO/ISSM tiers); set by the controller, not bindable from the query.
+	UserID *string
+	// OpDiv scope for OpDiv-scoped admin tiers, mirroring FindScores. Not
+	// schema-tagged - the controller sets them from the auth'd user.
+	OpDivIDs           []int32
+	RestrictToOpDivIDs bool
+}
+
+// FindScoreDiff compares the score (functionoption) answers of two data calls
+// for the in-scope FISMA system(s) and returns only the functions whose answer
+// differs between them, each annotated with who made the later change and when.
+//
+// "Differs" means the selected functionoption changed, the notes changed, or
+// the function was answered in exactly one of the two cycles. nil and empty
+// notes are treated as equal so a NULL-vs-"" notes box does not surface as a
+// spurious change (matching scoresEqualForUpdate's normalization).
+//
+// The query is hand-built parameterized SQL rather than squirrel because the
+// FULL OUTER JOIN between the two cycles, the catalog joins for the function /
+// question labels, and the events lateral for attribution exceed squirrel's
+// ergonomics. It is SELECT-only, so it goes through the read-path query helper
+// (never queryRow, which records events). See [[scores.FindScores]] for the
+// attribution lateral this mirrors.
+func FindScoreDiff(ctx context.Context, input FindScoreDiffInput) ([]*ScoreDiff, error) {
+	if err := input.validate(); err != nil {
+		return nil, err
+	}
+
+	sql, args := buildScoreDiffSQL(input)
+	return query(ctx, rawQuery{sql: sql, args: args}, scanScoreDiff)
+}
+
+func (i FindScoreDiffInput) validate() error {
+	err := InvalidInputError{data: map[string]any{}}
+
+	if i.FromDataCallID == nil {
+		err.data["from"] = "required"
+	}
+	if i.ToDataCallID == nil {
+		err.data["to"] = "required"
+	}
+	if i.FromDataCallID != nil && i.ToDataCallID != nil && *i.FromDataCallID == *i.ToDataCallID {
+		err.data["to"] = "must differ from 'from'"
+	}
+
+	if len(err.data) > 0 {
+		return &err
+	}
+	return nil
+}
+
+// buildScoreDiffSQL assembles the parameterized diff query. Extracted so unit
+// tests can pin the filter and scope shaping without a database connection.
+// validate() guarantees both data call IDs are non-nil before this is called.
+func buildScoreDiffSQL(input FindScoreDiffInput) (string, []any) {
+	var args []any
+	argN := 1
+
+	fromCTE := scoreCycleCTE(input, *input.FromDataCallID, &args, &argN)
+	toCTE := scoreCycleCTE(input, *input.ToDataCallID, &args, &argN)
+
+	// FULL OUTER JOIN on (system, function) so a function answered in only one
+	// cycle still surfaces (added or removed answer). Catalog joins are LEFT so
+	// a row whose function/question was since deleted still returns with empty
+	// labels rather than vanishing. The events lateral keys on the To scoreid
+	// because the later write is what "who made the change" refers to; the
+	// partial index events_score_audit_idx serves it. The IS DISTINCT FROM
+	// pair is the "drop the unchanged rows" filter.
+	sql := fmt.Sprintf(`
+WITH from_scores AS (%s),
+     to_scores AS (%s)
+SELECT
+    COALESCE(f.fismasystemid, t.fismasystemid) AS fismasystemid,
+    COALESCE(f.functionid, t.functionid)       AS functionid,
+    fn.function,
+    q.question,
+    f.scoreid, f.functionoptionid, f.option_score, f.optionname, f.notes,
+    t.scoreid, t.functionoptionid, t.option_score, t.optionname, t.notes,
+    le.createdat,
+    eu.userid, eu.fullname, eu.email, eu.role
+FROM from_scores f
+FULL OUTER JOIN to_scores t
+  ON f.fismasystemid = t.fismasystemid AND f.functionid = t.functionid
+LEFT JOIN functions fn ON fn.functionid = COALESCE(f.functionid, t.functionid)
+LEFT JOIN questions q  ON q.questionid  = fn.questionid
+LEFT JOIN LATERAL (
+    SELECT createdat, userid
+    FROM events
+    WHERE resource = 'public.scores'
+      AND (payload->>'scoreid')::int = t.scoreid
+    ORDER BY createdat DESC
+    LIMIT 1
+) le ON TRUE
+LEFT JOIN users eu ON eu.userid = le.userid
+WHERE f.functionoptionid IS DISTINCT FROM t.functionoptionid
+   OR COALESCE(f.notes, '') IS DISTINCT FROM COALESCE(t.notes, '')
+ORDER BY fismasystemid, fn.ordr, functionid
+`, fromCTE, toCTE)
+
+	return sql, args
+}
+
+// scoreCycleCTE builds the SELECT for one data call's scored functions, joined
+// to functionoptions for the maturity score + label and scoped identically to
+// FindScores (per-user assigned systems, OpDiv grants, or unrestricted). It
+// appends its bound values to args in placeholder order; both the from and to
+// cycles call it so the scope values are bound once per cycle.
+func scoreCycleCTE(input FindScoreDiffInput, dataCallID int32, args *[]any, argN *int) string {
+	var userJoin string
+	if input.UserID != nil {
+		userJoin = fmt.Sprintf("INNER JOIN users_fismasystems ufs ON ufs.fismasystemid = s.fismasystemid AND ufs.userid = $%d", *argN)
+		*args = append(*args, *input.UserID)
+		*argN++
+	}
+
+	conds := []string{fmt.Sprintf("s.datacallid = $%d", *argN)}
+	*args = append(*args, dataCallID)
+	*argN++
+
+	if input.FismaSystemID != nil {
+		conds = append(conds, fmt.Sprintf("s.fismasystemid = $%d", *argN))
+		*args = append(*args, *input.FismaSystemID)
+		*argN++
+	}
+
+	// OpDiv scope (fail-closed): empty grants under RestrictToOpDivIDs -> no
+	// rows. Expressed as a subquery predicate to match FindScores.
+	switch {
+	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
+		conds = append(conds, "FALSE")
+	case len(input.OpDivIDs) > 0:
+		conds = append(conds, fmt.Sprintf("s.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY($%d))", *argN))
+		*args = append(*args, input.OpDivIDs)
+		*argN++
+	}
+
+	return fmt.Sprintf(`
+    SELECT s.scoreid, s.fismasystemid, fo.functionid, s.functionoptionid,
+           fo.score AS option_score, fo.optionname, s.notes
+    FROM scores s
+    INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+    %s
+    WHERE %s`, userJoin, strings.Join(conds, " AND "))
+}
+
+func scanScoreDiff(row pgx.CollectableRow) (*ScoreDiff, error) {
+	var (
+		d  ScoreDiff
+		fn *string
+		qn *string
+
+		fScoreID  *int32
+		fFOID     *int32
+		fOptScore *int32
+		fOptName  *string
+		fNotes    *string
+
+		tScoreID  *int32
+		tFOID     *int32
+		tOptScore *int32
+		tOptName  *string
+		tNotes    *string
+
+		at     *time.Time
+		uID    *string
+		uName  *string
+		uEmail *string
+		uRole  *string
+	)
+
+	if err := row.Scan(
+		&d.FismaSystemID, &d.FunctionID, &fn, &qn,
+		&fScoreID, &fFOID, &fOptScore, &fOptName, &fNotes,
+		&tScoreID, &tFOID, &tOptScore, &tOptName, &tNotes,
+		&at, &uID, &uName, &uEmail, &uRole,
+	); err != nil {
+		return nil, err
+	}
+
+	d.Function = derefString(fn)
+	d.Question = derefString(qn)
+
+	// scoreid is NOT NULL in the scores table, so a non-nil scoreid is the
+	// signal that this side of the FULL OUTER JOIN matched a row; the other
+	// answer columns on that side are then guaranteed populated.
+	if fScoreID != nil {
+		d.From = &ScoreDiffSide{
+			ScoreID:          *fScoreID,
+			FunctionOptionID: derefInt32(fFOID),
+			OptionName:       derefString(fOptName),
+			Score:            derefInt32(fOptScore),
+			Notes:            fNotes,
+		}
+	}
+	if tScoreID != nil {
+		d.To = &ScoreDiffSide{
+			ScoreID:          *tScoreID,
+			FunctionOptionID: derefInt32(tFOID),
+			OptionName:       derefString(tOptName),
+			Score:            derefInt32(tOptScore),
+			Notes:            tNotes,
+		}
+	}
+
+	// Both-or-neither, mirroring FindScores: only attribute when the event
+	// timestamp AND the editor identity both resolved.
+	if at != nil && uID != nil {
+		d.ChangedAt = at
+		d.ChangedBy = &AuditRef{
+			UserID: *uID,
+			Name:   derefString(uName),
+			Email:  derefString(uEmail),
+			Role:   derefString(uRole),
+		}
+	}
+
+	return &d, nil
+}
+
+func derefInt32(i *int32) int32 {
+	if i == nil {
+		return 0
+	}
+	return *i
+}

--- a/backend/internal/model/scorediff_test.go
+++ b/backend/internal/model/scorediff_test.go
@@ -1,0 +1,173 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFindScoreDiffInputValidate pins the request preconditions: both data call
+// IDs are required, and the two cycles must differ (a diff of a cycle against
+// itself is always empty and almost certainly a client mistake). The error is
+// an *InvalidInputError so the controller surfaces it as a 400 with the
+// offending fields, matching the rest of the API.
+func TestFindScoreDiffInputValidate(t *testing.T) {
+	t.Run("BothPresentAndDistinct", func(t *testing.T) {
+		in := FindScoreDiffInput{FromDataCallID: int32Ptr(3), ToDataCallID: int32Ptr(4)}
+		assert.NoError(t, in.validate())
+	})
+
+	t.Run("MissingFrom", func(t *testing.T) {
+		in := FindScoreDiffInput{ToDataCallID: int32Ptr(4)}
+		err := in.validate()
+		iie, ok := err.(*InvalidInputError)
+		if assert.True(t, ok, "want *InvalidInputError, got %T", err) {
+			assert.Contains(t, iie.Data(), "from")
+		}
+	})
+
+	t.Run("MissingTo", func(t *testing.T) {
+		in := FindScoreDiffInput{FromDataCallID: int32Ptr(3)}
+		err := in.validate()
+		iie, ok := err.(*InvalidInputError)
+		if assert.True(t, ok, "want *InvalidInputError, got %T", err) {
+			assert.Contains(t, iie.Data(), "to")
+		}
+	})
+
+	t.Run("MissingBoth", func(t *testing.T) {
+		err := FindScoreDiffInput{}.validate()
+		iie, ok := err.(*InvalidInputError)
+		if assert.True(t, ok, "want *InvalidInputError, got %T", err) {
+			assert.Contains(t, iie.Data(), "from")
+			assert.Contains(t, iie.Data(), "to")
+		}
+	})
+
+	t.Run("SameCycle", func(t *testing.T) {
+		in := FindScoreDiffInput{FromDataCallID: int32Ptr(5), ToDataCallID: int32Ptr(5)}
+		err := in.validate()
+		iie, ok := err.(*InvalidInputError)
+		if assert.True(t, ok, "want *InvalidInputError, got %T", err) {
+			assert.Contains(t, iie.Data(), "to")
+		}
+	})
+}
+
+// TestBuildScoreDiffSQL_Shape verifies the structural invariants of the query:
+// it diffs two cycles via a FULL OUTER JOIN (so a one-sided answer surfaces),
+// drops unchanged rows with the IS DISTINCT FROM pair, treats nil/empty notes
+// as equal, and attributes the change to the later (To) write through the
+// events lateral. The two cycle CTEs each bind their own datacallid, so the
+// from/to ids appear once each in arg order.
+func TestBuildScoreDiffSQL_Shape(t *testing.T) {
+	in := FindScoreDiffInput{FromDataCallID: int32Ptr(3), ToDataCallID: int32Ptr(4)}
+	sql, args := buildScoreDiffSQL(in)
+
+	assert.Contains(t, sql, "FULL OUTER JOIN to_scores", "must outer-join the two cycles so one-sided answers surface")
+	assert.Contains(t, sql, "f.functionoptionid IS DISTINCT FROM t.functionoptionid", "must drop rows with an unchanged option")
+	assert.Contains(t, sql, "COALESCE(f.notes, '') IS DISTINCT FROM COALESCE(t.notes, '')", "nil/empty notes must compare equal")
+	assert.Contains(t, sql, "resource = 'public.scores'", "attribution lateral must read score events")
+	assert.Contains(t, sql, "(payload->>'scoreid')::int = t.scoreid", "attribution must key on the later (To) write")
+
+	// Two cycle filters, no scope: from=3 then to=4, in that order.
+	if assert.Len(t, args, 2, "expected one datacallid arg per cycle") {
+		assert.Equal(t, int32(3), args[0], "from cycle binds first")
+		assert.Equal(t, int32(4), args[1], "to cycle binds second")
+	}
+}
+
+// TestBuildScoreDiffSQL_FismaSystemScope verifies that a single-system request
+// adds the equality predicate to BOTH cycle CTEs (the diff is meaningless if
+// only one side is narrowed), binding the system id once per cycle.
+func TestBuildScoreDiffSQL_FismaSystemScope(t *testing.T) {
+	in := FindScoreDiffInput{
+		FromDataCallID: int32Ptr(3),
+		ToDataCallID:   int32Ptr(4),
+		FismaSystemID:  int32Ptr(1001),
+	}
+	sql, args := buildScoreDiffSQL(in)
+
+	assert.Equal(t, 2, strings.Count(sql, "s.fismasystemid = $"), "system filter must apply to both cycle CTEs")
+	// from: datacall, system ; to: datacall, system
+	assert.Equal(t, []any{int32(3), int32(1001), int32(4), int32(1001)}, args)
+}
+
+// TestBuildScoreDiffSQL_UserScope verifies the ISSO/ISSM path: each cycle CTE
+// inner-joins users_fismasystems on the requesting user so the diff only spans
+// their assigned systems, binding the user id once per cycle ahead of that
+// cycle's datacallid.
+func TestBuildScoreDiffSQL_UserScope(t *testing.T) {
+	uid := "11111111-1111-1111-1111-111111111111"
+	in := FindScoreDiffInput{
+		FromDataCallID: int32Ptr(3),
+		ToDataCallID:   int32Ptr(4),
+		UserID:         &uid,
+	}
+	sql, args := buildScoreDiffSQL(in)
+
+	assert.Equal(t, 2, strings.Count(sql, "INNER JOIN users_fismasystems"), "user scope must join both cycle CTEs")
+	// from: userid, datacall ; to: userid, datacall
+	assert.Equal(t, []any{uid, int32(3), uid, int32(4)}, args)
+}
+
+// TestBuildScoreDiffSQL_OpDivScope mirrors the OpDiv read-scope contract from
+// the aggregate query: granted OpDivs emit a subquery predicate on each cycle
+// and bind the slice; a restricted-but-empty grant set fails closed with FALSE
+// so a scoped admin with no grants matches nothing rather than everything.
+func TestBuildScoreDiffSQL_OpDivScope(t *testing.T) {
+	t.Run("ScopedToGrantedOpDivs", func(t *testing.T) {
+		in := FindScoreDiffInput{
+			FromDataCallID:     int32Ptr(3),
+			ToDataCallID:       int32Ptr(4),
+			RestrictToOpDivIDs: true,
+			OpDivIDs:           []int32{7, 9},
+		}
+		sql, args := buildScoreDiffSQL(in)
+
+		assert.Equal(t, 2, strings.Count(sql, "opdiv_id = ANY($"), "OpDiv scope must apply to both cycle CTEs")
+		assert.NotContains(t, sql, "FALSE", "non-empty grants should not fail closed")
+		// The slice is bound twice (once per cycle).
+		slices := 0
+		for _, a := range args {
+			if ids, ok := a.([]int32); ok && len(ids) == 2 && ids[0] == 7 && ids[1] == 9 {
+				slices++
+			}
+		}
+		assert.Equal(t, 2, slices, "the OpDiv id slice should be bound once per cycle")
+	})
+
+	t.Run("RestrictedWithNoGrantsFailsClosed", func(t *testing.T) {
+		in := FindScoreDiffInput{
+			FromDataCallID:     int32Ptr(3),
+			ToDataCallID:       int32Ptr(4),
+			RestrictToOpDivIDs: true,
+		}
+		sql, _ := buildScoreDiffSQL(in)
+
+		assert.Equal(t, 2, strings.Count(sql, "FALSE"), "a scoped admin with no grants must match nothing in both cycles")
+		assert.NotContains(t, sql, "opdiv_id = ANY($", "should not bind an OpDiv predicate when there are no grants")
+	})
+
+	t.Run("UnscopedEmitsNoOpDivPredicate", func(t *testing.T) {
+		in := FindScoreDiffInput{FromDataCallID: int32Ptr(3), ToDataCallID: int32Ptr(4)}
+		sql, _ := buildScoreDiffSQL(in)
+
+		assert.NotContains(t, sql, "opdiv_id = ANY($", "unscoped admins get no OpDiv filter")
+		assert.NotContains(t, sql, "FALSE", "unscoped admins do not fail closed")
+	})
+}
+
+// TestDerefInt32 covers the nil-safe int32 deref used when building a
+// ScoreDiffSide from nullable scan targets on the unmatched side of the FULL
+// OUTER JOIN.
+func TestDerefInt32(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		assert.Equal(t, int32(0), derefInt32(nil))
+	})
+	t.Run("Value", func(t *testing.T) {
+		v := int32(7)
+		assert.Equal(t, int32(7), derefInt32(&v))
+	})
+}

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -701,6 +701,142 @@ func TestScoreSaveNoOpPreservesPriorEditorIntegration(t *testing.T) {
 		"after a real change, the editor must be the user who made it")
 }
 
+// TestFindScoreDiffIntegration exercises the real diff SQL against Postgres:
+// the FULL OUTER JOIN between two cycles, the IS DISTINCT FROM "drop unchanged
+// rows" filter, the function/question catalog joins, and the events lateral
+// that attributes the later change. Pure-Go builder tests cannot see any of
+// these because the SQL never executes there.
+//
+// Fixture is built in-test against the empire seed: two synthetic future
+// data calls (cleaned up via the prefix sweep), and four scores written
+// through Save so each carries a real attributed event:
+//
+//	F1: option optA in 'from' (Krennic), optB in 'to' (Tarkin) -> CHANGED
+//	F2: option optC in both cycles                             -> unchanged, dropped
+//	F3: option optD in 'to' only                               -> one-sided, surfaces with From=nil
+//
+// Empire fixtures only (see [[feedback_no_real_pii_in_tests]]); never
+// substitute real CMS users.
+func TestFindScoreDiffIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	// Two future data calls so Save's deadline guard passes. The prefix makes
+	// them (and their cascaded scores) discoverable by the sweep.
+	suffix := time.Now().UnixNano()
+	var dcFrom, dcTo int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), NOW() + INTERVAL '30 days') RETURNING datacallid
+	`, fmt.Sprintf("%sdiff_from_%d", integrationTestPrefix, suffix)).Scan(&dcFrom))
+	require.NoError(t, conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), NOW() + INTERVAL '30 days') RETURNING datacallid
+	`, fmt.Sprintf("%sdiff_to_%d", integrationTestPrefix, suffix)).Scan(&dcTo))
+
+	// F1: a function with at least two options so the same function can carry
+	// a different answer across cycles.
+	var f1 int32
+	var optA, optB int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT functionid FROM functionoptions GROUP BY functionid HAVING COUNT(*) >= 2 LIMIT 1
+	`).Scan(&f1), "seed must have a function with >=2 options")
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT functionoptionid FROM functionoptions WHERE functionid = $1 ORDER BY functionoptionid LIMIT 1
+	`, f1).Scan(&optA))
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT functionoptionid FROM functionoptions WHERE functionid = $1 ORDER BY functionoptionid OFFSET 1 LIMIT 1
+	`, f1).Scan(&optB))
+
+	// F2, F3: two other distinct functions, one option each.
+	var f2, f3, optC, optD int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT functionid, functionoptionid FROM functionoptions WHERE functionid <> $1 ORDER BY functionid LIMIT 1
+	`, f1).Scan(&f2, &optC))
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT functionid, functionoptionid FROM functionoptions WHERE functionid NOT IN ($1, $2) ORDER BY functionid LIMIT 1
+	`, f1, f2).Scan(&f3, &optD))
+
+	// An existing system to attach the scores to (FK-safe).
+	var sys int32
+	require.NoError(t, conn.QueryRow(ctx, `SELECT fismasystemid FROM scores LIMIT 1`).Scan(&sys))
+
+	krennic := UserToContext(ctx, &User{
+		UserID: "44444444-4444-4444-4444-444444444444", Email: "Director.Krennic@scarif.empire",
+		FullName: "Orson Krennic", Role: "ISSO",
+	})
+	tarkin := UserToContext(ctx, &User{
+		UserID: "11111111-1111-1111-1111-111111111111", Email: "Grand.Moff@DeathStar.Empire",
+		FullName: "Grand Moff Tarkin", Role: "OWNER",
+	})
+
+	save := func(uctx context.Context, fo, dc int32) int32 {
+		t.Helper()
+		s, err := (&Score{FismaSystemID: sys, FunctionOptionID: fo, DataCallID: dc}).Save(uctx)
+		require.NoError(t, err)
+		return s.ScoreID
+	}
+
+	createdScoreIDs := []int32{
+		save(krennic, optA, dcFrom), // F1 from
+		save(tarkin, optB, dcTo),    // F1 to (changed; Tarkin is the change author)
+		save(krennic, optC, dcFrom), // F2 from
+		save(tarkin, optC, dcTo),    // F2 to (unchanged)
+		save(tarkin, optD, dcTo),    // F3 to only (one-sided)
+	}
+	defer func() {
+		for _, id := range createdScoreIDs {
+			_, _ = conn.Exec(ctx, `DELETE FROM events WHERE resource='public.scores' AND (payload->>'scoreid')::int = $1`, id)
+			_, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid = $1`, id)
+		}
+	}()
+
+	diffs, err := FindScoreDiff(ctx, FindScoreDiffInput{
+		FismaSystemID:  &sys,
+		FromDataCallID: &dcFrom,
+		ToDataCallID:   &dcTo,
+	})
+	require.NoError(t, err)
+
+	byFunction := map[int32]*ScoreDiff{}
+	for _, d := range diffs {
+		byFunction[d.FunctionID] = d
+	}
+
+	// F2 was answered identically in both cycles: it must be dropped.
+	assert.NotContains(t, byFunction, f2, "unchanged function must not appear in the diff")
+
+	// F1 changed option optA -> optB; the change is attributed to the 'to' writer.
+	if assert.Contains(t, byFunction, f1, "changed function must appear") {
+		d := byFunction[f1]
+		require.NotNil(t, d.From, "F1 answered in both cycles")
+		require.NotNil(t, d.To)
+		assert.Equal(t, optA, d.From.FunctionOptionID, "from side is the earlier option")
+		assert.Equal(t, optB, d.To.FunctionOptionID, "to side is the later option")
+		require.NotNil(t, d.ChangedBy, "a changed answer must resolve its author from events")
+		assert.Equal(t, "11111111-1111-1111-1111-111111111111", d.ChangedBy.UserID,
+			"the change is attributed to whoever wrote the later (to) answer")
+		assert.NotNil(t, d.ChangedAt)
+	}
+
+	// F3 was answered only in the 'to' cycle: it surfaces with no 'from' side.
+	if assert.Contains(t, byFunction, f3, "one-sided (newly answered) function must surface via the outer join") {
+		d := byFunction[f3]
+		assert.Nil(t, d.From, "F3 has no earlier-cycle answer")
+		require.NotNil(t, d.To)
+		assert.Equal(t, optD, d.To.FunctionOptionID)
+	}
+}
+
 // countScoreEvents is a small helper used by the no-op preservation test
 // to assert that read-through Saves do not append event rows.
 func countScoreEvents(t *testing.T, ctx context.Context, conn *pgxpool.Conn, scoreID int32) int {

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -118,6 +118,16 @@ components:
         error:
           type: string
       type: object
+    controller.apiResponse-array_model_ScoreDiff:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/model.ScoreDiff'
+          type: array
+          uniqueItems: false
+        error:
+          type: string
+      type: object
     controller.apiResponse-array_model_User:
       properties:
         data:
@@ -439,6 +449,38 @@ components:
           type: number
         systemtier:
           type: string
+      type: object
+    model.ScoreDiff:
+      properties:
+        changed_at:
+          type: string
+        changed_by:
+          $ref: '#/components/schemas/model.AuditRef'
+        fismasystemid:
+          type: integer
+        from:
+          $ref: '#/components/schemas/model.ScoreDiffSide'
+        function:
+          type: string
+        functionid:
+          type: integer
+        question:
+          type: string
+        to:
+          $ref: '#/components/schemas/model.ScoreDiffSide'
+      type: object
+    model.ScoreDiffSide:
+      properties:
+        functionoptionid:
+          type: integer
+        notes:
+          type: string
+        optionname:
+          type: string
+        score:
+          type: integer
+        scoreid:
+          type: integer
       type: object
     model.SystemEnrichment:
       properties:
@@ -1882,6 +1924,55 @@ paths:
       security:
       - bearerAuth: []
       summary: Get aggregated scores
+      tags:
+      - scores
+  /scores/diff:
+    get:
+      description: 'Compares the score (functionoption) answers of two data calls
+        and returns only the questionnaire functions whose answer changed, each annotated
+        with who made the later change and when. Scoped to the caller''s tier: unscoped
+        admins see all systems, OpDiv-scoped admins their OpDivs'' systems, and ISSO/ISSM
+        their assigned systems.'
+      parameters:
+      - description: Data call ID to compare from (earlier cycle)
+        in: query
+        name: from
+        required: true
+        schema:
+          type: integer
+      - description: Data call ID to compare to (later cycle)
+        in: query
+        name: to
+        required: true
+        schema:
+          type: integer
+      - description: Limit the diff to a single FISMA system
+        in: query
+        name: fismasystemid
+        schema:
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-array_model_ScoreDiff'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Diff scores between two data calls
       tags:
       - scores
   /systemenrichment/{fisma_uuid}:


### PR DESCRIPTION
Closes #133.

## What

Adds `GET /api/v1/scores/diff?from={datacallid}&to={datacallid}[&fismasystemid={id}]` — compares the score (functionoption) answers of two data calls and returns **only the questionnaire functions whose answer changed**, each annotated with **who made the later change and when**.

This is the "show all the changes in a time period" ask in #133: the two data calls bound the period; the response is the questionnaire delta plus attribution.

## Response shape

One entry per changed function:

```jsonc
{
  "fismasystemid": 1001,
  "functionid": 7007,
  "function": "Battle Station Device Management",
  "question": "Does your system track all assets with comprehensive inventory?",
  "from": { "scoreid": 9001, "functionoptionid": 25, "optionname": "Defined",  "score": 2, "notes": "..." },
  "to":   { "scoreid": 9025, "functionoptionid": 26, "optionname": "Managed",  "score": 3, "notes": "..." },
  "changed_at": "2026-06-18T16:20:18Z",
  "changed_by": { "userid": "...", "name": "Grand Moff Tarkin", "email": "...", "role": "OWNER" }
}
```

- `from` / `to` are the answer in each cycle; either is `null` when the function was answered in only one cycle (added or removed).
- `changed_by` / `changed_at` attribute the write that produced the `to` answer, resolved from the `events` audit trail (mirrors the `last_edited_by` lateral in `FindScores`). Absent when no write event exists for the `to` score (seed data, or a function answered only in the `from` cycle).

## What counts as a change

A function differs when the selected functionoption changed, the notes changed, or it was answered in exactly one of the two cycles. `nil` and empty notes compare equal (same normalization as the no-op rule on the write path). Unchanged rows are dropped.

## Scope & validation

- Tier scoping matches `ListScores`, applied after query decode so a client cannot widen it: unscoped admins see all systems, OpDiv-scoped admins their OpDivs' systems (fail-closed), ISSO/ISSM their assigned systems.
- `from` and `to` are required and must differ → `400` otherwise.

## Implementation

- New `FindScoreDiff` / `buildScoreDiffSQL` in `internal/model/scorediff.go`. Built as parameterized raw SQL via the existing `rawQuery` read-path helper (FULL OUTER JOIN of the two cycle CTEs on `(system, function)` + catalog joins for labels + events lateral for attribution exceed squirrel's ergonomics, matching the precedent set by `buildPillarScoresSQL`). SELECT-only, so it never touches the event-recording write path.
- New `GetScoresDiff` controller handler + `/api/v1/scores/diff` route.
- Regenerated `openapi.yaml` (swag); redocly lint clean (pre-existing warnings only).

## Testing

- Unit: input validation; SQL builder filter/scope shaping and arg ordering (single-system, ISSO user scope, OpDiv grants + fail-closed).
- Integration (real Postgres, empire seed): changed answer, unchanged-dropped, one-sided via the outer join, and `to`-side attribution.
- Verified locally on a freshly wiped + reseeded dev DB: `go build/vet/test ./...` all green (full suite incl. integration), and live HTTP smoke tests through the running API (400 validation cases, unchanged→empty, a rich non-empty diff, and an edit-then-diff that surfaced the change attributed to the editor).

> Note: as a fork PR without repo secrets, Snyk / secret-dependent CI checks won't run and will show red — expected; maintainers re-run after pulling.