### PR TITLE
ci: always run the rollout in Manual Deploy to DEV

### DIFF
--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -1,17 +1,15 @@
 name: Manual Deploy to DEV
 
-# Deploy main to DEV on demand. API/app only by default; Terraform apply is opt-in.
+# Deploy main to DEV on demand.
 #   - orchestration-dev (open/sync a PR): preview a feature branch on DEV.
 #   - this workflow: (re)deploy main to DEV, e.g. to reset DEV after branch deploys.
-# Always redeploys (skips the diff gate). Run:
-#   gh workflow run "Manual Deploy to DEV" --ref main [-f include_infrastructure=true]
+# The rollout IS the terraform apply (backend.yml only builds/pushes the image;
+# ecs.tf reads the tag from the ztmf_api_tag SSM param), so infrastructure always runs.
+# Caveat: re-running on an unchanged main SHA fails the immutable ECR tag push —
+# land a commit first so the build gets a new tag.
+# Run: gh workflow run "Manual Deploy to DEV" --ref main
 on:
   workflow_dispatch:
-    inputs:
-      include_infrastructure:
-        description: 'Also run the Terraform infrastructure apply against DEV'
-        type: boolean
-        default: false
 
 jobs:
   analysis:
@@ -33,7 +31,6 @@ jobs:
     needs:
       - analysis
       - backend
-    if: ${{ inputs.include_infrastructure }}
     uses: ./.github/workflows/infrastructure.yml
     with:
       environment: DEV


### PR DESCRIPTION
## What

Fixes the `Manual Deploy to DEV` workflow so it always performs the rollout. Removes the `include_infrastructure` input and runs the Infrastructure job unconditionally.

## Why

`backend.yml` only builds, smoke-tests, and pushes the image to ECR — it does **not** deploy it. The actual rollout is the `terraform apply` in `infrastructure.yml` (`ecs.tf` reads the image tag from the `ztmf_api_tag` SSM parameter). The previous `include_infrastructure: false` default therefore built an image without ever deploying it — a no-op for a "deploy to dev" action. Making the apply optional/off-by-default was a mistake; it is the rollout.

## Notes

- Known limitation (separate fix): re-running the manual deploy on an unchanged `main` SHA fails on the immutable ECR tag push in `backend.yml`. A future change should make that push idempotent (skip when the tag already exists) so the run falls through to the rollout.
- Opening this PR also exercises the standard dev pipeline: the `diff` gate sees no `backend/` change, so the build is skipped and Infrastructure rolls out the current API image already in ECR to dev.
