### PR TITLE
Standardize error responses in Middleware. Add case for unprovisioned users and session expiration

### DIFF
--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -1,6 +1,9 @@
 package auth
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"log"
 	"net"
 	"net/http"
@@ -10,6 +13,41 @@ import (
 	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 )
+
+// Error codes returned in the JSON body alongside the HTTP status. The FE keys
+// off these to render distinguishable copy: UNAUTHORIZED maps to "your session
+// has expired", ACCOUNT_NOT_PROVISIONED maps to a terminal "contact your
+// administrator" message with no retry CTA. See ztmf-ui#403.
+const (
+	CodeUnauthorized          = "UNAUTHORIZED"
+	CodeForbiddenOrigin       = "FORBIDDEN_ORIGIN"
+	CodeAccountNotProvisioned = "ACCOUNT_NOT_PROVISIONED"
+)
+
+// Package-level seams over the model lookups so tests can stub them without a
+// database. Production wiring is the real model functions.
+var (
+	findUserByID    = model.FindUserByID
+	findUserByEmail = model.FindUserByEmail
+)
+
+// errorBody is the JSON shape returned on every middleware-rejected request.
+// Single shape across 401/403/500 so the FE interceptor can rely on it and
+// branch on `code` rather than parsing status alone.
+type errorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code,omitempty"`
+}
+
+// writeJSONError writes a standardized JSON error response and is the only
+// rejection surface used by Middleware. Centralizing the shape keeps the FE
+// interceptor's contract single-sourced.
+func writeJSONError(w http.ResponseWriter, status int, msg, code string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{Error: msg, Code: code})
+}
 
 // Middleware authenticates /api/* requests and attaches the matching user to
 // the request context. It accepts two token sources, in order:
@@ -21,13 +59,20 @@ import (
 //     (HS256 bearer) and the E2E suite working, and also covers the interim
 //     period before the ALB rule flips, where the ALB still injects the IdP
 //     token on /api/*.
+//
+// Rejection statuses distinguish three failure shapes the FE needs to
+// disambiguate (ztmf-ui#403): 401 for missing/invalid session, 403 with code
+// ACCOUNT_NOT_PROVISIONED for an authenticated identity with no app account
+// (or a soft-deleted one), and 403 with code FORBIDDEN_ORIGIN for CSRF.
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cfg := config.GetInstance()
 
 		claims, isSession, ok := claimsFromRequest(r)
 		if !ok {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			writeJSONError(w, http.StatusUnauthorized,
+				"Your session has expired. Please sign in again.",
+				CodeUnauthorized)
 			return
 		}
 
@@ -37,7 +82,9 @@ func Middleware(next http.Handler) http.Handler {
 		// cookie path is browser-driven; the bearer path is for API clients and
 		// is not subject to CSRF.
 		if isSession && !isSafeMethod(r.Method) && !sameOrigin(r) {
-			http.Error(w, "forbidden", http.StatusForbidden)
+			writeJSONError(w, http.StatusForbidden,
+				"Request blocked: origin not allowed.",
+				CodeForbiddenOrigin)
 			return
 		}
 
@@ -51,12 +98,16 @@ func Middleware(next http.Handler) http.Handler {
 			err  error
 		)
 		if isSession {
-			user, err = model.FindUserByID(r.Context(), claims.Subject)
+			user, err = findUserByID(r.Context(), claims.Subject)
 		} else {
-			user, err = model.FindUserByEmail(r.Context(), IdentifierFromClaims(claims))
+			user, err = findUserByEmail(r.Context(), IdentifierFromClaims(claims))
 		}
 
 		if err != nil && !isSession && cfg.IsLocal() {
+			// Local dev convenience: an unauthenticated identity that doesn't
+			// map to a row gets a fresh OWNER user so contributors can poke
+			// around without seeding by hand. Any lookup error (not-found,
+			// connection blip) routes through this path locally.
 			log.Printf("Local dev: auto-creating OWNER user for %s\n", claims.Email)
 			user = &model.User{
 				Email:    claims.Email,
@@ -69,18 +120,39 @@ func Middleware(next http.Handler) http.Handler {
 			user, err = user.Save(r.Context())
 			if err != nil {
 				log.Printf("Failed to auto-create user: %s\n", err)
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				writeJSONError(w, http.StatusInternalServerError,
+					"internal error", "")
 				return
 			}
+		} else if errors.Is(err, model.ErrNoData) {
+			// The IdP authenticated this identity, but it has no row in the
+			// ZTMF users table. Distinct from "session expired" - the session
+			// is valid; the user simply has no app account. The FE branches on
+			// this code to render a terminal "contact your administrator"
+			// message instead of looping the user back through the IdP.
+			log.Printf("authenticated identity has no ZTMF account: %s\n", IdentifierFromClaims(claims))
+			writeJSONError(w, http.StatusForbidden,
+				"Your ZTMF account is not set up. Contact your administrator to request access.",
+				CodeAccountNotProvisioned)
+			return
 		} else if err != nil {
-			log.Printf("Could not find user for request: %s\n", err)
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			// DB connection blip, decode failure, etc. Not a credential
+			// problem, so do not present as one to the FE.
+			log.Printf("user lookup failed: %s\n", err)
+			writeJSONError(w, http.StatusInternalServerError,
+				"internal error", "")
 			return
 		}
 
 		if user.Deleted {
-			log.Println("a deleted user tried to access the API")
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			// Same FE-facing UX as the never-provisioned case: the IdP
+			// session is valid but no usable app account exists. Logged
+			// distinctly so support can tell "offboarded" from "never
+			// onboarded" without grepping the users table.
+			log.Printf("deleted user attempted to access the API: %s\n", user.Email)
+			writeJSONError(w, http.StatusForbidden,
+				"Your ZTMF account is no longer active. Contact your administrator.",
+				CodeAccountNotProvisioned)
 			return
 		}
 
@@ -88,6 +160,14 @@ func Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
+
+// Compile-time assertion that the model lookup vars have the signatures the
+// middleware (and the tests) expect. Keeps a future signature drift in the
+// model package from sneaking through.
+var (
+	_ func(context.Context, string) (*model.User, error) = findUserByID
+	_ func(context.Context, string) (*model.User, error) = findUserByEmail
+)
 
 // isSafeMethod reports whether the HTTP method is read-only and therefore not
 // a CSRF concern.

--- a/backend/cmd/api/internal/auth/middleware_test.go
+++ b/backend/cmd/api/internal/auth/middleware_test.go
@@ -1,6 +1,9 @@
 package auth
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -74,6 +77,163 @@ func TestIsSafeMethod(t *testing.T) {
 	for _, m := range []string{"POST", "PUT", "DELETE", "PATCH"} {
 		assert.False(t, isSafeMethod(m), m)
 	}
+}
+
+// TestMiddleware covers the three response shapes the FE keys off after
+// ztmf-ui#403: unauthenticated -> 401 UNAUTHORIZED, authenticated identity
+// with no app account -> 403 ACCOUNT_NOT_PROVISIONED, and the happy path
+// where a provisioned user passes through to the next handler. A bonus case
+// covers the soft-deleted user, which collapses into the same FE UX as
+// "never provisioned" but logs distinctly.
+func TestMiddleware(t *testing.T) {
+	cfg := config.GetInstance()
+
+	mintBearer := func(t *testing.T, email string) string {
+		t.Helper()
+		tok := jwt.NewWithClaims(jwt.SigningMethodHS256, &Claims{
+			Email:            email,
+			RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour))},
+		})
+		s, err := tok.SignedString([]byte(testHS256Secret))
+		require.NoError(t, err)
+		return s
+	}
+
+	nextFn := func(called *bool) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			*called = true
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+
+	decodeBody := func(t *testing.T, w *httptest.ResponseRecorder) errorBody {
+		t.Helper()
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+		var body errorBody
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		return body
+	}
+
+	// stubFindUserByEmail swaps the package-level seam for the duration of a
+	// subtest. The original is restored via t.Cleanup so subtests stay
+	// independent regardless of order.
+	stubFindUserByEmail := func(t *testing.T, fn func(context.Context, string) (*model.User, error)) {
+		t.Helper()
+		prev := findUserByEmail
+		findUserByEmail = fn
+		t.Cleanup(func() { findUserByEmail = prev })
+	}
+
+	t.Run("no auth -> 401 UNAUTHORIZED", func(t *testing.T) {
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.False(t, called, "next must not be called on rejection")
+		body := decodeBody(t, w)
+		assert.Equal(t, CodeUnauthorized, body.Code)
+		assert.NotEmpty(t, body.Error)
+	})
+
+	t.Run("bearer present but token invalid -> 401 UNAUTHORIZED", func(t *testing.T) {
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		r.Header.Set(cfg.Auth.HeaderField, "Bearer not.a.real.token")
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.False(t, called)
+		body := decodeBody(t, w)
+		assert.Equal(t, CodeUnauthorized, body.Code)
+	})
+
+	t.Run("authed + unprovisioned -> 403 ACCOUNT_NOT_PROVISIONED", func(t *testing.T) {
+		stubFindUserByEmail(t, func(context.Context, string) (*model.User, error) {
+			return nil, model.ErrNoData
+		})
+
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		r.Header.Set(cfg.Auth.HeaderField, "Bearer "+mintBearer(t, "ghost@nowhere.xyz"))
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.False(t, called, "next must not be called for an unprovisioned identity")
+		body := decodeBody(t, w)
+		assert.Equal(t, CodeAccountNotProvisioned, body.Code)
+		assert.NotEmpty(t, body.Error)
+	})
+
+	t.Run("authed + provisioned -> next called", func(t *testing.T) {
+		stubFindUserByEmail(t, func(_ context.Context, email string) (*model.User, error) {
+			return &model.User{
+				UserID: "11111111-1111-1111-1111-111111111111",
+				Email:  email,
+				Role:   "OWNER",
+			}, nil
+		})
+
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		r.Header.Set(cfg.Auth.HeaderField, "Bearer "+mintBearer(t, "provisioned@empire.test"))
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.True(t, called, "next must be called on the happy path")
+	})
+
+	t.Run("authed + soft-deleted -> 403 ACCOUNT_NOT_PROVISIONED", func(t *testing.T) {
+		stubFindUserByEmail(t, func(_ context.Context, email string) (*model.User, error) {
+			return &model.User{
+				UserID:  "22222222-2222-2222-2222-222222222222",
+				Email:   email,
+				Role:    "OWNER",
+				Deleted: true,
+			}, nil
+		})
+
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		r.Header.Set(cfg.Auth.HeaderField, "Bearer "+mintBearer(t, "offboarded@empire.test"))
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.False(t, called)
+		body := decodeBody(t, w)
+		assert.Equal(t, CodeAccountNotProvisioned, body.Code)
+	})
+
+	t.Run("authed + lookup errors (non-ErrNoData) -> 500", func(t *testing.T) {
+		stubFindUserByEmail(t, func(context.Context, string) (*model.User, error) {
+			return nil, errors.New("simulated db connection blip")
+		})
+
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		r.Header.Set(cfg.Auth.HeaderField, "Bearer "+mintBearer(t, "anyone@empire.test"))
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.False(t, called, "next must not be called on an upstream failure")
+		// 500 carries an error but no code: opaque to the FE on purpose so the
+		// "contact your administrator" terminal copy is not triggered by a
+		// transient DB blip.
+		body := decodeBody(t, w)
+		assert.Empty(t, body.Code)
+	})
 }
 
 func TestSameOrigin(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes the BE half of `CMS-Enterprise/ztmf-ui#403`.

Pre-existing bug: the auth middleware collapsed three semantically distinct failures into one response — `http.Error(w, "unauthorized", 401)` for a missing/invalid session, for an IdP-authed identity with no ZTMF row, and for a soft-deleted account. The FE had no signal to tell them apart, so a valid IdP session with no app account rendered as "Your session has expired" with the infinite Sign in loop documented in the issue.

This PR splits those cases into distinguishable responses: 401 + `UNAUTHORIZED` for no/invalid session (semantics unchanged), 403 + `ACCOUNT_NOT_PROVISIONED` for an authenticated identity with no usable app account (never-provisioned and soft-deleted collapse to the same code, distinguished in server logs only), and 500 for upstream lookup failures that aren't a credential problem. CSRF rejections also gain a typed code (`FORBIDDEN_ORIGIN`).

## Frontend dependency

Pairs with the FE handling change: `CMS-Enterprise/ztmf-ui#418`. The new `code` field only has user-visible effect once the FE starts reading it.

**Deploy order: FE first, BE second.** Mirrors the deploy order stated in #418. With #418 deployed first against the current (unchanged) BE, every new FE code path stays dormant, since the BE never emits `code`, so the FE falls back to existing behavior and matches today. Once this BE lands, `ACCOUNT_NOT_PROVISIONED` drives the `NO_ACCOUNT` terminal state and the loop is broken. The reverse order (this BE first, #418 second) is worse than the current bug: the new 403 + code is unrecognized by the old FE interceptor, which surfaces the BE message via the OOS toast on subsequent `/api/*` calls, causing a confusing toast on a stuck page instead of the familiar (if misleading) loop. Coordinated single-deploy is best.

## Changes

* **`backend/cmd/api/internal/auth/middleware.go`**
  * Added typed response codes: `CodeUnauthorized`, `CodeForbiddenOrigin`, `CodeAccountNotProvisioned`. Mirrored on the FE in `utils/authCodes.ts`.
  * Replaced `http.Error(...)` plain-text rejections with `writeJSONError(...)`. Single shape `{error, code}` across 401 / 403 / 500. Sets `X-Content-Type-Options: nosniff` on the response.
  * Split the post-lookup error handling: `errors.Is(err, model.ErrNoData)` → 403 `ACCOUNT_NOT_PROVISIONED`; any other non-nil err → 500 (opaque, no code, so the FE falls through to `ServerErrorPage` rather than misclassifying as auth-expired). Local-dev auto-create path unchanged.
  * Soft-deleted user now 403 + `ACCOUNT_NOT_PROVISIONED` (was 401). Same response as never-provisioned; log line distinguishes them for ops/support without exposing the distinction to clients.
  * CSRF origin rejection now 403 + `FORBIDDEN_ORIGIN` (was plain "forbidden").
  * Lookup calls go through package-level `findUserByID` / `findUserByEmail` vars so tests can stub without a database. Compile-time signature assertion at the bottom of the file guards against future signature drift in the `model` package.
* **`backend/cmd/api/internal/auth/middleware_test.go`**
  * New `TestMiddleware` covering the three contract cases from #403 plus three regression bonuses:
    * no auth → 401 `UNAUTHORIZED`
    * bearer present but invalid token → 401 `UNAUTHORIZED`
    * authed + unprovisioned → 403 `ACCOUNT_NOT_PROVISIONED`
    * authed + provisioned → next handler called
    * authed + soft-deleted → 403 `ACCOUNT_NOT_PROVISIONED`
    * authed + lookup errors (non-`ErrNoData`) → 500 (no code)

## Test plan

Backend unit tests:

* `middleware_test.TestMiddleware` covers all six cases above.
* Existing `TestClaimsFromRequest`, `TestIsSafeMethod`, `TestSameOrigin`, plus `auth/{ratelimit,session,token}_test.go` and `controller/auth_test.go` continue to pass.

`go test ./cmd/api/...` and `go vet ./cmd/api/...` green.

Container smoke (`compose-dev` rebuilt against this branch). First, mint a bearer for the local admin:

```bash
cd ztmf-ui && make frontend-env EMAIL=Grand.Moff@DeathStar.Empire
# Uncomment VITE_AUTH_TOKEN3 in .env.development.local, then:
export TOKEN='<paste the JWT>'
```

* [ ] **No auth → 401 `UNAUTHORIZED`**
  ```bash
  curl -s -i 'http://localhost:8080/api/v1/users/current' | head -20
  # HTTP/1.1 401 Unauthorized
  # Content-Type: application/json
  # X-Content-Type-Options: nosniff
  # {"error":"Your session has expired. Please sign in again.","code":"UNAUTHORIZED"}
  ```
* [ ] **Invalid bearer → 401 `UNAUTHORIZED`** (same shape)
  ```bash
  curl -s -i -H "Authorization: Bearer not.a.real.token" \
    'http://localhost:8080/api/v1/users/current' | head -20
  ```
* [ ] **Provisioned bearer → 200** (regression check)
  ```bash
  curl -s -H "Authorization: Bearer $TOKEN" \
    'http://localhost:8080/api/v1/users/current' | jq
  # {"data": {"userid": "...", "email": "Grand.Moff@DeathStar.Empire", ...}}
  ```
* [ ] **Soft-deleted user → 403 `ACCOUNT_NOT_PROVISIONED`**
  ```bash
  # Soft-delete a seeded user
  docker exec backend-postgre-1 psql -U admin -d ztmf -p 54321 -c \
    "UPDATE users SET deleted = true WHERE email = 'Grand.Admiral.Thrawn@chiss.empire';"

  # Mint their token, paste below
  cd ztmf-ui && make frontend-env EMAIL=Grand.Admiral.Thrawn@chiss.empire
  export GHOST_TOKEN='<paste>'

  curl -s -i -H "Authorization: Bearer $GHOST_TOKEN" \
    'http://localhost:8080/api/v1/users/current' | head -20
  # HTTP/1.1 403 Forbidden
  # {"error":"Your ZTMF account is no longer active. Contact your administrator.","code":"ACCOUNT_NOT_PROVISIONED"}

  # Restore
  docker exec backend-postgre-1 psql -U admin -d ztmf -p 54321 -c \
    "UPDATE users SET deleted = false WHERE email = 'Grand.Admiral.Thrawn@chiss.empire';"
  ```
* [ ] **Never-provisioned bearer → 403 `ACCOUNT_NOT_PROVISIONED`**
  The local-dev auto-create branch masks this path under `ENVIRONMENT=local`, so flip the env temporarily.
  ```bash
  # Edit backend/dev.compose.env: ENVIRONMENT=local → ENVIRONMENT=test
  docker compose -f backend/compose-dev.yml restart api

  cd ztmf-ui && make frontend-env EMAIL=nobody@nowhere.test
  export GHOST_TOKEN='<paste>'

  curl -s -i -H "Authorization: Bearer $GHOST_TOKEN" \
    'http://localhost:8080/api/v1/users/current' | head -20
  # HTTP/1.1 403 Forbidden
  # {"error":"Your ZTMF account is not set up. Contact your administrator to request access.","code":"ACCOUNT_NOT_PROVISIONED"}

  # Revert backend/dev.compose.env: ENVIRONMENT=test → ENVIRONMENT=local
  docker compose -f backend/compose-dev.yml restart api
  ```
* [ ] **Controller-level 403 stays unchanged** (regression check, as this confirms the FE's "code present = middleware, code absent = controller" discriminator)
  Mint a non-admin bearer (e.g. `Admiral.Piett@executor.empire`, role `ISSO`), hit an admin-only route:
  ```bash
  cd ztmf-ui && make frontend-env EMAIL=Admiral.Piett@executor.empire
  export ISSO_TOKEN='<paste>'

  curl -s -i -H "Authorization: Bearer $ISSO_TOKEN" \
    'http://localhost:8080/api/v1/users' | head -20
  # HTTP/1.1 403 Forbidden
  # {"data":null,"error":"forbidden"}        <- no `code` field, unchanged shape
  ```

End-to-end with #418 applied locally:

* [ ] Sign in as a normal admin, soft-delete the row in another shell, reload → `NoAccountTerminal` renders the BE message verbatim, no Sign in button, no infinite loop. Restore the row → normal flow resumes.

## Notes for reviewers

* **The response-shape split between middleware and controllers is intentional.** Middleware-rejected responses carry `{error, code}`. Controller-rejected responses (everything through `controller.respond`) stay at `{data, error}` with no `code` field. Presence/absence of `code` is the FE's discriminator. Widening `code` to controller responses is a separate future change; not needed for this ticket.
* **`error` is user-facing copy here.** Because the paired FE renders the BE message verbatim on the `NoAccountTerminal` screen, the strings use sentence case with periods rather than the lowercase-no-period style of `errors.New(...)` sentinels elsewhere in the codebase. `ST1005` does not apply, because these are response-body strings inside `writeJSONError(...)` calls, not error sentinels. The FE keeps a `NO_ACCOUNT_FALLBACK_MESSAGE` for resilience if the body is ever empty.
* **Never-provisioned and soft-deleted collapse to the same code.** Same practical UX outcome ("contact your administrator"); the distinction is preserved in server logs so support can tell offboarded from never-onboarded without grepping the users table. Easy to split into a second code (`ACCOUNT_REVOKED`) later if a client-visible distinction is wanted.
* **Non-`ErrNoData` lookup errors now 500.** Previously a DB connection blip during the user lookup was reported to the FE as 401, misclassifying server failures as auth problems and contributing to the misleading "session expired" UX. The FE now correctly falls through to `ServerErrorPage` for these.
* **CSRF check is semantically unchanged**, but now returns a structured JSON body with `FORBIDDEN_ORIGIN` so the FE can surface a defensive message rather than the generic 403 toast. Paired FE PR wires this to a `console.error` + permission toast.