### PR TITLE
Gate system enrichment API by per-OpDiv insights flag

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -18,6 +18,11 @@ INSERT INTO public.opdivs (code, name, is_parent, active)
 -- here. There is no plain unique constraint on code (only a partial expression
 -- index), hence an UPDATE rather than ON CONFLICT DO UPDATE.
 UPDATE public.opdivs SET is_parent = TRUE WHERE LOWER(code) = 'empire';
+-- Enable ZTMF Insights for the EMPIRE OpDiv so system_enrichment is served for
+-- EMPIRE systems (mirrors CMS being the insights-enabled OpDiv in prod). The
+-- migration only enables code='CMS', so set the test OpDiv explicitly here.
+-- REBELLION is intentionally left disabled to exercise the OpDiv-gated 404.
+UPDATE public.opdivs SET insights_enabled = TRUE WHERE LOWER(code) = 'empire';
 
 -- 13 sister divisions of the Empire.
 INSERT INTO public.opdivs (code, name, is_parent, active) VALUES
@@ -530,6 +535,16 @@ ON CONFLICT (idm_name) DO NOTHING;
 INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
     'E1D00198-36D4-4EAB-8C00-501E1D000999',
     '{"fisma_acronym":"SLD-GEN","cfacts":{"lifecycle_phase":"Operational","fips_impact_level":"Moderate"},"scoring":{"suggested_score":2,"suggested_label":"Initial","evidence_sources":["Kion","Hardenize"]}}',
+    '2026-05-20 00:00:00+00'
+) ON CONFLICT (fisma_uuid) DO NOTHING;
+
+-- Enrichment row for a REBELLION system (RB-1, 1005). REBELLION has
+-- insights_enabled = FALSE, so the OpDiv gate must hide this row: a read returns
+-- 404 even though the payload exists and the caller is authorized. Proves the
+-- gate is the OpDiv flag, not merely a missing row.
+INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
+    'A1B2C300-1977-4E5F-9D0A-1234567890AB',
+    '{"fisma_acronym":"RB-1","cfacts":{"lifecycle_phase":"Operational","fips_impact_level":"Low"},"scoring":{"suggested_score":1,"suggested_label":"Traditional","evidence_sources":["Kion"]}}',
     '2026-05-20 00:00:00+00'
 ) ON CONFLICT (fisma_uuid) DO NOTHING;
 

--- a/backend/cmd/api/internal/controller/systemenrichment.go
+++ b/backend/cmd/api/internal/controller/systemenrichment.go
@@ -8,9 +8,15 @@ import (
 )
 
 // GetSystemEnrichment returns the generic enrichment payload for a FISMA system
-// by its fisma_uuid. Access control mirrors the FISMA-system assignment check:
-// admins (and read-only admins) may read any system; an ISSO may read only
-// systems they are assigned to. A system with no enrichment row yields 404.
+// by its fisma_uuid. Access is OpDiv-scoped (fetch-then-gate): unscoped admin
+// tiers read any system, OpDiv-scoped admins read systems in their granted
+// OpDivs, and an ISSO reads only systems they are assigned to. Enrichment is
+// additionally gated on the owning OpDiv having insights_enabled = TRUE (handled
+// in the model), so a system in a non-enabled OpDiv yields 404 - the same
+// response as a system with no enrichment row. A caller who lacks access to an
+// existing, insights-enabled system still gets 403 (consistent with the rest of
+// the API's authz); this hides the gate and missing systems, not the existence
+// of systems the caller simply cannot read.
 //	@Summary	Get enrichment payload for a FISMA system
 //	@Tags		systemenrichment
 //	@Produce	json
@@ -31,16 +37,16 @@ func GetSystemEnrichment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !user.HasAdminRead() {
-		canAccess, err := model.UserCanAccessFismaSystemByUUID(r.Context(), user.UserID, fismaUUID)
-		if err != nil {
-			respond(w, r, nil, err)
-			return
-		}
-		if !canAccess {
-			respond(w, r, nil, ErrForbidden)
-			return
-		}
+	// Resolve the system first so access is evaluated against its OpDiv. A miss
+	// stays 404 (ErrNoData) so we never leak which systems exist via a 403.
+	system, err := model.FindFismaSystemByUUID(r.Context(), fismaUUID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+	if !user.CanAccessFismaSystem(system.OpDivID, system.FismaSystemID) {
+		respond(w, r, nil, ErrForbidden)
+		return
 	}
 
 	enrichment, err := model.FindSystemEnrichment(r.Context(), fismaUUID)

--- a/backend/cmd/api/internal/migrations/0042opdivinsightsflag.go
+++ b/backend/cmd/api/internal/migrations/0042opdivinsightsflag.go
@@ -1,0 +1,27 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add opdivs.insights_enabled flag and enable it for CMS",
+		`
+-- System enrichment (ZTMF Insights) is only available for OpDivs that have an
+-- insights pipeline feeding system_enrichment. Today that is CMS only (the only
+-- OpDiv with security-insight logs). Rather than hardcode code='CMS' in the read
+-- path, gate on a per-OpDiv capability flag so enabling another OpDiv later is a
+-- single UPDATE (no code change / redeploy).
+--
+-- Defaults FALSE so no OpDiv surfaces enrichment until explicitly enabled; the
+-- backfill turns it on for the active CMS row. NOT NULL keeps the read-path join
+-- predicate simple (no three-valued logic). IF NOT EXISTS for idempotent retry.
+
+ALTER TABLE public.opdivs
+    ADD COLUMN IF NOT EXISTS insights_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE public.opdivs
+    SET insights_enabled = TRUE
+    WHERE code = 'CMS' AND active = TRUE;
+        `,
+		`
+ALTER TABLE public.opdivs DROP COLUMN IF EXISTS insights_enabled;
+        `)
+}

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1121,6 +1121,16 @@ tests:
     expect:
       status: 404
 
+  # OpDiv gate: RB-1 (REBELLION) HAS an enrichment row, but REBELLION is not
+  # insights_enabled, so even an unscoped admin (commonHeaders) gets 404. Proves
+  # the gate is the OpDiv flag, not a missing row or an access failure.
+  - url: http://localhost:8080/api/v1/systemenrichment/A1B2C300-1977-4E5F-9D0A-1234567890AB
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 404
+
   # massemails only supports this one route
   # test that it errors on invalid input
   - url: http://localhost:8080/api/v1/massemails

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -117,7 +117,9 @@ func FindFismaSystem(ctx context.Context, input FindFismaSystemsInput) (*FismaSy
 // matches. Used by the enrichment endpoint to resolve a system's opdiv_id for
 // OpDiv-scoped access checks before serving enrichment. fismauid is not unique
 // by schema; this returns the first match, which is sufficient for the access
-// check since duplicates are not expected in practice.
+// check since duplicates are not expected in practice. LIMIT 1 makes that
+// single-row intent explicit at the query level rather than relying on the
+// driver discarding extra rows.
 func FindFismaSystemByUUID(ctx context.Context, fismaUUID string) (*FismaSystem, error) {
 	if fismaUUID == "" {
 		return nil, ErrNoData
@@ -126,7 +128,8 @@ func FindFismaSystemByUUID(ctx context.Context, fismaUUID string) (*FismaSystem,
 	sqlb := stmntBuilder.
 		Select(fismaSystemColumns...).
 		From("fismasystems").
-		Where("LOWER(fismauid) = LOWER(?)", fismaUUID)
+		Where("LOWER(fismauid) = LOWER(?)", fismaUUID).
+		Limit(1)
 
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[FismaSystem])
 }

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -112,26 +112,23 @@ func FindFismaSystem(ctx context.Context, input FindFismaSystemsInput) (*FismaSy
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[FismaSystem])
 }
 
-// UserCanAccessFismaSystemByUUID checks whether a user is assigned to the
-// FISMA system identified by fismaUUID (fismasystems.fismauid), via the
-// users_fismasystems junction table. Returns (false, nil) when the user has
-// no assignment to that system.
-func UserCanAccessFismaSystemByUUID(ctx context.Context, userID string, fismaUUID string) (bool, error) {
-	sqlb := stmntBuilder.
-		Select("1").
-		From("users_fismasystems").
-		InnerJoin("fismasystems ON fismasystems.fismasystemid = users_fismasystems.fismasystemid").
-		Where("LOWER(fismasystems.fismauid) = LOWER(?) AND users_fismasystems.userid = ?", fismaUUID, userID).
-		Limit(1)
-
-	_, err := queryRow(ctx, sqlb, pgx.RowTo[int])
-	if err != nil {
-		if err == ErrNoData {
-			return false, nil
-		}
-		return false, err
+// FindFismaSystemByUUID returns the FISMA system identified by its fisma_uuid
+// (fismasystems.fismauid, matched case-insensitively), or ErrNoData if none
+// matches. Used by the enrichment endpoint to resolve a system's opdiv_id for
+// OpDiv-scoped access checks before serving enrichment. fismauid is not unique
+// by schema; this returns the first match, which is sufficient for the access
+// check since duplicates are not expected in practice.
+func FindFismaSystemByUUID(ctx context.Context, fismaUUID string) (*FismaSystem, error) {
+	if fismaUUID == "" {
+		return nil, ErrNoData
 	}
-	return true, nil
+
+	sqlb := stmntBuilder.
+		Select(fismaSystemColumns...).
+		From("fismasystems").
+		Where("LOWER(fismauid) = LOWER(?)", fismaUUID)
+
+	return queryRow(ctx, sqlb, pgx.RowToStructByName[FismaSystem])
 }
 
 func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {

--- a/backend/internal/model/opdivs.go
+++ b/backend/internal/model/opdivs.go
@@ -20,6 +20,11 @@ type OpDiv struct {
 	// omitting active would silently deactivate an active OpDiv.
 	IsParent *bool `json:"is_parent" db:"is_parent"`
 	Active   *bool `json:"active"`
+	// InsightsEnabled gates whether system_enrichment (ZTMF Insights) is served
+	// for systems in this OpDiv. Pointer for the same reason as IsParent/Active:
+	// an update that omits it must leave the column untouched, not reset it to
+	// false (which would silently disable enrichment for an enabled OpDiv).
+	InsightsEnabled *bool `json:"insights_enabled" db:"insights_enabled"`
 }
 
 // FindOpDivsInput holds optional filters for listing OpDivs.
@@ -32,7 +37,7 @@ type FindOpDivsInput struct {
 // and by the onboarding workbook importer to validate opdiv codes.
 func FindOpDivs(ctx context.Context, input FindOpDivsInput) ([]*OpDiv, error) {
 	sqlb := stmntBuilder.
-		Select("opdiv_id", "code", "name", "is_parent", "active").
+		Select("opdiv_id", "code", "name", "is_parent", "active", "insights_enabled").
 		From("public.opdivs").
 		OrderBy("(NOT is_parent), code")
 
@@ -79,30 +84,35 @@ func (o *OpDiv) Save(ctx context.Context) (*OpDiv, error) {
 
 	var sqlb SqlBuilder
 	if o.OpDivID == 0 {
-		// Create: a new OpDiv is always active; is_parent defaults to false when
-		// the optional field is omitted.
+		// Create: a new OpDiv is always active; is_parent and insights_enabled
+		// default to false when the optional fields are omitted.
 		isParent := o.IsParent != nil && *o.IsParent
+		insightsEnabled := o.InsightsEnabled != nil && *o.InsightsEnabled
 		sqlb = stmntBuilder.
 			Insert("public.opdivs").
-			Columns("code", "name", "is_parent", "active").
-			Values(o.Code, o.Name, isParent, true).
-			Suffix("RETURNING opdiv_id, code, name, is_parent, active")
+			Columns("code", "name", "is_parent", "active", "insights_enabled").
+			Values(o.Code, o.Name, isParent, true, insightsEnabled).
+			Suffix("RETURNING opdiv_id, code, name, is_parent, active, insights_enabled")
 	} else {
 		ub := stmntBuilder.
 			Update("public.opdivs").
 			Set("code", o.Code).
 			Set("name", o.Name)
-		// Only touch is_parent / active when the caller explicitly supplied them;
-		// omitting a field (nil) must leave the current value intact.
+		// Only touch is_parent / active / insights_enabled when the caller
+		// explicitly supplied them; omitting a field (nil) must leave the current
+		// value intact.
 		if o.IsParent != nil {
 			ub = ub.Set("is_parent", *o.IsParent)
 		}
 		if o.Active != nil {
 			ub = ub.Set("active", *o.Active)
 		}
+		if o.InsightsEnabled != nil {
+			ub = ub.Set("insights_enabled", *o.InsightsEnabled)
+		}
 		sqlb = ub.
 			Where("opdiv_id=?", o.OpDivID).
-			Suffix("RETURNING opdiv_id, code, name, is_parent, active")
+			Suffix("RETURNING opdiv_id, code, name, is_parent, active, insights_enabled")
 	}
 
 	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByName[OpDiv])

--- a/backend/internal/model/systemenrichment.go
+++ b/backend/internal/model/systemenrichment.go
@@ -23,15 +23,33 @@ type SystemEnrichment struct {
 // FindSystemEnrichment returns the enrichment row for a FISMA system by its
 // fisma_uuid, or ErrNoData if none exists (e.g. a deployment with no enrichment
 // pipeline attached, or a system the pipeline has not scored).
+//
+// Enrichment is gated on the owning OpDiv's insights_enabled flag: the row is
+// returned only when the system maps (via fismasystems.opdiv_id) to an OpDiv
+// with insights_enabled = TRUE. A system in a non-enabled OpDiv yields ErrNoData
+// (-> 404), indistinguishable from "no enrichment row", so the gate never leaks
+// which systems exist. This is the data-layer half of the OpDiv-conditional
+// feature; the controller separately enforces per-caller access.
 func FindSystemEnrichment(ctx context.Context, fismaUUID string) (*SystemEnrichment, error) {
 	if fismaUUID == "" {
 		return nil, ErrNoData
 	}
 
+	// EXISTS (not a JOIN): fismasystems.fismauid is not unique by schema, so a
+	// JOIN could fan out to multiple rows and would pass the gate if ANY system
+	// sharing the uuid were in an enabled OpDiv. EXISTS keeps this to a single
+	// enrichment row and gates on whether the uuid maps to an insights-enabled
+	// OpDiv at all.
 	sqlb := stmntBuilder.
-		Select("fisma_uuid", "payload", "synced_at").
-		From("system_enrichment").
-		Where("fisma_uuid=?", fismaUUID)
+		Select("se.fisma_uuid", "se.payload", "se.synced_at").
+		From("system_enrichment se").
+		Where("se.fisma_uuid = ?", fismaUUID).
+		Where(`EXISTS (
+			SELECT 1 FROM fismasystems fs
+			JOIN opdivs o ON o.opdiv_id = fs.opdiv_id
+			WHERE LOWER(fs.fismauid) = LOWER(se.fisma_uuid)
+			  AND o.insights_enabled = TRUE
+		)`)
 
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[SystemEnrichment])
 }

--- a/backend/internal/model/systemenrichment_test.go
+++ b/backend/internal/model/systemenrichment_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -45,4 +46,41 @@ func TestFindSystemEnrichment_EmptyUUID(t *testing.T) {
 	// no test database.
 	_, err := FindSystemEnrichment(context.TODO(), "")
 	assert.Equal(t, ErrNoData, err)
+}
+
+// TestFindSystemEnrichmentOpDivGate exercises the OpDiv-conditional gate added
+// for ZTMF Insights consumption. Relies on the empire integration seed:
+//   - Shield Gen (E1D00198-...-999) is an EMPIRE system; EMPIRE has
+//     insights_enabled = TRUE and a seeded enrichment row -> returned.
+//   - RB-1 (A1B2C300-...) is a REBELLION system; REBELLION has
+//     insights_enabled = FALSE but DOES have a seeded enrichment row, so it
+//     isolates the gate from the "no row" case -> ErrNoData.
+func TestFindSystemEnrichmentOpDivGate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+
+	t.Run("EnabledOpDivReturnsRow", func(t *testing.T) {
+		got, err := FindSystemEnrichment(ctx, "E1D00198-36D4-4EAB-8C00-501E1D000999")
+		assert.NoError(t, err)
+		if assert.NotNil(t, got) {
+			assert.Equal(t, "E1D00198-36D4-4EAB-8C00-501E1D000999", got.FismaUUID)
+			assert.NotEmpty(t, got.Payload)
+		}
+	})
+
+	t.Run("DisabledOpDivIsGated", func(t *testing.T) {
+		// Payload exists, but REBELLION is not insights_enabled, so the gate must
+		// hide it as ErrNoData (-> 404), not return the row.
+		got, err := FindSystemEnrichment(ctx, "A1B2C300-1977-4E5F-9D0A-1234567890AB")
+		assert.Nil(t, got)
+		assert.True(t, errors.Is(err, ErrNoData), "expected ErrNoData for non-insights OpDiv, got %v", err)
+	})
+
+	t.Run("NonexistentReturnsNoData", func(t *testing.T) {
+		got, err := FindSystemEnrichment(ctx, "00000000-0000-0000-0000-000000000000")
+		assert.Nil(t, got)
+		assert.True(t, errors.Is(err, ErrNoData))
+	})
 }

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -353,6 +353,13 @@ components:
           type: boolean
         code:
           type: string
+        insights_enabled:
+          description: |-
+            InsightsEnabled gates whether system_enrichment (ZTMF Insights) is served
+            for systems in this OpDiv. Pointer for the same reason as IsParent/Active:
+            an update that omits it must leave the column untouched, not reset it to
+            false (which would silently disable enrichment for an enabled OpDiv).
+          type: boolean
         is_parent:
           description: |-
             IsParent and Active are pointers so an update can distinguish "not supplied"


### PR DESCRIPTION
## Summary

Gates the existing system enrichment read endpoint (`GET /api/v1/systemenrichment/{fisma_uuid}`) on a new per-OpDiv capability flag, so ZTMF Insights enrichment is served only for OpDivs that have an insights pipeline feeding them. Today that is CMS only; enabling another OpDiv later is a single database update, no code change.

## Why

Enrichment data (system metadata from the ZTMF Insights pipeline) currently exists only for CMS, but the read endpoint returned a payload for any system that had a row, with no notion of which OpDivs are entitled to the feature. This adds that boundary and makes it data-driven so the feature can extend to other OpDivs as an add-on.

## Changes

- **Migration 0042**: adds `opdivs.insights_enabled` (boolean, default false), backfills it true for the active CMS OpDiv. Down migration drops the column.
- **Model**: `OpDiv.InsightsEnabled *bool` (pointer so an update that omits it does not reset it), conditional set on save. `FindSystemEnrichment` returns a row only when the system's `fismauid` maps to an OpDiv with `insights_enabled = TRUE` (an `EXISTS` predicate, which avoids fanning out on the non-unique `fismauid`).
- **Controller**: resolves the system first, then authorizes against its OpDiv (`CanAccessFismaSystem`), replacing the prior per-system-only check. A system in a non-enabled OpDiv returns 404, identical to a system with no enrichment row, so the gate never reveals which systems exist.
- **Tests**: model integration test for the gate, plus an Emberfall E2E case proving a system with an enrichment row in a disabled OpDiv returns 404.
- **OpenAPI** regenerated from annotations.

## Behavior and compatibility

- Backwards compatible. Additive schema change; deploys to dev on PR, prod on merge.
- Enrichment is only hidden for systems in OpDivs that are not insights-enabled. The pipeline only feeds CMS, and the migration enables CMS, so existing enrichment continues to be served unchanged.
- Minor authorization tightening: OpDiv-scoped admins now read enrichment only for systems in their granted OpDivs (previously any admin tier could read any system's enrichment). Unscoped admins (OWNER, HHS) and assigned ISSOs are unaffected.

## Testing

Full local suite passes: unit, integration (including the new gate test), and E2E (Emberfall). Validated end to end against real enrichment data in the impl environment.

## Issues

Implements CMS-Enterprise/ztmf-misc#85 (API endpoints for SDL enrichment data). The read surface landed in #211; this PR adds the OpDiv-conditional gate that completes the consumption API. The issue's original per-function response shape is superseded by the generic jsonb payload (the pipeline owns structure). It will be closed on merge (cross-repo keywords do not auto-close from this repository).
