### PR TITLE
create batch grant opdivs endpoint

### DIFF
--- a/backend/cmd/api/internal/controller/usersopdivs.go
+++ b/backend/cmd/api/internal/controller/usersopdivs.go
@@ -128,6 +128,102 @@ func CreateUserOpDiv(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, saved, err)
 }
 
+type setUserOpDivsInput struct {
+	OpDivIDs []int32 `json:"opdiv_ids"`
+}
+
+// SetUserOpDivs replaces a user's full OpDiv grant set in one batch. The desired
+// set is reconciled against current grants (adds missing, removes extra) in one
+// transaction, and identity_provider is re-derived once at the end. An
+// OPDIV_ADMIN may only include OpDivs they hold; grants outside their scope are
+// left unchanged.
+//
+//	@Summary	Set a user's OpDiv grants (batch replace)
+//	@Tags		users
+//	@Accept		json
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		userid	path	string				true	"User ID"
+//	@Param		body	body	setUserOpDivsInput	true	"Desired grant set"
+//	@Success	204	"No Content"
+//	@Failure	400	{object}	apiResponse[any]
+//	@Failure	403	{object}	apiResponse[any]
+//	@Failure	404	{object}	apiResponse[any]
+//	@Failure	500	{object}	apiResponse[any]
+//	@Router		/users/{userid}/opdivs [put]
+func SetUserOpDivs(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.IsAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	userID, ok := mux.Vars(r)["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	var input setUserOpDivsInput
+	if err := getJSON(r.Body, &input); err != nil {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+
+	// Scope gate: OPDIV_ADMIN may only request OpDivs they hold. Pure memory
+	// check — runs before the tier-ceiling DB call to short-circuit early.
+	if !authdUser.HasUnscopedRead() {
+		for _, id := range input.OpDivIDs {
+			if !authdUser.IsAssignedOpDiv(id) {
+				respond(w, r, nil, ErrForbidden)
+				return
+			}
+		}
+	}
+
+	// Tier ceiling: cannot manage a higher-tier user.
+	target, err := model.FindUserByID(r.Context(), userID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+	if !authdUser.CanAssignRole(target.Role) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	current, err := model.FindUserOpDivsByUserID(r.Context(), userID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	desiredSet := make(map[int32]bool, len(input.OpDivIDs))
+	for _, id := range input.OpDivIDs {
+		desiredSet[id] = true
+	}
+	currentSet := make(map[int32]bool, len(current))
+	for _, id := range current {
+		currentSet[id] = true
+	}
+
+	var toAdd, toRemove []int32
+	for _, id := range input.OpDivIDs {
+		if !currentSet[id] {
+			toAdd = append(toAdd, id)
+		}
+	}
+	for _, id := range current {
+		if !desiredSet[id] && (authdUser.HasUnscopedRead() || authdUser.IsAssignedOpDiv(id)) {
+			toRemove = append(toRemove, id)
+		}
+	}
+
+	err = model.SetUserOpDivs(r.Context(), userID, toAdd, toRemove, &authdUser.UserID)
+	respond(w, r, nil, err)
+}
+
 // DeleteUserOpDiv revokes a user's OpDiv grant. Same scope as granting: an
 // OPDIV_ADMIN may only revoke an OpDiv they hold.
 //	@Summary	Revoke a user's OpDiv grant

--- a/backend/cmd/api/internal/controller/usersopdivs.go
+++ b/backend/cmd/api/internal/controller/usersopdivs.go
@@ -123,13 +123,20 @@ func CreateUserOpDiv(w http.ResponseWriter, r *http.Request) {
 		respond(w, r, nil, ErrForbidden)
 		return
 	}
+	// Shared-OpDiv check: an OPDIV_ADMIN may only act on users who already share
+	// one of their OpDivs. A user with no grants is not yet in any scope, so
+	// an OPDIV_ADMIN granting their own OpDiv is the intended onboarding path.
+	if !authdUser.HasUnscopedRead() && len(target.AssignedOpDivIDs) > 0 && !sharesOpDiv(authdUser, target) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
 
 	saved, err := uo.Save(r.Context())
 	respond(w, r, saved, err)
 }
 
 type setUserOpDivsInput struct {
-	OpDivIDs []int32 `json:"opdiv_ids"`
+	OpDivIDs *[]int32 `json:"opdiv_ids"`
 }
 
 // SetUserOpDivs replaces a user's full OpDiv grant set in one batch. The desired
@@ -170,11 +177,19 @@ func SetUserOpDivs(w http.ResponseWriter, r *http.Request) {
 		respond(w, r, nil, ErrMalformed)
 		return
 	}
+	// A missing opdiv_ids key and an explicit [] both would otherwise deserialize
+	// identically. Require the field to be present so a serialization bug cannot
+	// silently clear all grants; an intentional clear must send an explicit [].
+	if input.OpDivIDs == nil {
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+	opdivIDs := *input.OpDivIDs
 
 	// Scope gate: OPDIV_ADMIN may only request OpDivs they hold. Pure memory
 	// check — runs before the tier-ceiling DB call to short-circuit early.
 	if !authdUser.HasUnscopedRead() {
-		for _, id := range input.OpDivIDs {
+		for _, id := range opdivIDs {
 			if !authdUser.IsAssignedOpDiv(id) {
 				respond(w, r, nil, ErrForbidden)
 				return
@@ -192,6 +207,13 @@ func SetUserOpDivs(w http.ResponseWriter, r *http.Request) {
 		respond(w, r, nil, ErrForbidden)
 		return
 	}
+	// Shared-OpDiv check: an OPDIV_ADMIN may only act on users who already share
+	// one of their OpDivs. A user with no grants is not yet in any scope, so
+	// an OPDIV_ADMIN granting their own OpDiv is the intended onboarding path.
+	if !authdUser.HasUnscopedRead() && len(target.AssignedOpDivIDs) > 0 && !sharesOpDiv(authdUser, target) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
 
 	current, err := model.FindUserOpDivsByUserID(r.Context(), userID)
 	if err != nil {
@@ -199,8 +221,8 @@ func SetUserOpDivs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	desiredSet := make(map[int32]bool, len(input.OpDivIDs))
-	for _, id := range input.OpDivIDs {
+	desiredSet := make(map[int32]bool, len(opdivIDs))
+	for _, id := range opdivIDs {
 		desiredSet[id] = true
 	}
 	currentSet := make(map[int32]bool, len(current))
@@ -209,8 +231,11 @@ func SetUserOpDivs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var toAdd, toRemove []int32
-	for _, id := range input.OpDivIDs {
-		if !currentSet[id] {
+	// Scope-guard toAdd locally as defense-in-depth: even though the scope gate
+	// above already validates every requested ID, mirror the check here so the
+	// invariant holds if the gate above is ever relaxed.
+	for _, id := range opdivIDs {
+		if !currentSet[id] && (authdUser.HasUnscopedRead() || authdUser.IsAssignedOpDiv(id)) {
 			toAdd = append(toAdd, id)
 		}
 	}
@@ -264,6 +289,25 @@ func DeleteUserOpDiv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := uo.Delete(r.Context())
+	// Tier ceiling + shared-OpDiv check: mirror the same gates as the other
+	// single-grant handler (CreateUserOpDiv) so all three mutation paths are
+	// consistently scoped.
+	target, err := model.FindUserByID(r.Context(), uo.UserID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+	if !authdUser.CanAssignRole(target.Role) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+	// A user with no grants is not yet in any scope; allow the revoke to
+	// proceed (edge case: all grants already removed by another admin).
+	if !authdUser.HasUnscopedRead() && len(target.AssignedOpDivIDs) > 0 && !sharesOpDiv(authdUser, target) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	err = uo.Delete(r.Context())
 	respond(w, r, "", err)
 }

--- a/backend/cmd/api/internal/controller/usersopdivs_test.go
+++ b/backend/cmd/api/internal/controller/usersopdivs_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
@@ -11,6 +12,55 @@ import (
 )
 
 const grantUserID = "11111111-1111-4111-8111-111111111111"
+
+// SetUserOpDivs forbidden paths are reached before any DB call: a non-admin is
+// rejected by the tier gate, and an OPDIV_ADMIN requesting an out-of-scope OpDiv
+// is rejected by the in-memory scope check.
+func TestSetUserOpDivs_Forbidden(t *testing.T) {
+	t.Run("non-admin tier is forbidden", func(t *testing.T) {
+		r := withUser(httptest.NewRequest("PUT", "/api/v1/users/"+grantUserID+"/opdivs",
+			jsonBody(t, map[string]any{"opdiv_ids": []int{3}})), &model.User{Role: "ISSO"})
+		r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+		w := httptest.NewRecorder()
+		SetUserOpDivs(w, r)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("OPDIV_ADMIN cannot request an OpDiv they do not hold", func(t *testing.T) {
+		opdiv2 := int32(2)
+		actor := &model.User{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{&opdiv2}}
+		r := withUser(httptest.NewRequest("PUT", "/api/v1/users/"+grantUserID+"/opdivs",
+			jsonBody(t, map[string]any{"opdiv_ids": []int{99}})), actor)
+		r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+		w := httptest.NewRecorder()
+		SetUserOpDivs(w, r)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+}
+
+// SetUserOpDivs returns 400 for a malformed request body before touching the DB.
+func TestSetUserOpDivs_MalformedBody(t *testing.T) {
+	r := withUser(httptest.NewRequest("PUT", "/api/v1/users/"+grantUserID+"/opdivs",
+		strings.NewReader("not-json")), &model.User{Role: "HHS_ADMIN"})
+	r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+	w := httptest.NewRecorder()
+	SetUserOpDivs(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// An OPDIV_ADMIN requesting only their own OpDivs clears the scope gate. The
+// handler proceeds to the tier-ceiling DB lookup (no test DB) and returns 500
+// — crucially NOT 403, which would mean the gate incorrectly blocked them.
+func TestSetUserOpDivs_OpDivAdminInScopePassesGate(t *testing.T) {
+	opdiv5 := int32(5)
+	actor := &model.User{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{&opdiv5}}
+	r := withUser(httptest.NewRequest("PUT", "/api/v1/users/"+grantUserID+"/opdivs",
+		jsonBody(t, map[string]any{"opdiv_ids": []int{5}})), actor)
+	r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+	w := httptest.NewRecorder()
+	SetUserOpDivs(w, r)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}
 
 // CreateUserOpDiv's forbidden paths are reached before any DB call: a non-admin
 // is rejected by the tier gate, and an OPDIV_ADMIN granting an OpDiv they do not

--- a/backend/cmd/api/internal/controller/usersopdivs_test.go
+++ b/backend/cmd/api/internal/controller/usersopdivs_test.go
@@ -62,6 +62,44 @@ func TestSetUserOpDivs_OpDivAdminInScopePassesGate(t *testing.T) {
 	assert.NotEqual(t, http.StatusForbidden, w.Code)
 }
 
+// A missing opdiv_ids key returns 400 — the field is required so a serialization
+// bug that drops it cannot silently clear all grants.
+func TestSetUserOpDivs_MissingOpDivIDs(t *testing.T) {
+	r := withUser(httptest.NewRequest("PUT", "/api/v1/users/"+grantUserID+"/opdivs",
+		jsonBody(t, map[string]any{})), &model.User{Role: "HHS_ADMIN"})
+	r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+	w := httptest.NewRecorder()
+	SetUserOpDivs(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// An explicit empty slice is a valid "clear all in-scope grants" request; it
+// must pass the nil check and not be rejected as malformed.
+func TestSetUserOpDivs_ExplicitEmptySlicePassesNilCheck(t *testing.T) {
+	r := withUser(httptest.NewRequest("PUT", "/api/v1/users/"+grantUserID+"/opdivs",
+		jsonBody(t, map[string]any{"opdiv_ids": []int{}})), &model.User{Role: "HHS_ADMIN"})
+	r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+	w := httptest.NewRecorder()
+	SetUserOpDivs(w, r)
+	assert.NotEqual(t, http.StatusBadRequest, w.Code)
+}
+
+// SetUserOpDivs must not block an OPDIV_ADMIN from granting their own OpDiv to a
+// brand-new user who has no existing grants (bootstrap onboarding path).
+// The handler cannot reach the shared-OpDiv check without a DB (FindUserByID),
+// so this test verifies the scope gate still passes — the response is 500 (no DB),
+// NOT 403 from a shared-OpDiv rejection.
+func TestSetUserOpDivs_OpDivAdminNewUserBootstrap(t *testing.T) {
+	opdiv5 := int32(5)
+	actor := &model.User{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{&opdiv5}}
+	r := withUser(httptest.NewRequest("PUT", "/api/v1/users/"+grantUserID+"/opdivs",
+		jsonBody(t, map[string]any{"opdiv_ids": []int{5}})), actor)
+	r = mux.SetURLVars(r, map[string]string{"userid": grantUserID})
+	w := httptest.NewRecorder()
+	SetUserOpDivs(w, r)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}
+
 // CreateUserOpDiv's forbidden paths are reached before any DB call: a non-admin
 // is rejected by the tier gate, and an OPDIV_ADMIN granting an OpDiv they do not
 // hold is rejected by the in-memory scope check.

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -79,6 +79,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedopdivs", controller.ListUserOpDivs).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedopdivs", controller.CreateUserOpDiv).Methods("POST")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedopdivs/{opdiv_id:[0-9]+}", controller.DeleteUserOpDiv).Methods("DELETE")
+	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/opdivs", controller.SetUserOpDivs).Methods("PUT")
 
 	router.HandleFunc("/api/v1/scores", controller.ListScores).Methods("GET")
 	router.HandleFunc("/api/v1/scores/aggregate", controller.GetScoresAggregate).Methods("GET") // yes "aggregate" is a noun

--- a/backend/internal/model/usersopdivs.go
+++ b/backend/internal/model/usersopdivs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 	"github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
 )
@@ -89,6 +90,66 @@ func FindUserOpDivsByUserID(ctx context.Context, userID string) ([]int32, error)
 		OrderBy("opdiv_id")
 
 	return query(ctx, sqlb, pgx.RowTo[int32])
+}
+
+// SetUserOpDivs reconciles a user's OpDiv grants against the desired set in one
+// transaction: removes grants in toRemove, adds grants in toAdd, then re-derives
+// identity_provider once. toAdd and toRemove are pre-computed by the controller,
+// which enforces scope (an OPDIV_ADMIN can only touch OpDivs they hold).
+func SetUserOpDivs(ctx context.Context, userID string, toAdd, toRemove []int32, grantedBy *string) error {
+	if !isValidUUID(userID) {
+		return &InvalidInputError{data: map[string]any{"userid": "uuid required"}}
+	}
+
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		return nil
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return trapError(err)
+	}
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		conn.Release()
+		return trapError(err)
+	}
+	defer func() {
+		tx.Rollback(ctx)
+		conn.Release()
+	}()
+
+	if len(toRemove) > 0 {
+		if _, err = tx.Exec(ctx,
+			"DELETE FROM users_opdivs WHERE userid=$1 AND opdiv_id = ANY($2)",
+			userID, toRemove,
+		); err != nil {
+			return trapError(err)
+		}
+	}
+
+	if len(toAdd) > 0 {
+		sqlb := stmntBuilder.
+			Insert("users_opdivs").
+			Columns("userid", "opdiv_id", "granted_by")
+		for _, id := range toAdd {
+			sqlb = sqlb.Values(userID, id, grantedBy)
+		}
+		sqlb = sqlb.Suffix("ON CONFLICT (userid, opdiv_id) DO NOTHING")
+		q, args, err := sqlb.ToSql()
+		if err != nil {
+			return trapError(err)
+		}
+		if _, err = tx.Exec(ctx, q, args...); err != nil {
+			return trapError(err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return trapError(err)
+	}
+
+	return deriveIdentityProvider(ctx, userID)
 }
 
 // deriveIdentityProvider sets a user's identity_provider from their OpDiv


### PR DESCRIPTION
## Summary

Closes #345. Paired with ztmf-ui#437 (frontend switches `OpDivGrantModal` to use this endpoint).

Adds `PUT /api/v1/users/{userid}/opdivs` — a batch endpoint that sets a user's full OpDiv grant set in one transaction, replacing the N per-item POST/DELETE calls previously required by the frontend.

- **Controller** (`controller/usersopdivs.go`): adds `SetUserOpDivs` with a two-stage authorization check — scope gate first (pure memory, short-circuits before any DB call), then tier-ceiling check via `FindUserByID`. Reconciles desired vs current grants into `toAdd`/`toRemove` slices; OPDIV_ADMIN's `toRemove` is further filtered to only grants within their scope so out-of-scope grants are left untouched.
- **Model** (`internal/model/usersopdivs.go`): adds `SetUserOpDivs` which executes DELETE then INSERT in a single pgx transaction on a dedicated pinned connection (`db.Conn`), then calls `deriveIdentityProvider` once after commit. `ON CONFLICT DO NOTHING` on INSERT makes the add step idempotent.
- **Router** (`router/router.go`): registers `PUT /api/v1/users/{userid}/opdivs` → `SetUserOpDivs`.
- **Tests** (`controller/usersopdivs_test.go`): adds four cases — non-admin tier forbidden, OPDIV_ADMIN out-of-scope forbidden, malformed body returns 400, OPDIV_ADMIN in-scope passes the gate (500 from no test DB, not 403).

## Acceptance criteria

- [x] `PUT /api/v1/users/{userid}/opdivs` accepts `{ "opdiv_ids": [1, 2, 3] }` and reconciles grants in one transaction
- [x] Returns 204 on success
- [x] Non-admin roles receive 403
- [x] OPDIV_ADMIN receives 403 if any requested ID is outside their own grants
- [x] OPDIV_ADMIN cannot remove grants outside their scope (left unchanged)
- [x] `identity_provider` is re-derived exactly once after the transaction commits
- [x] Sending an empty array clears all in-scope grants

## Test plan

- [ ] `PUT /opdivs` with a valid admin token and a subset of OpDiv IDs → 204, grants updated
- [ ] Same request as OPDIV_ADMIN with only their own OpDiv IDs → 204
- [ ] Same request as OPDIV_ADMIN with an OpDiv they don't hold → 403
- [ ] Non-admin token → 403
- [ ] Malformed body → 400
- [ ] Send empty `opdiv_ids: []` → 204, all in-scope grants removed
- [ ] Verify `identity_provider` on the user reflects the new grant set after the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)