### PR TITLE
Renumber seed datacalls chronologically

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -164,15 +164,19 @@ INSERT INTO public.pillars VALUES (5, 'CrossCutting', 0) ON CONFLICT DO NOTHING;
 INSERT INTO public.pillars VALUES (6, 'Identity', 0) ON CONFLICT DO NOTHING;
 
 -- Test DataCalls (Imperial Audits)
-INSERT INTO public.datacalls VALUES (1, 'FY2024 Imperial Security Review', '2024-01-01T00:00:00Z', '2024-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
-INSERT INTO public.datacalls VALUES (2, 'FY2025 Death Star Assessment', '2025-01-01T00:00:00Z', '2025-03-31T23:59:59Z') ON CONFLICT DO NOTHING;
+-- IDs are intentionally ordered chronologically so FindLatestDataCall
+-- (ORDER BY datacallid DESC) returns the open Audit cycle as current.
+INSERT INTO public.datacalls VALUES (1, 'FY2022 Imperial Security Review', '2022-01-01T00:00:00Z', '2022-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
+INSERT INTO public.datacalls VALUES (2, 'FY2023 Imperial Security Review', '2023-01-01T00:00:00Z', '2023-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
+INSERT INTO public.datacalls VALUES (3, 'FY2024 Imperial Security Review', '2024-01-01T00:00:00Z', '2024-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
+INSERT INTO public.datacalls VALUES (4, 'FY2025 Death Star Assessment', '2025-01-01T00:00:00Z', '2025-03-31T23:59:59Z') ON CONFLICT DO NOTHING;
 -- Future-deadline cycle used by audit-field smoke tests (ISSO writes need
 -- a non-expired datacall so validate() does not trip the deadline guard).
--- NOTE: backend/emberfall_tests.yml references datacallid=3 literally in
+-- NOTE: backend/emberfall_tests.yml references datacallid=5 literally in
 -- the audit-fields block; if you reorder or renumber this row, update the
--- four "datacallid: 3" references and the "?datacallid=3" query string
+-- "datacallid: 5" references and the "?datacallid=5" query string
 -- in that file in lockstep.
-INSERT INTO public.datacalls VALUES (3, 'Audit Fields Smoke Cycle', '2026-01-01T00:00:00Z', '2099-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
+INSERT INTO public.datacalls VALUES (5, 'Audit Fields Smoke Cycle', '2026-01-01T00:00:00Z', '2099-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
 
 -- Test FISMA Systems (Imperial Systems)
 -- Use explicit column names to work with initial schema
@@ -313,11 +317,16 @@ INSERT INTO public.users_fismasystems VALUES ('44444444-4444-4444-4444-444444444
 INSERT INTO public.users_fismasystems VALUES ('66666666-6666-6666-6666-666666666666', 1003) ON CONFLICT DO NOTHING; -- Emberfall ISSO -> Shield Gen (for system_enrichment access E2E tests)
 
 -- DataCall-System Assignments (Systems participating in audits)
-INSERT INTO public.datacalls_fismasystems VALUES (1, 1001) ON CONFLICT DO NOTHING; -- DS-1 in FY2024 review
-INSERT INTO public.datacalls_fismasystems VALUES (1, 1002) ON CONFLICT DO NOTHING; -- Executor in FY2024 review
-INSERT INTO public.datacalls_fismasystems VALUES (2, 1001) ON CONFLICT DO NOTHING; -- DS-1 in FY2025 assessment
-INSERT INTO public.datacalls_fismasystems VALUES (2, 1003) ON CONFLICT DO NOTHING; -- Shield Gen in FY2025 assessment
-INSERT INTO public.datacalls_fismasystems VALUES (2, 1002) ON CONFLICT DO NOTHING; -- Executor in FY2025 assessment
+INSERT INTO public.datacalls_fismasystems VALUES (3, 1001) ON CONFLICT DO NOTHING; -- DS-1 in FY2024 review
+INSERT INTO public.datacalls_fismasystems VALUES (3, 1002) ON CONFLICT DO NOTHING; -- Executor in FY2024 review
+INSERT INTO public.datacalls_fismasystems VALUES (4, 1001) ON CONFLICT DO NOTHING; -- DS-1 in FY2025 assessment
+INSERT INTO public.datacalls_fismasystems VALUES (4, 1003) ON CONFLICT DO NOTHING; -- Shield Gen in FY2025 assessment
+INSERT INTO public.datacalls_fismasystems VALUES (4, 1002) ON CONFLICT DO NOTHING; -- Executor in FY2025 assessment
+-- Enroll systems 1001-1003 in the open Audit cycle so Emberfall score tests
+-- (createScoreForAudit, issoCreateScoreOwnSystem) can write against datacall 5.
+INSERT INTO public.datacalls_fismasystems VALUES (5, 1001) ON CONFLICT DO NOTHING; -- DS-1 in Audit Smoke Cycle
+INSERT INTO public.datacalls_fismasystems VALUES (5, 1002) ON CONFLICT DO NOTHING; -- Executor in Audit Smoke Cycle
+INSERT INTO public.datacalls_fismasystems VALUES (5, 1003) ON CONFLICT DO NOTHING; -- Shield Gen in Audit Smoke Cycle
 
 -- Imperial Zero Trust Questionnaire (Full Coverage)
 
@@ -479,45 +488,45 @@ INSERT INTO public.functionoptions VALUES (69, 7018, 4, 'Advanced', 'Continuous 
 -- Comprehensive Test Scores across all Zero Trust pillars
 -- Scores reference functionoptionids: 1-23 (Imperial-Fleet), 24-46 (Space-Station), 47-69 (Forest-Moon)
 
--- Death Star System Scores (datacall 1) - Space-Station functionoptions
-INSERT INTO public.scores VALUES (9001, 1001, '2024-09-01 00:00:00+00', 'Death Star device tracking shows thermal exhaust port vulnerability', 25, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9002, 1001, '2024-09-01 00:00:00+00', 'Superlaser targeting applications have basic authentication', 28, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9003, 1001, '2024-09-01 00:00:00+00', 'Imperial communication networks use basic encryption', 32, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9004, 1001, '2024-09-01 00:00:00+00', 'Death Star plans stored on isolated systems', 36, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9005, 1001, '2024-09-01 00:00:00+00', 'Empire-wide policies standardized but manual enforcement', 40, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9006, 1001, '2024-09-01 00:00:00+00', 'Imperial officer credentials use biometric authentication', 44, 1) ON CONFLICT DO NOTHING;
+-- Death Star System Scores (datacall 3 / FY2024) - Space-Station functionoptions
+INSERT INTO public.scores VALUES (9001, 1001, '2024-09-01 00:00:00+00', 'Death Star device tracking shows thermal exhaust port vulnerability', 25, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9002, 1001, '2024-09-01 00:00:00+00', 'Superlaser targeting applications have basic authentication', 28, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9003, 1001, '2024-09-01 00:00:00+00', 'Imperial communication networks use basic encryption', 32, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9004, 1001, '2024-09-01 00:00:00+00', 'Death Star plans stored on isolated systems', 36, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9005, 1001, '2024-09-01 00:00:00+00', 'Empire-wide policies standardized but manual enforcement', 40, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9006, 1001, '2024-09-01 00:00:00+00', 'Imperial officer credentials use biometric authentication', 44, 3) ON CONFLICT DO NOTHING;
 
--- Executor System Scores (datacall 1) - Imperial-Fleet functionoptions
-INSERT INTO public.scores VALUES (9007, 1002, '2024-09-01 00:00:00+00', 'Star Destroyer inventory centrally tracked with automation', 2, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9008, 1002, '2024-09-01 00:00:00+00', 'Bridge applications use standardized access controls', 6, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9009, 1002, '2024-09-01 00:00:00+00', 'Fleet networks have dynamic security with real-time monitoring', 11, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9010, 1002, '2024-09-01 00:00:00+00', 'Tactical intelligence has automated data loss prevention', 15, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9011, 1002, '2024-09-01 00:00:00+00', 'Automated compliance monitoring across Executor systems', 18, 1) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9012, 1002, '2024-09-01 00:00:00+00', 'Centralized Imperial identity with Force-sensitivity screening', 22, 1) ON CONFLICT DO NOTHING;
+-- Executor System Scores (datacall 3 / FY2024) - Imperial-Fleet functionoptions
+INSERT INTO public.scores VALUES (9007, 1002, '2024-09-01 00:00:00+00', 'Star Destroyer inventory centrally tracked with automation', 2, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9008, 1002, '2024-09-01 00:00:00+00', 'Bridge applications use standardized access controls', 6, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9009, 1002, '2024-09-01 00:00:00+00', 'Fleet networks have dynamic security with real-time monitoring', 11, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9010, 1002, '2024-09-01 00:00:00+00', 'Tactical intelligence has automated data loss prevention', 15, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9011, 1002, '2024-09-01 00:00:00+00', 'Automated compliance monitoring across Executor systems', 18, 3) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9012, 1002, '2024-09-01 00:00:00+00', 'Centralized Imperial identity with Force-sensitivity screening', 22, 3) ON CONFLICT DO NOTHING;
 
--- Shield Generator System Scores (datacall 2) - Forest-Moon functionoptions
-INSERT INTO public.scores VALUES (9013, 1003, '2024-09-01 00:00:00+00', 'Real-time AT-ST monitoring with behavioral analysis', 49, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9014, 1003, '2024-09-01 00:00:00+00', 'Bunker applications have zero trust micro-segmentation', 54, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9015, 1003, '2024-09-01 00:00:00+00', 'Endor communications use software-defined networks', 58, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9016, 1003, '2024-09-01 00:00:00+00', 'Shield generator data has dynamic protection with analytics', 62, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9017, 1003, '2024-09-01 00:00:00+00', 'Continuous Imperial security posture with adaptive controls', 65, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9018, 1003, '2024-09-01 00:00:00+00', 'Continuous identity verification detects Ewok infiltration', 69, 2) ON CONFLICT DO NOTHING;
+-- Shield Generator System Scores (datacall 4 / FY2025) - Forest-Moon functionoptions
+INSERT INTO public.scores VALUES (9013, 1003, '2024-09-01 00:00:00+00', 'Real-time AT-ST monitoring with behavioral analysis', 49, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9014, 1003, '2024-09-01 00:00:00+00', 'Bunker applications have zero trust micro-segmentation', 54, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9015, 1003, '2024-09-01 00:00:00+00', 'Endor communications use software-defined networks', 58, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9016, 1003, '2024-09-01 00:00:00+00', 'Shield generator data has dynamic protection with analytics', 62, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9017, 1003, '2024-09-01 00:00:00+00', 'Continuous Imperial security posture with adaptive controls', 65, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9018, 1003, '2024-09-01 00:00:00+00', 'Continuous identity verification detects Ewok infiltration', 69, 4) ON CONFLICT DO NOTHING;
 
--- Executor System Scores (datacall 2) - Imperial-Fleet functionoptions
-INSERT INTO public.scores VALUES (9019, 1002, '2024-09-01 00:00:00+00', 'Enhanced Star Destroyer device security with predictive maintenance', 4, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9020, 1002, '2024-09-01 00:00:00+00', 'Advanced bridge applications with zero trust architecture', 8, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9021, 1002, '2024-09-01 00:00:00+00', 'Imperial fleet networks fully software-defined with zero trust', 12, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9022, 1002, '2024-09-01 00:00:00+00', 'Tactical intelligence with dynamic data protection and analytics', 16, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9023, 1002, '2024-09-01 00:00:00+00', 'Continuous adaptive Imperial security posture across all systems', 19, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9024, 1002, '2024-09-01 00:00:00+00', 'Advanced identity verification with continuous Force-sensitivity monitoring', 23, 2) ON CONFLICT DO NOTHING;
+-- Executor System Scores (datacall 4 / FY2025) - Imperial-Fleet functionoptions
+INSERT INTO public.scores VALUES (9019, 1002, '2024-09-01 00:00:00+00', 'Enhanced Star Destroyer device security with predictive maintenance', 4, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9020, 1002, '2024-09-01 00:00:00+00', 'Advanced bridge applications with zero trust architecture', 8, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9021, 1002, '2024-09-01 00:00:00+00', 'Imperial fleet networks fully software-defined with zero trust', 12, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9022, 1002, '2024-09-01 00:00:00+00', 'Tactical intelligence with dynamic data protection and analytics', 16, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9023, 1002, '2024-09-01 00:00:00+00', 'Continuous adaptive Imperial security posture across all systems', 19, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9024, 1002, '2024-09-01 00:00:00+00', 'Advanced identity verification with continuous Force-sensitivity monitoring', 23, 4) ON CONFLICT DO NOTHING;
 
--- Death Star System Scores (datacall 2) - Space-Station functionoptions
-INSERT INTO public.scores VALUES (9025, 1001, '2024-09-01 00:00:00+00', 'Death Star device security upgraded with automated threat detection', 26, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9026, 1001, '2024-09-01 00:00:00+00', 'Superlaser applications now use standardized access controls', 29, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9027, 1001, '2024-09-01 00:00:00+00', 'Imperial networks enhanced with dynamic security monitoring', 34, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9028, 1001, '2024-09-01 00:00:00+00', 'Death Star plans now have automated data loss prevention', 38, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9029, 1001, '2024-09-01 00:00:00+00', 'Automated compliance monitoring across Death Star systems', 41, 2) ON CONFLICT DO NOTHING;
-INSERT INTO public.scores VALUES (9030, 1001, '2024-09-01 00:00:00+00', 'Centralized Imperial identity with enhanced Force-sensitivity detection', 45, 2) ON CONFLICT DO NOTHING;
+-- Death Star System Scores (datacall 4 / FY2025) - Space-Station functionoptions
+INSERT INTO public.scores VALUES (9025, 1001, '2024-09-01 00:00:00+00', 'Death Star device security upgraded with automated threat detection', 26, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9026, 1001, '2024-09-01 00:00:00+00', 'Superlaser applications now use standardized access controls', 29, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9027, 1001, '2024-09-01 00:00:00+00', 'Imperial networks enhanced with dynamic security monitoring', 34, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9028, 1001, '2024-09-01 00:00:00+00', 'Death Star plans now have automated data loss prevention', 38, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9029, 1001, '2024-09-01 00:00:00+00', 'Automated compliance monitoring across Death Star systems', 41, 4) ON CONFLICT DO NOTHING;
+INSERT INTO public.scores VALUES (9030, 1001, '2024-09-01 00:00:00+00', 'Centralized Imperial identity with enhanced Force-sensitivity detection', 45, 4) ON CONFLICT DO NOTHING;
 
 -- IdM Scoring lookup table for identity enrichment tooltips
 INSERT INTO public.idm_scoring (idm_name, display_name, score, reasoning) VALUES
@@ -554,8 +563,8 @@ INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
 -- climbs over time, and three additional questionnaires (datacenterenvironments).
 --
 -- Everything below uses fresh ID ranges and NEW OpDivs only. It deliberately
--- does not touch systems 1001-1006, datacalls 1-3, or scores 9001-9030, which
--- the Emberfall E2E suite asserts against (aggregate on 1001, datacallid=3, the
+-- does not touch systems 1001-1006, datacalls 1-5, or scores 9001-9030, which
+-- the Emberfall E2E suite asserts against (aggregate on 1001, datacallid=5, the
 -- EMPIRE/REBELLION OpDiv-scoped read counts).
 -- ============================================================================
 
@@ -672,16 +681,14 @@ SELECT u.userid, s.fismasystemid
   JOIN public.fismasystems s ON s.fismasystemid = m.sysid
 ON CONFLICT DO NOTHING;
 
--- Historical data-call cycles. FY2024 (1) and FY2025 (2) already exist; add the
--- two prior fiscal years so the new systems have a 4-cycle maturity trend.
-INSERT INTO public.datacalls VALUES (4, 'FY2022 Imperial Security Review', '2022-01-01T00:00:00Z', '2022-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
-INSERT INTO public.datacalls VALUES (5, 'FY2023 Imperial Security Review', '2023-01-01T00:00:00Z', '2023-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
+-- Historical data-call cycles. FY2022 (1) and FY2023 (2) are declared in the
+-- header block above; FY2024 (3) and FY2025 (4) are also above. No new inserts
+-- needed here — just wire the new systems into all four closed cycles.
 
 -- Every new system participates in all four cycles (FY2022, FY2023, FY2024, FY2025).
 INSERT INTO public.datacalls_fismasystems (datacallid, fismasystemid)
 SELECT dc, s.fismasystemid
-  FROM generate_series(1, 1) g
-  CROSS JOIN (VALUES (4),(5),(1),(2)) AS d(dc)
+  FROM (VALUES (1),(2),(3),(4)) AS d(dc)
   JOIN public.fismasystems s ON s.fismasystemid BETWEEN 1101 AND 1110
 ON CONFLICT DO NOTHING;
 
@@ -754,10 +761,10 @@ BEGIN
         base_off := sys.off;
         FOR dc IN
             SELECT * FROM (VALUES
-                (4, 0, TIMESTAMPTZ '2022-09-01 00:00:00+00'),
-                (5, 1, TIMESTAMPTZ '2023-09-01 00:00:00+00'),
-                (1, 2, TIMESTAMPTZ '2024-09-01 00:00:00+00'),
-                (2, 3, TIMESTAMPTZ '2025-02-15 00:00:00+00')
+                (1, 0, TIMESTAMPTZ '2022-09-01 00:00:00+00'),
+                (2, 1, TIMESTAMPTZ '2023-09-01 00:00:00+00'),
+                (3, 2, TIMESTAMPTZ '2024-09-01 00:00:00+00'),
+                (4, 3, TIMESTAMPTZ '2025-02-15 00:00:00+00')
             ) AS d(datacallid, yr, dt)
         LOOP
             yr_index := dc.yr;

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -836,8 +836,8 @@ tests:
   # type. Anything that survives unit + integration but breaks at the
   # HTTP boundary still shows up here.
   #
-  # The DS-1 seed (fismasystemid=1001) has 24 score rows across datacalls
-  # 1 and 2 in _test_data_empire.sql, guaranteeing a non-empty response.
+  # The DS-1 seed (fismasystemid=1001) has 12 score rows across datacalls
+  # 3 and 4 in _test_data_empire.sql, guaranteeing a non-empty response.
 
   # 1. Scored system returns a populated aggregate via the full HTTP
   #    path. Regression target: 5xx anywhere in the new aggregation SQL,
@@ -881,15 +881,15 @@ tests:
   #
   # commonHeaders maps to test.user@nowhere.xyz (the OWNER fixture); the
   # ISSO scope block below uses Isso.User@nowhere.xyz via issoHeaders.
-  # Both saves target datacallid=3 ("Audit Fields Smoke Cycle"), seeded in
+  # Both saves target datacallid=5 ("Audit Fields Smoke Cycle"), seeded in
   # _test_data_empire.sql with deadline 2099-12-31 so validate() does not
   # trip the past-deadline guard on the ISSO path. (Admin bypasses the
   # guard, but routing both paths through the same fixture keeps the
   # regression honest if the admin bypass is ever tightened.)
   #
-  # The literal "datacallid: 3" appears in this block four times plus
+  # The literal "datacallid: 5" appears in this block and below plus
   # once in a query string. If you renumber the seed row, update all
-  # five references in lockstep -- see the NOTE at the seed INSERT in
+  # references in lockstep -- see the NOTE at the seed INSERT in
   # backend/_test_data_empire.sql.
   - id: createScoreForAudit
     url: http://localhost:8080/api/v1/scores
@@ -901,7 +901,7 @@ tests:
       json:
         fismasystemid: 1001
         functionoptionid: 1
-        datacallid: 3
+        datacallid: 5
         notes: "Audit field smoke - created by Emberfall"
     expect:
       status: 201
@@ -912,7 +912,7 @@ tests:
           data:
             fismasystemid: 1001
             functionoptionid: 1
-            datacallid: 3
+            datacallid: 5
             notes: "Audit field smoke - created by Emberfall"
             last_edited_by:
               email: "Test.User@nowhere.xyz"
@@ -922,7 +922,7 @@ tests:
   # response so no body.json assertion (aquia-inc/emberfall#36); status +
   # content-type are the regression target here. The POST above carries
   # the per-field audit assertion against the single-object response.
-  - url: "http://localhost:8080/api/v1/scores?fismasystemid=1001&datacallid=3"
+  - url: "http://localhost:8080/api/v1/scores?fismasystemid=1001&datacallid=5"
     method: GET
     headers:
       <<: *commonHeaders
@@ -943,7 +943,7 @@ tests:
       json:
         fismasystemid: 1001
         functionoptionid: 1
-        datacallid: 3
+        datacallid: 5
         notes: "Audit field smoke - updated by Emberfall"
     expect:
       status: 204
@@ -979,7 +979,7 @@ tests:
       json:
         fismasystemid: 1003
         functionoptionid: 1
-        datacallid: 3
+        datacallid: 5
         notes: "ISSO audit smoke - own system"
     expect:
       status: 201
@@ -1008,7 +1008,7 @@ tests:
       json:
         fismasystemid: 1001
         functionoptionid: 1
-        datacallid: 3
+        datacallid: 5
         notes: "ISSO write to unassigned system - should be blocked"
     expect:
       status: 403
@@ -1263,7 +1263,7 @@ tests:
         fismasystemid: 1002
         functionoptionid: 1
         notes: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        datacallid: 1
+        datacallid: 5
     expect:
       status: 400
 
@@ -1278,7 +1278,7 @@ tests:
         fismasystemid: 1
         functionoptionid: 1
         notes: "should be blocked"
-        datacallid: 1
+        datacallid: 5
     expect:
       status: 403
 
@@ -1600,13 +1600,14 @@ tests:
       json:
         fismasystemid: 1006
         functionoptionid: 1
-        datacallid: 3
+        datacallid: 5
         notes: "cross-OpDiv score attempt - must be blocked"
     expect:
       status: 403
 
   # OPDIV_ADMIN gets 403 marking an out-of-scope REBELLION system (1006) complete.
-  - url: http://localhost:8080/api/v1/datacalls/2/fismasystems/1006
+  # datacallid=4 (FY2025) is a literal; if datacalls are renumbered, update here too.
+  - url: http://localhost:8080/api/v1/datacalls/4/fismasystems/1006
     method: PUT
     headers:
       <<: *opDivAdminHeaders
@@ -1694,7 +1695,7 @@ tests:
       json:
         fismasystemid: 1002
         functionoptionid: 1
-        datacallid: 3
+        datacallid: 5
         notes: "readonly write attempt - must be blocked"
     expect:
       status: 403

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -357,7 +357,7 @@ func boolPtr(b bool) *bool { return &b }
 // sweep cleans it up) if none exists in seed data. Shared by the audit
 // field tests below so each one does not redo the discovery dance.
 //
-// In the default empire seed this resolves to datacallid=3 ("Audit
+// In the default empire seed this resolves to datacallid=5 ("Audit
 // Fields Smoke Cycle", deadline 2099-12-31), which is also the cycle
 // the emberfall audit-fields block writes to. That is intentional
 // reuse, not a fixture collision: scores written by these integration
@@ -543,7 +543,7 @@ func TestFindScoresIncludesAuditFieldsIntegration(t *testing.T) {
 // when nothing has been edited in the current session.
 //
 // The fixture is the expanded empire seed: system 1110 (Tarkin Initiative
-// Superweapon R&D), scored in datacall 2 (FY2025) with one seeded "updated"
+// Superweapon R&D), scored in datacall 2 (FY2023) with one seeded "updated"
 // event per score attributed to its assigned officer, Bevel Lemelisk. If the
 // seed audit events go missing or the join regresses, last_edited_by silently
 // returns to blank in the UI and this test fails.
@@ -560,7 +560,7 @@ func TestFindScoresResolvesSeededAuditFieldsIntegration(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Tarkin Initiative R&D system and the FY2025 cycle, both from the seed.
+	// Tarkin Initiative R&D system and the FY2023 cycle, both from the seed.
 	fismaSystemID := int32(1110)
 	dataCallID := int32(2)
 
@@ -570,7 +570,7 @@ func TestFindScoresResolvesSeededAuditFieldsIntegration(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, scores,
-		"expanded empire seed must score system 1110 in datacall 2 (FY2025)")
+		"expanded empire seed must score system 1110 in datacall 2 (FY2023)")
 
 	// Every seeded score for this system+cycle carries an event attributed to
 	// the system's assigned officer, so each row must resolve the same editor.


### PR DESCRIPTION
In-repo version of #363 by @costacalvin, moved onto a CMS-Enterprise branch so the org-secret CI gates (Snyk, Infrastructure/Deploy) can run — they cannot on a fork PR. Commits are pushed unchanged; authorship is preserved.

Refs #363

## Problem

`FindLatestDataCall` sorts by `datacallid DESC` to find the active cycle. The seed data inserted FY2022 (id=4) and FY2023 (id=5) after the initial three rows, giving them higher IDs than FY2024 (id=1) and the Audit cycle (id=3). As a result, FY2023 was returned as the current datacall instead of "Audit Fields Smoke Cycle".

## Solution

Renumber the seed datacalls in chronological order (FY2022=1, FY2023=2, FY2024=3, FY2025=4, Audit=5) so the highest ID is always the most recent cycle. No Go model changes.

## Changes

**`backend/_test_data_empire.sql`**
- Reorder datacall inserts 1–5 chronologically; Audit Smoke Cycle gets id=5 (highest → returned as current)
- Update `datacalls_fismasystems` enrollment rows to match new IDs
- Add enrollment rows for datacall 5 (systems 1001–1003) so Emberfall score tests can write against the open Audit cycle
- Update the 30 score rows referencing old ids 1→3 and 2→4
- Remove now-duplicate FY2022/FY2023 inserts from the expanded section; fix the PL/pgSQL historical score loop and the cross-join to use the correct ids; remove dead `generate_series(1,1)` fragment

**`backend/emberfall_tests.yml`**
- Update all 10 literal datacall ID references: audit-field and RBAC tests → datacallid=5; `datacalls/2/fismasystems/1006` URL → `datacalls/4/fismasystems/1006`; notes-length and HHS_READONLY_ADMIN 403 tests → datacallid=5
- Update inline comments to match

**`backend/internal/model/scores_integration_test.go`**
- Comment-only fixes: `datacallid=3` → `datacallid=5` in `ensureFutureDataCall` doc; `FY2025` → `FY2023` where datacall 2 is referenced

## Test plan
- [x] `make test-integration` — `ok github.com/CMS-Enterprise/ztmf/backend/internal/model`
- [x] `make test-e2e` (Emberfall) — `Ran: 118, Failed: 0, Skipped: 0`
- [x] reseeded DB and verified correct ordering on the frontend UI / backend DB

Closes #364
