### PR TITLE
ci: add Manual Deploy to DEV workflow

### DIFF
--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -1,0 +1,40 @@
+name: Manual Deploy to DEV
+
+# Deploy main to DEV on demand. API/app only by default; Terraform apply is opt-in.
+#   - orchestration-dev (open/sync a PR): preview a feature branch on DEV.
+#   - this workflow: (re)deploy main to DEV, e.g. to reset DEV after branch deploys.
+# Always redeploys (skips the diff gate). Run:
+#   gh workflow run "Manual Deploy to DEV" --ref main [-f include_infrastructure=true]
+on:
+  workflow_dispatch:
+    inputs:
+      include_infrastructure:
+        description: 'Also run the Terraform infrastructure apply against DEV'
+        type: boolean
+        default: false
+
+jobs:
+  analysis:
+    name: Analysis
+    uses: ./.github/workflows/analysis.yml
+    secrets: inherit
+
+  backend:
+    name: Backend
+    needs:
+      - analysis
+    uses: ./.github/workflows/backend.yml
+    with:
+      environment: DEV
+    secrets: inherit
+
+  infrastructure:
+    name: Infrastructure
+    needs:
+      - analysis
+      - backend
+    if: ${{ inputs.include_infrastructure }}
+    uses: ./.github/workflows/infrastructure.yml
+    with:
+      environment: DEV
+    secrets: inherit


### PR DESCRIPTION
## What

Adds a `Manual Deploy to DEV` workflow (`workflow_dispatch`) so the current `main` can be published to the DEV environment on demand.

## Why

DEV only deploys via `orchestration-dev`, which triggers on `pull_request` to `main` and builds the **PR's head branch** — so `main` itself is never auto-deployed to DEV, and DEV ends up reflecting whichever PR last synced rather than the merged baseline. This adds a way to reset/redeploy DEV to `main` without opening a throwaway PR.

## How

Run from the Actions tab, or:

```
gh workflow run "Manual Deploy to DEV" --ref main
gh workflow run "Manual Deploy to DEV" --ref main -f include_infrastructure=true
```

It reuses the existing reusable workflows (no deploy logic is duplicated): Analysis → Backend, and optionally Infrastructure.

Two intentional differences from `orchestration-dev`:

- **Skips the `diff` change-detection gate** and always redeploys the backend. A manual reset republishes `main` regardless of what changed since `origin/main` (the diff would be empty on a main→DEV run and would otherwise skip the deploy).
- **Infrastructure (Terraform apply) is opt-in**, off by default, via the `include_infrastructure` input. The common case is an API/app-only reset; flip the input when you also want the Terraform apply against DEV.

The existing PR-triggered DEV behavior is unchanged — this is purely additive.

## Note

`workflow_dispatch` is only registered once the workflow file is on the default branch, so this has to merge before the manual trigger becomes available.
