### PR TITLE
Bugfix/prevent admin self deletion

### DIFF
--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -22,6 +22,7 @@ const (
 	CodeUnauthorized          = "UNAUTHORIZED"
 	CodeForbiddenOrigin       = "FORBIDDEN_ORIGIN"
 	CodeAccountNotProvisioned = "ACCOUNT_NOT_PROVISIONED"
+	CodeSelfDeleteForbidden = "SELF_DELETE_FORBIDDEN"
 )
 
 // Package-level seams over the model lookups so tests can stub them without a
@@ -39,10 +40,10 @@ type errorBody struct {
 	Code  string `json:"code,omitempty"`
 }
 
-// writeJSONError writes a standardized JSON error response and is the only
+// WriteJSONError writes a standardized JSON error response and is the only
 // rejection surface used by Middleware. Centralizing the shape keeps the FE
 // interceptor's contract single-sourced.
-func writeJSONError(w http.ResponseWriter, status int, msg, code string) {
+func WriteJSONError(w http.ResponseWriter, status int, msg, code string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(status)
@@ -70,7 +71,7 @@ func Middleware(next http.Handler) http.Handler {
 
 		claims, isSession, ok := claimsFromRequest(r)
 		if !ok {
-			writeJSONError(w, http.StatusUnauthorized,
+			WriteJSONError(w, http.StatusUnauthorized,
 				"Your session has expired. Please sign in again.",
 				CodeUnauthorized)
 			return
@@ -82,7 +83,7 @@ func Middleware(next http.Handler) http.Handler {
 		// cookie path is browser-driven; the bearer path is for API clients and
 		// is not subject to CSRF.
 		if isSession && !isSafeMethod(r.Method) && !sameOrigin(r) {
-			writeJSONError(w, http.StatusForbidden,
+			WriteJSONError(w, http.StatusForbidden,
 				"Request blocked: origin not allowed.",
 				CodeForbiddenOrigin)
 			return
@@ -120,7 +121,7 @@ func Middleware(next http.Handler) http.Handler {
 			user, err = user.Save(r.Context())
 			if err != nil {
 				log.Printf("Failed to auto-create user: %s\n", err)
-				writeJSONError(w, http.StatusInternalServerError,
+				WriteJSONError(w, http.StatusInternalServerError,
 					"internal error", "")
 				return
 			}
@@ -131,7 +132,7 @@ func Middleware(next http.Handler) http.Handler {
 			// this code to render a terminal "contact your administrator"
 			// message instead of looping the user back through the IdP.
 			log.Printf("authenticated identity has no ZTMF account: %s\n", IdentifierFromClaims(claims))
-			writeJSONError(w, http.StatusForbidden,
+			WriteJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is not set up. Contact your administrator to request access.",
 				CodeAccountNotProvisioned)
 			return
@@ -139,7 +140,7 @@ func Middleware(next http.Handler) http.Handler {
 			// DB connection blip, decode failure, etc. Not a credential
 			// problem, so do not present as one to the FE.
 			log.Printf("user lookup failed: %s\n", err)
-			writeJSONError(w, http.StatusInternalServerError,
+			WriteJSONError(w, http.StatusInternalServerError,
 				"internal error", "")
 			return
 		}
@@ -150,7 +151,7 @@ func Middleware(next http.Handler) http.Handler {
 			// distinctly so support can tell "offboarded" from "never
 			// onboarded" without grepping the users table.
 			log.Printf("deleted user attempted to access the API: %s\n", user.Email)
-			writeJSONError(w, http.StatusForbidden,
+			WriteJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is no longer active. Contact your administrator.",
 				CodeAccountNotProvisioned)
 			return

--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -40,10 +40,10 @@ type errorBody struct {
 	Code  string `json:"code,omitempty"`
 }
 
-// WriteJSONError writes a standardized JSON error response and is the only
+// writeJSONError writes a standardized JSON error response and is the only
 // rejection surface used by Middleware. Centralizing the shape keeps the FE
 // interceptor's contract single-sourced.
-func WriteJSONError(w http.ResponseWriter, status int, msg, code string) {
+func writeJSONError(w http.ResponseWriter, status int, msg, code string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(status)
@@ -71,7 +71,7 @@ func Middleware(next http.Handler) http.Handler {
 
 		claims, isSession, ok := claimsFromRequest(r)
 		if !ok {
-			WriteJSONError(w, http.StatusUnauthorized,
+			writeJSONError(w, http.StatusUnauthorized,
 				"Your session has expired. Please sign in again.",
 				CodeUnauthorized)
 			return
@@ -83,7 +83,7 @@ func Middleware(next http.Handler) http.Handler {
 		// cookie path is browser-driven; the bearer path is for API clients and
 		// is not subject to CSRF.
 		if isSession && !isSafeMethod(r.Method) && !sameOrigin(r) {
-			WriteJSONError(w, http.StatusForbidden,
+			writeJSONError(w, http.StatusForbidden,
 				"Request blocked: origin not allowed.",
 				CodeForbiddenOrigin)
 			return
@@ -121,7 +121,7 @@ func Middleware(next http.Handler) http.Handler {
 			user, err = user.Save(r.Context())
 			if err != nil {
 				log.Printf("Failed to auto-create user: %s\n", err)
-				WriteJSONError(w, http.StatusInternalServerError,
+				writeJSONError(w, http.StatusInternalServerError,
 					"internal error", "")
 				return
 			}
@@ -132,7 +132,7 @@ func Middleware(next http.Handler) http.Handler {
 			// this code to render a terminal "contact your administrator"
 			// message instead of looping the user back through the IdP.
 			log.Printf("authenticated identity has no ZTMF account: %s\n", IdentifierFromClaims(claims))
-			WriteJSONError(w, http.StatusForbidden,
+			writeJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is not set up. Contact your administrator to request access.",
 				CodeAccountNotProvisioned)
 			return
@@ -140,7 +140,7 @@ func Middleware(next http.Handler) http.Handler {
 			// DB connection blip, decode failure, etc. Not a credential
 			// problem, so do not present as one to the FE.
 			log.Printf("user lookup failed: %s\n", err)
-			WriteJSONError(w, http.StatusInternalServerError,
+			writeJSONError(w, http.StatusInternalServerError,
 				"internal error", "")
 			return
 		}
@@ -151,7 +151,7 @@ func Middleware(next http.Handler) http.Handler {
 			// distinctly so support can tell "offboarded" from "never
 			// onboarded" without grepping the users table.
 			log.Printf("deleted user attempted to access the API: %s\n", user.Email)
-			WriteJSONError(w, http.StatusForbidden,
+			writeJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is no longer active. Contact your administrator.",
 				CodeAccountNotProvisioned)
 			return

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -514,24 +515,41 @@ func TestDeleteUser_SelfDeleteRejected(t *testing.T) {
 	assert.NotEmpty(t, body.Error)
 }
 
-func TestDeleteUser_OtherDeleteNotSelfError(t *testing.T) {
-	// A non-caller UUID that contains hex letters, so we can also try a case
-	// variant. 
+func TestDeleteUser_OtherDeleteSucceeds(t *testing.T) {
 	otherIDLower := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
-	for _, otherID := range []string{otherIDLower, strings.ToUpper(otherIDLower)} {
-		t.Run(otherID, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+otherID, nil)
-			r = mux.SetURLVars(r, map[string]string{"userid": otherID})
+	target := &model.User{
+		UserID: otherIDLower,
+		Email:  "target@empire.test",
+		Role:   "ISSO",
+	}
+
+	prevFind, prevDel := findUserByID, deleteUser
+	findUserByID = func(_ context.Context, _ string) (*model.User, error) {
+		return target, nil
+	}
+	deleteUser = func(_ context.Context, _ string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		findUserByID = prevFind
+		deleteUser = prevDel
+	})
+
+	
+	variants := map[string]string{
+		"lower-cased": otherIDLower,
+		"upper-cased": strings.ToUpper(otherIDLower),
+	}
+	for name, pathID := range variants {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+pathID, nil)
+			r = mux.SetURLVars(r, map[string]string{"userid": pathID})
 			r = withUser(r, adminUser)
 			w := httptest.NewRecorder()
 
 			DeleteUser(w, r)
 
-			var body struct {
-				Code string `json:"code"`
-			}
-			_ = json.Unmarshal(w.Body.Bytes(), &body)
-			assert.NotEqual(t, auth.CodeSelfDeleteForbidden, body.Code)
+			assert.Equal(t, http.StatusNoContent, w.Code)
 		})
 	}
 }

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -489,4 +491,50 @@ func TestSaveMassEmail_ReadonlyAdminForbidden(t *testing.T) {
 // helper
 func int32Ptr(i int32) *int32 {
 	return &i
+}
+
+func TestDeleteUser_SelfDeleteRejected(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+adminUser.UserID, nil)
+	r = mux.SetURLVars(r, map[string]string{"userid": adminUser.UserID})
+	r = withUser(r, adminUser)
+	w := httptest.NewRecorder()
+
+	DeleteUser(w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var body struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, auth.CodeSelfDeleteForbidden, body.Code)
+	assert.NotEmpty(t, body.Error)
+}
+
+func TestDeleteUser_OtherDeleteNotSelfError(t *testing.T) {
+	otherID := "99999999-9999-4999-8999-999999999999"
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+otherID, nil)
+	r = mux.SetURLVars(r, map[string]string{"userid": otherID})
+	r = withUser(r, adminUser)
+	w := httptest.NewRecorder()
+
+	DeleteUser(w, r)
+
+	var body struct {
+		Code string `json:"code"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	assert.NotEqual(t, auth.CodeSelfDeleteForbidden, body.Code)
+}
+
+func TestDeleteUser_MissingIDIsNotFound(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users", nil)
+	r = withUser(r, adminUser)
+	w := httptest.NewRecorder()
+
+	DeleteUser(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
@@ -514,19 +515,57 @@ func TestDeleteUser_SelfDeleteRejected(t *testing.T) {
 }
 
 func TestDeleteUser_OtherDeleteNotSelfError(t *testing.T) {
-	otherID := "99999999-9999-4999-8999-999999999999"
-	r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+otherID, nil)
-	r = mux.SetURLVars(r, map[string]string{"userid": otherID})
-	r = withUser(r, adminUser)
-	w := httptest.NewRecorder()
+	// A non-caller UUID that contains hex letters, so we can also try a case
+	// variant. 
+	otherIDLower := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	for _, otherID := range []string{otherIDLower, strings.ToUpper(otherIDLower)} {
+		t.Run(otherID, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+otherID, nil)
+			r = mux.SetURLVars(r, map[string]string{"userid": otherID})
+			r = withUser(r, adminUser)
+			w := httptest.NewRecorder()
 
-	DeleteUser(w, r)
+			DeleteUser(w, r)
 
-	var body struct {
-		Code string `json:"code"`
+			var body struct {
+				Code string `json:"code"`
+			}
+			_ = json.Unmarshal(w.Body.Bytes(), &body)
+			assert.NotEqual(t, auth.CodeSelfDeleteForbidden, body.Code)
+		})
 	}
-	_ = json.Unmarshal(w.Body.Bytes(), &body)
-	assert.NotEqual(t, auth.CodeSelfDeleteForbidden, body.Code)
+}
+
+func TestDeleteUser_SelfDeleteRejected_CaseInsensitive(t *testing.T) {
+	// Use a UUID with hex letters so case-folding is observable. Local
+	// fixture rather than the shared adminUser (whose UserID is all digits).
+	callerID := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	caller := &model.User{
+		UserID: callerID,
+		Email:  "case@empire.test",
+		Role:   "OWNER",
+	}
+	variants := map[string]string{
+		"upper-cased": strings.ToUpper(callerID),
+		"mixed-case":  "F47ac10B-58CC-4372-A567-0e02B2c3D479",
+	}
+	for name, pathID := range variants {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+pathID, nil)
+			r = mux.SetURLVars(r, map[string]string{"userid": pathID})
+			r = withUser(r, caller)
+			w := httptest.NewRecorder()
+
+			DeleteUser(w, r)
+
+			assert.Equal(t, http.StatusForbidden, w.Code)
+			var body struct {
+				Code string `json:"code"`
+			}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			assert.Equal(t, auth.CodeSelfDeleteForbidden, body.Code)
+		})
+	}
 }
 
 func TestDeleteUser_MissingIDIsNotFound(t *testing.T) {

--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -91,6 +91,8 @@ func parseRFC3339(dateStr string) (time.Time, error) {
 	return time.Parse(time.RFC3339, dateStr)
 }
 
+// sanitizeErr maps an error to an HTTP status code and optional typed code string.
+// error is last so the signature follows Go convention (status, code, err).
 func sanitizeErr(err error) (int, string, error) {
 	switch err.(type) {
 	case *model.InvalidInputError:

--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/gorilla/schema"
 )
@@ -19,6 +20,10 @@ var decoder = schema.NewDecoder()
 type response struct {
 	Data any    `json:"data,omitempty"`
 	Err  string `json:"error,omitempty"`
+	// Set only for error responses that opt into
+	// a typed code via sanitizeErr; omitted for both successful responses
+	// and generic errors so existing consumers see the same shape.
+	Code string `json:"code,omitempty"`
 }
 
 // respondOK writes an HTTP 200 with the JSON-wrapped data payload. Use for
@@ -61,12 +66,14 @@ func respond(w http.ResponseWriter, r *http.Request, data any, err error) {
 	}
 
 	if err != nil {
-		status, err = sanitizeErr(err)
+		var code string
+		status, err, code = sanitizeErr(err)
 		switch e := err.(type) {
 		case *model.InvalidInputError:
 			res.Data = e.Data()
 		}
 		res.Err = err.Error()
+		res.Code = code
 	}
 
 	w.WriteHeader(status)
@@ -84,13 +91,16 @@ func parseRFC3339(dateStr string) (time.Time, error) {
 	return time.Parse(time.RFC3339, dateStr)
 }
 
-func sanitizeErr(err error) (int, error) {
+func sanitizeErr(err error) (int, error, string) {
 	switch err.(type) {
 	case *model.InvalidInputError:
-		return 400, err
+		return 400, err, ""
 	}
 
-	var status int
+	var (
+		status int
+		code   string
+	)
 
 	switch {
 	case errors.Is(err, model.ErrNoData):
@@ -98,6 +108,9 @@ func sanitizeErr(err error) (int, error) {
 		fallthrough
 	case errors.Is(err, ErrNotFound):
 		status = 404
+	case errors.Is(err, ErrSelfDelete):
+		status = 403
+		code = auth.CodeSelfDeleteForbidden
 	case errors.Is(err, ErrForbidden),
 		errors.Is(err, model.ErrPastDeadline):
 		status = 403
@@ -117,5 +130,5 @@ func sanitizeErr(err error) (int, error) {
 		err = ErrServer
 	}
 
-	return status, err
+	return status, err, code
 }

--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -67,7 +67,7 @@ func respond(w http.ResponseWriter, r *http.Request, data any, err error) {
 
 	if err != nil {
 		var code string
-		status, err, code = sanitizeErr(err)
+		status, code, err = sanitizeErr(err)
 		switch e := err.(type) {
 		case *model.InvalidInputError:
 			res.Data = e.Data()
@@ -91,10 +91,10 @@ func parseRFC3339(dateStr string) (time.Time, error) {
 	return time.Parse(time.RFC3339, dateStr)
 }
 
-func sanitizeErr(err error) (int, error, string) {
+func sanitizeErr(err error) (int, string, error) {
 	switch err.(type) {
 	case *model.InvalidInputError:
-		return 400, err, ""
+		return 400, "", err
 	}
 
 	var (
@@ -130,5 +130,5 @@ func sanitizeErr(err error) (int, error, string) {
 		err = ErrServer
 	}
 
-	return status, err, code
+	return status, code, err
 }

--- a/backend/cmd/api/internal/controller/errors.go
+++ b/backend/cmd/api/internal/controller/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrServer             = errors.New("server error")
 	ErrServiceUnavailable = errors.New("service unavailable")
 	ErrMalformed          = errors.New("json malformed or type mismatch")
+	ErrSelfDelete = errors.New("You cannot delete your own account.")
 )

--- a/backend/cmd/api/internal/controller/errors.go
+++ b/backend/cmd/api/internal/controller/errors.go
@@ -10,5 +10,5 @@ var (
 	ErrServer             = errors.New("server error")
 	ErrServiceUnavailable = errors.New("service unavailable")
 	ErrMalformed          = errors.New("json malformed or type mismatch")
-	ErrSelfDelete = errors.New("You cannot delete your own account.")
+	ErrSelfDelete = errors.New("cannot delete your own account")
 )

--- a/backend/cmd/api/internal/controller/errors.go
+++ b/backend/cmd/api/internal/controller/errors.go
@@ -10,5 +10,6 @@ var (
 	ErrServer             = errors.New("server error")
 	ErrServiceUnavailable = errors.New("service unavailable")
 	ErrMalformed          = errors.New("json malformed or type mismatch")
+	// lowercase, no period — Go error strings must not be capitalized or end with punctuation
 	ErrSelfDelete = errors.New("cannot delete your own account")
 )

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/gorilla/mux"
 )
@@ -217,9 +216,7 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 		caseVariant := userID != authdUser.UserID
 		log.Printf("user: self-delete blocked actor=%s target=%s case_variant=%t\n",
 			authdUser.UserID, userID, caseVariant)
-		auth.WriteJSONError(w, http.StatusForbidden,
-			"You cannot delete your own account.",
-			auth.CodeSelfDeleteForbidden)
+		respond(w, r, nil, ErrSelfDelete)
 		return
 	}
 

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/gorilla/mux"
 )
@@ -207,6 +208,14 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 	userID, ok := vars["userid"]
 	if !ok {
 		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	// Self delete prevention gate.
+	if userID == authdUser.UserID {
+		auth.WriteJSONError(w, http.StatusForbidden,
+			"You cannot delete your own account.",
+			auth.CodeSelfDeleteForbidden)
 		return
 	}
 

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
@@ -212,7 +213,10 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Self delete prevention gate.
-	if userID == authdUser.UserID {
+	if strings.EqualFold(userID, authdUser.UserID) {
+		caseVariant := userID != authdUser.UserID
+		log.Printf("user: self-delete blocked actor=%s target=%s case_variant=%t\n",
+			authdUser.UserID, userID, caseVariant)
 		auth.WriteJSONError(w, http.StatusForbidden,
 			"You cannot delete your own account.",
 			auth.CodeSelfDeleteForbidden)

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -1,12 +1,21 @@
 package controller
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"strings"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/gorilla/mux"
+)
+
+// Package-level seams over the model funcs used by DeleteUser so tests can
+// stub them without a database. Production wiring is the real model funcs.
+// Same pattern as auth/middleware.go's findUserByID / findUserByEmail vars.
+var (
+	findUserByID = model.FindUserByID
+	deleteUser   = model.DeleteUser
 )
 
 //	@Summary	List all users
@@ -221,7 +230,7 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// An OpDiv-scoped admin may only delete a user within their OpDiv.
-	target, terr := model.FindUserByID(r.Context(), userID)
+	target, terr := findUserByID(r.Context(), userID)
 	if terr != nil {
 		respond(w, r, nil, terr)
 		return
@@ -231,7 +240,7 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := model.DeleteUser(r.Context(), userID)
+	err := deleteUser(r.Context(), userID)
 	if err != nil {
 		log.Println(err)
 		respond(w, r, nil, err)
@@ -288,3 +297,11 @@ func RestoreUser(w http.ResponseWriter, r *http.Request) {
 
 	respondOK(w, user)
 }
+
+// Compile-time assertion that the model funcs used by DeleteUser keep the
+// signatures the seams (and their tests) expect. Guards against silent
+// signature drift in the model package.
+var (
+	_ func(context.Context, string) (*model.User, error) = findUserByID
+	_ func(context.Context, string) error                = deleteUser
+)


### PR DESCRIPTION
## Summary

Pre-existing bug: `DELETE /api/v1/users/<id>` accepted the request regardless of whether the caller was deleting their own account. An admin who self-deleted got soft-deleted; their next `/users/current` no longer found their row and they were locked out, recoverable only by a sibling admin running `PUT /users/<id>/restore`. Closes #366. Pairs with the FE half at CMS-Enterprise/ztmf-ui#433 (shipped first). In-repo rehome of #374 by @tarratsco so the org-secret CI gates (Snyk, Infrastructure/Deploy) can run — they can't on a fork PR; original authorship preserved.

The FE half disables the row action on the caller's own row plus a handler short-circuit — enough for the accidental click. This is the defense-in-depth backend half: the server rejects the request so a direct curl, a scripted client, or a future FE regression cannot bypass it.

## Changes

- **`controller/users.go`** — `DeleteUser` now rejects self-deletion. After the admin check and path-param lookup, it compares the target id to the caller's id with `strings.EqualFold(userID, authdUser.UserID)` and short-circuits with `respond(w, r, nil, ErrSelfDelete)` **before** the DB lookup — so the rejection costs no query and fires against the JWT-derived caller id even if the caller's own row is in an odd state. A `case_variant` boolean is logged to tell an honest self-click apart from a differently-cased probe. `EqualFold` mirrors the case-insensitive semantics of the native Postgres `uuid` column. Also adds package-level `findUserByID`/`deleteUser` seams (same pattern as `auth/middleware.go`) so `DeleteUser` is unit-testable without a database, with compile-time assertions guarding against model-signature drift.
- **`controller/errors.go`** — adds `ErrSelfDelete` (`"cannot delete your own account"`).
- **`controller/controller.go`** — `sanitizeErr` now returns `(status, code, err)` and maps `ErrSelfDelete` → 403 with `code = auth.CodeSelfDeleteForbidden`. The `response` struct gains an optional `code` field (`omitempty`), so successful responses and generic errors keep their existing shape; only typed-code errors carry it.
- **`auth/middleware.go`** — adds `CodeSelfDeleteForbidden = "SELF_DELETE_FORBIDDEN"` to the existing `Code*` block, where response codes live so the FE can mirror them in `utils/authCodes.ts`.
- **`controller/authorization_test.go`** — four new tests (below).

Check order in `DeleteUser`:
1. `authdUser.IsAdmin()` → 403 `ErrForbidden` if not
2. `vars["userid"]` present? → 404 `ErrNotFound` if missing
3. self? (`EqualFold(userID, caller)`) → 403 `SELF_DELETE_FORBIDDEN`
4. `findUserByID` → 404/500 as today
5. `CanManageUser(target)` → 403 `ErrForbidden` if OpDiv scope fails
6. `deleteUser` → 204

## Test plan

- `TestDeleteUser_SelfDeleteRejected` — self-delete returns 403; body `code` is `SELF_DELETE_FORBIDDEN`.
- `TestDeleteUser_SelfDeleteRejected_CaseInsensitive` — upper/mixed-case variants of the caller's own id are still rejected (locks in the `uuid`/`EqualFold` semantics).
- `TestDeleteUser_OtherDeleteSucceeds` — deleting a different user (including an upper-cased id) still succeeds.
- `TestDeleteUser_MissingIDIsNotFound` — pre-existing 404 branch unchanged.
- `go test ./cmd/api/...` and `go vet ./cmd/api/...` green.

## Notes for reviewers

No API shape change for existing consumers: the new `response.code` field is `omitempty` and set only for typed-code errors. The self-delete path reuses the existing `respond()`/`sanitizeErr()` error-mapping pipeline rather than writing responses directly, keeping error handling in one place.

Refs #374. Original contribution by @tarratsco.
