### PR TITLE
Tarratsco/bugfix/prevent admin self deletion

### DIFF
--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -22,6 +22,7 @@ const (
 	CodeUnauthorized          = "UNAUTHORIZED"
 	CodeForbiddenOrigin       = "FORBIDDEN_ORIGIN"
 	CodeAccountNotProvisioned = "ACCOUNT_NOT_PROVISIONED"
+	CodeSelfDeleteForbidden = "SELF_DELETE_FORBIDDEN"
 )
 
 // Package-level seams over the model lookups so tests can stub them without a
@@ -39,10 +40,10 @@ type errorBody struct {
 	Code  string `json:"code,omitempty"`
 }
 
-// writeJSONError writes a standardized JSON error response and is the only
+// WriteJSONError writes a standardized JSON error response and is the only
 // rejection surface used by Middleware. Centralizing the shape keeps the FE
 // interceptor's contract single-sourced.
-func writeJSONError(w http.ResponseWriter, status int, msg, code string) {
+func WriteJSONError(w http.ResponseWriter, status int, msg, code string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(status)
@@ -70,7 +71,7 @@ func Middleware(next http.Handler) http.Handler {
 
 		claims, isSession, ok := claimsFromRequest(r)
 		if !ok {
-			writeJSONError(w, http.StatusUnauthorized,
+			WriteJSONError(w, http.StatusUnauthorized,
 				"Your session has expired. Please sign in again.",
 				CodeUnauthorized)
 			return
@@ -82,7 +83,7 @@ func Middleware(next http.Handler) http.Handler {
 		// cookie path is browser-driven; the bearer path is for API clients and
 		// is not subject to CSRF.
 		if isSession && !isSafeMethod(r.Method) && !sameOrigin(r) {
-			writeJSONError(w, http.StatusForbidden,
+			WriteJSONError(w, http.StatusForbidden,
 				"Request blocked: origin not allowed.",
 				CodeForbiddenOrigin)
 			return
@@ -120,7 +121,7 @@ func Middleware(next http.Handler) http.Handler {
 			user, err = user.Save(r.Context())
 			if err != nil {
 				log.Printf("Failed to auto-create user: %s\n", err)
-				writeJSONError(w, http.StatusInternalServerError,
+				WriteJSONError(w, http.StatusInternalServerError,
 					"internal error", "")
 				return
 			}
@@ -131,7 +132,7 @@ func Middleware(next http.Handler) http.Handler {
 			// this code to render a terminal "contact your administrator"
 			// message instead of looping the user back through the IdP.
 			log.Printf("authenticated identity has no ZTMF account: %s\n", IdentifierFromClaims(claims))
-			writeJSONError(w, http.StatusForbidden,
+			WriteJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is not set up. Contact your administrator to request access.",
 				CodeAccountNotProvisioned)
 			return
@@ -139,7 +140,7 @@ func Middleware(next http.Handler) http.Handler {
 			// DB connection blip, decode failure, etc. Not a credential
 			// problem, so do not present as one to the FE.
 			log.Printf("user lookup failed: %s\n", err)
-			writeJSONError(w, http.StatusInternalServerError,
+			WriteJSONError(w, http.StatusInternalServerError,
 				"internal error", "")
 			return
 		}
@@ -150,7 +151,7 @@ func Middleware(next http.Handler) http.Handler {
 			// distinctly so support can tell "offboarded" from "never
 			// onboarded" without grepping the users table.
 			log.Printf("deleted user attempted to access the API: %s\n", user.Email)
-			writeJSONError(w, http.StatusForbidden,
+			WriteJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is no longer active. Contact your administrator.",
 				CodeAccountNotProvisioned)
 			return

--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -40,10 +40,10 @@ type errorBody struct {
 	Code  string `json:"code,omitempty"`
 }
 
-// WriteJSONError writes a standardized JSON error response and is the only
+// writeJSONError writes a standardized JSON error response and is the only
 // rejection surface used by Middleware. Centralizing the shape keeps the FE
 // interceptor's contract single-sourced.
-func WriteJSONError(w http.ResponseWriter, status int, msg, code string) {
+func writeJSONError(w http.ResponseWriter, status int, msg, code string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(status)
@@ -71,7 +71,7 @@ func Middleware(next http.Handler) http.Handler {
 
 		claims, isSession, ok := claimsFromRequest(r)
 		if !ok {
-			WriteJSONError(w, http.StatusUnauthorized,
+			writeJSONError(w, http.StatusUnauthorized,
 				"Your session has expired. Please sign in again.",
 				CodeUnauthorized)
 			return
@@ -83,7 +83,7 @@ func Middleware(next http.Handler) http.Handler {
 		// cookie path is browser-driven; the bearer path is for API clients and
 		// is not subject to CSRF.
 		if isSession && !isSafeMethod(r.Method) && !sameOrigin(r) {
-			WriteJSONError(w, http.StatusForbidden,
+			writeJSONError(w, http.StatusForbidden,
 				"Request blocked: origin not allowed.",
 				CodeForbiddenOrigin)
 			return
@@ -121,7 +121,7 @@ func Middleware(next http.Handler) http.Handler {
 			user, err = user.Save(r.Context())
 			if err != nil {
 				log.Printf("Failed to auto-create user: %s\n", err)
-				WriteJSONError(w, http.StatusInternalServerError,
+				writeJSONError(w, http.StatusInternalServerError,
 					"internal error", "")
 				return
 			}
@@ -132,7 +132,7 @@ func Middleware(next http.Handler) http.Handler {
 			// this code to render a terminal "contact your administrator"
 			// message instead of looping the user back through the IdP.
 			log.Printf("authenticated identity has no ZTMF account: %s\n", IdentifierFromClaims(claims))
-			WriteJSONError(w, http.StatusForbidden,
+			writeJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is not set up. Contact your administrator to request access.",
 				CodeAccountNotProvisioned)
 			return
@@ -140,7 +140,7 @@ func Middleware(next http.Handler) http.Handler {
 			// DB connection blip, decode failure, etc. Not a credential
 			// problem, so do not present as one to the FE.
 			log.Printf("user lookup failed: %s\n", err)
-			WriteJSONError(w, http.StatusInternalServerError,
+			writeJSONError(w, http.StatusInternalServerError,
 				"internal error", "")
 			return
 		}
@@ -151,7 +151,7 @@ func Middleware(next http.Handler) http.Handler {
 			// distinctly so support can tell "offboarded" from "never
 			// onboarded" without grepping the users table.
 			log.Printf("deleted user attempted to access the API: %s\n", user.Email)
-			WriteJSONError(w, http.StatusForbidden,
+			writeJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is no longer active. Contact your administrator.",
 				CodeAccountNotProvisioned)
 			return

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -514,24 +515,41 @@ func TestDeleteUser_SelfDeleteRejected(t *testing.T) {
 	assert.NotEmpty(t, body.Error)
 }
 
-func TestDeleteUser_OtherDeleteNotSelfError(t *testing.T) {
-	// A non-caller UUID that contains hex letters, so we can also try a case
-	// variant. 
+func TestDeleteUser_OtherDeleteSucceeds(t *testing.T) {
 	otherIDLower := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
-	for _, otherID := range []string{otherIDLower, strings.ToUpper(otherIDLower)} {
-		t.Run(otherID, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+otherID, nil)
-			r = mux.SetURLVars(r, map[string]string{"userid": otherID})
+	target := &model.User{
+		UserID: otherIDLower,
+		Email:  "target@empire.test",
+		Role:   "ISSO",
+	}
+
+	prevFind, prevDel := findUserByID, deleteUser
+	findUserByID = func(_ context.Context, _ string) (*model.User, error) {
+		return target, nil
+	}
+	deleteUser = func(_ context.Context, _ string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		findUserByID = prevFind
+		deleteUser = prevDel
+	})
+
+	
+	variants := map[string]string{
+		"lower-cased": otherIDLower,
+		"upper-cased": strings.ToUpper(otherIDLower),
+	}
+	for name, pathID := range variants {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+pathID, nil)
+			r = mux.SetURLVars(r, map[string]string{"userid": pathID})
 			r = withUser(r, adminUser)
 			w := httptest.NewRecorder()
 
 			DeleteUser(w, r)
 
-			var body struct {
-				Code string `json:"code"`
-			}
-			_ = json.Unmarshal(w.Body.Bytes(), &body)
-			assert.NotEqual(t, auth.CodeSelfDeleteForbidden, body.Code)
+			assert.Equal(t, http.StatusNoContent, w.Code)
 		})
 	}
 }

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -489,4 +491,50 @@ func TestSaveMassEmail_ReadonlyAdminForbidden(t *testing.T) {
 // helper
 func int32Ptr(i int32) *int32 {
 	return &i
+}
+
+func TestDeleteUser_SelfDeleteRejected(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+adminUser.UserID, nil)
+	r = mux.SetURLVars(r, map[string]string{"userid": adminUser.UserID})
+	r = withUser(r, adminUser)
+	w := httptest.NewRecorder()
+
+	DeleteUser(w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var body struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, auth.CodeSelfDeleteForbidden, body.Code)
+	assert.NotEmpty(t, body.Error)
+}
+
+func TestDeleteUser_OtherDeleteNotSelfError(t *testing.T) {
+	otherID := "99999999-9999-4999-8999-999999999999"
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+otherID, nil)
+	r = mux.SetURLVars(r, map[string]string{"userid": otherID})
+	r = withUser(r, adminUser)
+	w := httptest.NewRecorder()
+
+	DeleteUser(w, r)
+
+	var body struct {
+		Code string `json:"code"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	assert.NotEqual(t, auth.CodeSelfDeleteForbidden, body.Code)
+}
+
+func TestDeleteUser_MissingIDIsNotFound(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users", nil)
+	r = withUser(r, adminUser)
+	w := httptest.NewRecorder()
+
+	DeleteUser(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
@@ -514,19 +515,57 @@ func TestDeleteUser_SelfDeleteRejected(t *testing.T) {
 }
 
 func TestDeleteUser_OtherDeleteNotSelfError(t *testing.T) {
-	otherID := "99999999-9999-4999-8999-999999999999"
-	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+otherID, nil)
-	r = mux.SetURLVars(r, map[string]string{"userid": otherID})
-	r = withUser(r, adminUser)
-	w := httptest.NewRecorder()
+	// A non-caller UUID that contains hex letters, so we can also try a case
+	// variant. 
+	otherIDLower := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	for _, otherID := range []string{otherIDLower, strings.ToUpper(otherIDLower)} {
+		t.Run(otherID, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+otherID, nil)
+			r = mux.SetURLVars(r, map[string]string{"userid": otherID})
+			r = withUser(r, adminUser)
+			w := httptest.NewRecorder()
 
-	DeleteUser(w, r)
+			DeleteUser(w, r)
 
-	var body struct {
-		Code string `json:"code"`
+			var body struct {
+				Code string `json:"code"`
+			}
+			_ = json.Unmarshal(w.Body.Bytes(), &body)
+			assert.NotEqual(t, auth.CodeSelfDeleteForbidden, body.Code)
+		})
 	}
-	_ = json.Unmarshal(w.Body.Bytes(), &body)
-	assert.NotEqual(t, auth.CodeSelfDeleteForbidden, body.Code)
+}
+
+func TestDeleteUser_SelfDeleteRejected_CaseInsensitive(t *testing.T) {
+	// Use a UUID with hex letters so case-folding is observable. Local
+	// fixture rather than the shared adminUser (whose UserID is all digits).
+	callerID := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	caller := &model.User{
+		UserID: callerID,
+		Email:  "case@empire.test",
+		Role:   "OWNER",
+	}
+	variants := map[string]string{
+		"upper-cased": strings.ToUpper(callerID),
+		"mixed-case":  "F47ac10B-58CC-4372-A567-0e02B2c3D479",
+	}
+	for name, pathID := range variants {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+pathID, nil)
+			r = mux.SetURLVars(r, map[string]string{"userid": pathID})
+			r = withUser(r, caller)
+			w := httptest.NewRecorder()
+
+			DeleteUser(w, r)
+
+			assert.Equal(t, http.StatusForbidden, w.Code)
+			var body struct {
+				Code string `json:"code"`
+			}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			assert.Equal(t, auth.CodeSelfDeleteForbidden, body.Code)
+		})
+	}
 }
 
 func TestDeleteUser_MissingIDIsNotFound(t *testing.T) {

--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/gorilla/schema"
 )
@@ -19,6 +20,10 @@ var decoder = schema.NewDecoder()
 type response struct {
 	Data any    `json:"data,omitempty"`
 	Err  string `json:"error,omitempty"`
+	// Set only for error responses that opt into
+	// a typed code via sanitizeErr; omitted for both successful responses
+	// and generic errors so existing consumers see the same shape.
+	Code string `json:"code,omitempty"`
 }
 
 // respondOK writes an HTTP 200 with the JSON-wrapped data payload. Use for
@@ -61,12 +66,14 @@ func respond(w http.ResponseWriter, r *http.Request, data any, err error) {
 	}
 
 	if err != nil {
-		status, err = sanitizeErr(err)
+		var code string
+		status, err, code = sanitizeErr(err)
 		switch e := err.(type) {
 		case *model.InvalidInputError:
 			res.Data = e.Data()
 		}
 		res.Err = err.Error()
+		res.Code = code
 	}
 
 	w.WriteHeader(status)
@@ -84,13 +91,16 @@ func parseRFC3339(dateStr string) (time.Time, error) {
 	return time.Parse(time.RFC3339, dateStr)
 }
 
-func sanitizeErr(err error) (int, error) {
+func sanitizeErr(err error) (int, error, string) {
 	switch err.(type) {
 	case *model.InvalidInputError:
-		return 400, err
+		return 400, err, ""
 	}
 
-	var status int
+	var (
+		status int
+		code   string
+	)
 
 	switch {
 	case errors.Is(err, model.ErrNoData):
@@ -98,6 +108,9 @@ func sanitizeErr(err error) (int, error) {
 		fallthrough
 	case errors.Is(err, ErrNotFound):
 		status = 404
+	case errors.Is(err, ErrSelfDelete):
+		status = 403
+		code = auth.CodeSelfDeleteForbidden
 	case errors.Is(err, ErrForbidden),
 		errors.Is(err, model.ErrPastDeadline):
 		status = 403
@@ -117,5 +130,5 @@ func sanitizeErr(err error) (int, error) {
 		err = ErrServer
 	}
 
-	return status, err
+	return status, err, code
 }

--- a/backend/cmd/api/internal/controller/errors.go
+++ b/backend/cmd/api/internal/controller/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrServer             = errors.New("server error")
 	ErrServiceUnavailable = errors.New("service unavailable")
 	ErrMalformed          = errors.New("json malformed or type mismatch")
+	ErrSelfDelete = errors.New("You cannot delete your own account.")
 )

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/gorilla/mux"
 )
@@ -217,9 +216,7 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 		caseVariant := userID != authdUser.UserID
 		log.Printf("user: self-delete blocked actor=%s target=%s case_variant=%t\n",
 			authdUser.UserID, userID, caseVariant)
-		auth.WriteJSONError(w, http.StatusForbidden,
-			"You cannot delete your own account.",
-			auth.CodeSelfDeleteForbidden)
+		respond(w, r, nil, ErrSelfDelete)
 		return
 	}
 

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/gorilla/mux"
 )
@@ -207,6 +208,14 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 	userID, ok := vars["userid"]
 	if !ok {
 		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	// Self delete prevention gate.
+	if userID == authdUser.UserID {
+		auth.WriteJSONError(w, http.StatusForbidden,
+			"You cannot delete your own account.",
+			auth.CodeSelfDeleteForbidden)
 		return
 	}
 

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
@@ -212,7 +213,10 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Self delete prevention gate.
-	if userID == authdUser.UserID {
+	if strings.EqualFold(userID, authdUser.UserID) {
+		caseVariant := userID != authdUser.UserID
+		log.Printf("user: self-delete blocked actor=%s target=%s case_variant=%t\n",
+			authdUser.UserID, userID, caseVariant)
 		auth.WriteJSONError(w, http.StatusForbidden,
 			"You cannot delete your own account.",
 			auth.CodeSelfDeleteForbidden)

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -1,12 +1,21 @@
 package controller
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"strings"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/gorilla/mux"
+)
+
+// Package-level seams over the model funcs used by DeleteUser so tests can
+// stub them without a database. Production wiring is the real model funcs.
+// Same pattern as auth/middleware.go's findUserByID / findUserByEmail vars.
+var (
+	findUserByID = model.FindUserByID
+	deleteUser   = model.DeleteUser
 )
 
 //	@Summary	List all users
@@ -221,7 +230,7 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// An OpDiv-scoped admin may only delete a user within their OpDiv.
-	target, terr := model.FindUserByID(r.Context(), userID)
+	target, terr := findUserByID(r.Context(), userID)
 	if terr != nil {
 		respond(w, r, nil, terr)
 		return
@@ -231,7 +240,7 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := model.DeleteUser(r.Context(), userID)
+	err := deleteUser(r.Context(), userID)
 	if err != nil {
 		log.Println(err)
 		respond(w, r, nil, err)
@@ -288,3 +297,11 @@ func RestoreUser(w http.ResponseWriter, r *http.Request) {
 
 	respondOK(w, user)
 }
+
+// Compile-time assertion that the model funcs used by DeleteUser keep the
+// signatures the seams (and their tests) expect. Guards against silent
+// signature drift in the model package.
+var (
+	_ func(context.Context, string) (*model.User, error) = findUserByID
+	_ func(context.Context, string) error                = deleteUser
+)


### PR DESCRIPTION
## Summary

Closes `CMS-Enterprise/ztmf#366`. Pairs with the FE half at `CMS-Enterprise/ztmf-ui#433`, which shipped first.

Pre-existing bug: `DELETE /api/v1/users/<id>` accepted the request regardless of whether the caller was deleting their own account. An admin who self-deleted got soft-deleted, the next `/users/current` call no longer found their row, and they were locked out with no FE-recoverable path back in — recovery required a sibling admin running `PUT /users/<id>/restore`.

The FE half disables the row-action icon on the caller's own row plus a handler short-circuit. That's sufficient for the accidental click. This PR is the **defense-in-depth half**: the BE rejects the request server-side so a direct `curl`, a scripted client, or a future FE refactor that re-enables the affordance cannot bypass.

## Changes

* **`backend/cmd/api/internal/auth/middleware.go`**
  * `writeJSONError` → `WriteJSONError` (export so it's callable from `controller`). Signature, body, and behavior unchanged. The six internal call sites in this file are updated in the same diff.
  * Added `CodeSelfDeleteForbidden = "SELF_DELETE_FORBIDDEN"` alongside the existing `Code*` family. Keeping all response codes in one place since the FE mirrors them in `utils/authCodes.ts`, regardless of which BE package emits them.
* **`backend/cmd/api/internal/controller/users.go`**
  * New import: `auth`.
  * In `DeleteUser`, after the admin check and path-param lookup, compare `userID == authdUser.UserID` and short-circuit with `auth.WriteJSONError(w, http.StatusForbidden, "You cannot delete your own account.", auth.CodeSelfDeleteForbidden)`. Placed before the DB lookup so the rejection costs no query and fires even if the row was somehow corrupted mid-session.
* **`backend/cmd/api/internal/controller/users_test.go`**
  * Three new tests covering the AC's three cases.

Updated order of checks in `DeleteUser`:

```
1. authdUser.IsAdmin()              -> 403 ErrForbidden if not
2. vars["userid"] present?          -> 404 ErrNotFound if missing
3. userID == authdUser.UserID?      -> 403 SELF_DELETE_FORBIDDEN if true
4. model.FindUserByID               -> errors as today (404/500)
5. authdUser.CanManageUser(target)  -> 403 ErrForbidden if scope fails
6. model.DeleteUser                 -> soft-delete (204 success)
```

## Test plan

Backend unit tests:

* `TestDeleteUser_SelfDeleteRejected` — self-delete deets in the body code match `SELF_DELETE_FORBIDDEN`.
* `TestDeleteUser_OtherDeleteNotSelfError` — differs; body code is not `SELF_DELETE_FORBIDDEN`.
* `TestDeleteUser_MissingIDIsNotFound` — pre-existing 404 branch unchanged.

`go test ./cmd/api/...` and `go vet ./cmd/api/...` green.

Container smoke against `compose-dev` rebuilt on this branch:

```bash
cd ztmf-ui && make frontend-env EMAIL=Grand.Moff@DeathStar.Empire
# uncomment VITE_AUTH_TOKEN3 in .env.development.local
export AUTH_TOKEN='<paste the JWT>'
```

* [x] **Self-delete → 403 `SELF_DELETE_FORBIDDEN`**
  ```bash
  USER_ID=$(curl -s -H "Authorization: Bearer $AUTH_TOKEN" \
    'http://localhost:8080/api/v1/users/current' | jq -r '.data.userid')

  curl -s -i -X DELETE \
    -H "Authorization: Bearer $AUTH_TOKEN" \
    "http://localhost:8080/api/v1/users/$USER_ID"
  # HTTP/1.1 403 Forbidden
  # Content-Type: application/json
  # X-Content-Type-Options: nosniff
  # {"error":"You cannot delete your own account.","code":"SELF_DELETE_FORBIDDEN"}
  ```
* [ ] **Other-delete still flows past the guard** (regression check)
  ```bash
  OTHER_ID=$(curl -s -H "Authorization: Bearer $AUTH_TOKEN" \
    'http://localhost:8080/api/v1/users?email=Admiral.Piett@executor.empire' \
    | jq -r '.data[0].userid')

  curl -s -i -X DELETE \
    -H "Authorization: Bearer $AUTH_TOKEN" \
    "http://localhost:8080/api/v1/users/$OTHER_ID"
  # Expect: 204 (success) — and crucially the body code is NOT SELF_DELETE_FORBIDDEN.
  ```
* [ ] **Existing middleware shape regression check** — checking that standard middleware blocks (e.g. no Authorization header) still emits the `{error,code}` body unchanged after the helper rename:
  ```bash
  curl -s -i 'http://localhost:8080/api/v1/users/current' | head -20
  # HTTP/1.1 401 Unauthorized
  # {"error":"Your session has expired. Please sign in again.","code":"UNAUTHORIZED"}
  ```

End-to-end with `ztmf-ui#433` applied:

* [ ] Log into the dashboard as Grand.Moff. The Delete button on your row is disabled (FE guard). Use DevTools to remove the `disabled` attribute and click → confirm the dialog → BE rejects with 403 + `SELF_DELETE_FORBIDDEN` → snackbar toast surfaces "You cannot delete your own account." instead of locking the session out.

## Notes for reviewers

* **`writeJSONError` rename to `WriteJSONError`** is a pure visibility flip — same signature, same body, same caller behavior. The six internal call sites in `middleware.go` are updated in this diff so no in-flight callers break. If a future PR wants the helper in a shared `internal/api/responses` package, that's a clean follow-up.
