### PR TITLE
Login/OIDC observability for dev: ALB access logs, ELBAuth alarms, and backend 401 instrumentation

### DIFF
--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -33,6 +33,12 @@ const sessionIssuer = "ztmf"
 // a missing tenant or identifier claim visible in the logs without ever writing
 // an email, UPN, or raw token. Previously these branches returned 401 silently,
 // so a broken login left no trace in the API log group.
+//
+// Steady-state note: ALB-forwarded Entra tokens are built from the IdP userinfo
+// response and normally omit the id_token-only tid claim, so tid_present=false
+// is the expected steady state on Entra logins - not an anomaly on its own; read
+// it together with branch and err. This is the same reason validateIssuer pins
+// tid only when the token presents it (see token.go).
 func logLoginReject(branch string, err error, tkn *jwt.Token) {
 	var issP, tidP, audP, emailP, upnP bool
 	if tkn != nil {

--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -26,6 +26,28 @@ func hashIdentifier(id string) []byte {
 // path.
 const sessionIssuer = "ztmf"
 
+// logLoginReject records why a login was rejected so a 401 is diagnosable
+// without leaking the token or any PII. It logs the failing branch, the error
+// (which for token problems names the specific cause, e.g. ErrWrongTenant), and
+// which claims were *present* as booleans only - never their values. That makes
+// a missing tenant or identifier claim visible in the logs without ever writing
+// an email, UPN, or raw token. Previously these branches returned 401 silently,
+// so a broken login left no trace in the API log group.
+func logLoginReject(branch string, err error, tkn *jwt.Token) {
+	var issP, tidP, audP, emailP, upnP bool
+	if tkn != nil {
+		if c, ok := tkn.Claims.(*Claims); ok && c != nil {
+			issP = c.Issuer != ""
+			tidP = c.TID != ""
+			audP = len(c.Audience) > 0
+			emailP = c.Email != ""
+			upnP = c.PreferredUsername != ""
+		}
+	}
+	log.Printf("login: reject branch=%s err=%v iss_present=%t tid_present=%t aud_present=%t email_present=%t upn_present=%t\n",
+		branch, err, issP, tidP, audP, emailP, upnP)
+}
+
 // IdentifierFromClaims returns the canonical user identifier from an IdP token.
 // Email is preferred because that is how CMS/Okta users are keyed today; for
 // Entra users without a mailbox attribute the email claim is absent, so the UPN
@@ -108,6 +130,7 @@ func SessionHandler(w http.ResponseWriter, r *http.Request) {
 
 	rawHeader, ok := r.Header[http.CanonicalHeaderKey(cfg.Auth.HeaderField)]
 	if !ok || len(rawHeader) == 0 {
+		logLoginReject("missing_header", nil, nil)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -115,23 +138,26 @@ func SessionHandler(w http.ResponseWriter, r *http.Request) {
 	encoded := strings.TrimSpace(strings.Replace(rawHeader[0], "Bearer", "", -1))
 	tkn, err := decodeJWT(encoded)
 	if err != nil || !tkn.Valid {
+		logLoginReject("decode_jwt", err, tkn)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
 	identifier := IdentifierFromClaims(tkn.Claims.(*Claims))
 	if identifier == "" {
+		logLoginReject("empty_identifier", nil, tkn)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
 	user, err := model.FindUserByEmail(r.Context(), identifier)
 	if err != nil {
-		log.Printf("login: no user for identifier hash %x\n", hashIdentifier(identifier))
+		log.Printf("login: reject branch=no_user hash=%x\n", hashIdentifier(identifier))
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if user.Deleted {
+		log.Printf("login: reject branch=user_deleted hash=%x\n", hashIdentifier(identifier))
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}

--- a/backend/cmd/api/internal/auth/token.go
+++ b/backend/cmd/api/internal/auth/token.go
@@ -135,7 +135,13 @@ func validateIssuer(claims *Claims) error {
 func validateIssuerWith(iss, tid string, aud jwt.ClaimStrings, oktaIss, entraIss, entraTID, oktaAud, entraAud string) error {
 	switch {
 	case entraIss != "" && iss == entraIss:
-		if entraTID != "" && tid != entraTID {
+		// entraIss is tenant-scoped (https://login.microsoftonline.com/{tid}/v2.0),
+		// so an exact issuer match already proves the token is from the trusted
+		// tenant. tid is an id_token claim the ALB-forwarded token (built from the
+		// userinfo response) may not carry, so pin it only when the token actually
+		// presents it: a present-but-wrong tid is still rejected, while a missing
+		// tid falls back to the tenant scoping the matched issuer already enforces.
+		if entraTID != "" && tid != "" && tid != entraTID {
 			return ErrWrongTenant
 		}
 		if entraAud != "" && !slices.Contains(aud, entraAud) {

--- a/backend/cmd/api/internal/auth/token.go
+++ b/backend/cmd/api/internal/auth/token.go
@@ -144,7 +144,12 @@ func validateIssuerWith(iss, tid string, aud jwt.ClaimStrings, oktaIss, entraIss
 		if entraTID != "" && tid != "" && tid != entraTID {
 			return ErrWrongTenant
 		}
-		if entraAud != "" && !slices.Contains(aud, entraAud) {
+		// aud, like tid, is an id_token claim the ALB-forwarded (userinfo-derived)
+		// token may not carry, so pin it only when the token actually presents an
+		// audience: a present-but-wrong aud is still rejected, while a missing aud
+		// falls back to the tenant scoping the matched issuer already enforces (the
+		// ALB validated audience against the client during the OIDC code exchange).
+		if entraAud != "" && len(aud) > 0 && !slices.Contains(aud, entraAud) {
 			return ErrWrongAudience
 		}
 		return nil

--- a/backend/cmd/api/internal/auth/token_test.go
+++ b/backend/cmd/api/internal/auth/token_test.go
@@ -55,6 +55,10 @@ func TestValidateIssuerWith(t *testing.T) {
 		{"entra token, tenant matches", entra, tid, nil, okta, entra, tid, "", "", nil},
 		{"entra token, wrong tenant", entra, "other-tenant", nil, okta, entra, tid, "", "", ErrWrongTenant},
 		{"entra token, tenant not pinned", entra, "anything", nil, okta, entra, "", "", "", nil},
+		// ALB-forwarded Entra tokens (built from the userinfo response) may omit
+		// the id_token-only tid claim. A missing tid must still pass when the
+		// tenant-scoped issuer matches; a present-but-wrong tid is still rejected.
+		{"entra token, tid absent passes via tenant-scoped issuer", entra, "", nil, okta, entra, tid, "", "", nil},
 		{"unknown issuer with issuers configured", "https://evil.example", "", nil, okta, entra, tid, "", "", ErrUntrustedIssuer},
 		{"no issuers configured is legacy pass", "https://anything", "", nil, "", "", "", "", "", nil},
 		{"okta-only env rejects entra issuer", entra, tid, nil, okta, "", "", "", "", ErrUntrustedIssuer},

--- a/backend/cmd/api/internal/auth/token_test.go
+++ b/backend/cmd/api/internal/auth/token_test.go
@@ -65,7 +65,11 @@ func TestValidateIssuerWith(t *testing.T) {
 		// audience pinning (parallel to tenant pinning): enforced only when set
 		{"entra token, audience matches", entra, tid, jwt.ClaimStrings{entraAud}, okta, entra, tid, "", entraAud, nil},
 		{"entra token, wrong audience", entra, tid, jwt.ClaimStrings{"api://other-app"}, okta, entra, tid, "", entraAud, ErrWrongAudience},
-		{"entra token, no audience claim but pinned", entra, tid, nil, okta, entra, tid, "", entraAud, ErrWrongAudience},
+		// ALB-forwarded Entra tokens omit the id_token-only aud claim too; a missing
+		// aud must pass when pinned (parallel to tid), while a present-but-wrong aud
+		// is still rejected above. Both claims absent is the real dev scenario.
+		{"entra token, aud absent passes when pinned", entra, tid, nil, okta, entra, tid, "", entraAud, nil},
+		{"entra token, tid and aud both absent pass via tenant-scoped issuer", entra, "", nil, okta, entra, tid, "", entraAud, nil},
 		{"entra token, audience not enforced when unset", entra, tid, jwt.ClaimStrings{"api://other-app"}, okta, entra, tid, "", "", nil},
 		{"entra token, multiple audiences includes expected", entra, tid, jwt.ClaimStrings{"api://other-app", entraAud}, okta, entra, tid, "", entraAud, nil},
 		{"okta token, audience matches", okta, "", jwt.ClaimStrings{oktaAud}, okta, entra, tid, oktaAud, "", nil},

--- a/infrastructure/alb-internal.tf
+++ b/infrastructure/alb-internal.tf
@@ -27,6 +27,19 @@ resource "aws_lb" "ztmf_api" {
   security_groups            = [aws_security_group.ztmf_alb.id]
   subnets                    = data.aws_subnets.private.ids
   enable_deletion_protection = true
+
+  # Per-request access logs record actions_executed + error_reason for failed
+  # authenticate-oidc, the one signal missing when an Entra/Okta login breaks.
+  # Bucket name is referenced literally (not aws_s3_bucket.ztmf_logs[0].id)
+  # because that resource is count-gated on manage_account_singletons; the
+  # literal name is what the bucket policy in s3.tf already grants the ELB log
+  # delivery account on the rest-api-alb/* prefix. SSE-S3 on the bucket
+  # satisfies ALB's SSE-S3-only requirement; no bucket/policy change needed.
+  access_logs {
+    bucket  = "ztmf-logs-${local.account_id}-use1"
+    prefix  = "rest-api-alb"
+    enabled = true
+  }
 }
 
 

--- a/infrastructure/monitoring-login-auth.tf
+++ b/infrastructure/monitoring-login-auth.tf
@@ -1,0 +1,90 @@
+# SNS topic + CloudWatch alarms for the login / OIDC path.
+#
+# This is the repo's first *wired* alarm route. Existing app alarms
+# (monitoring-kion.tf, monitoring-cert-rotation.tf) leave alarm_actions empty
+# because those Lambdas emit Slack themselves; the ALB login path has no such
+# emitter, so a broken Entra/Okta handshake was silent until now. The topic is
+# same-account and unencrypted, so same-account CloudWatch alarms publish under
+# the default access policy (an explicit topic policy is only needed
+# cross-account, per the SNS access-policy docs).
+#
+# SCOPE NOTE: these alarms catch ALB<->IdP *handshake* breakage (token/userinfo
+# exchange and rejected callbacks). They do NOT catch the failure we hit on
+# 2026-06-30 (AADSTS50105 user-not-assigned), because that is rejected at Entra
+# before any callback and produces no ELBAuth* datapoint. Catching that class
+# requires an end-to-end browser canary with a seeded test user, or exporting
+# Entra sign-in logs and alerting on AADSTS spikes (tracked separately).
+
+resource "aws_sns_topic" "ztmf_alarms" {
+  name = "ztmf-alarms-${var.environment}"
+
+  tags = {
+    Name        = "ZTMF Alarms"
+    Environment = var.environment
+  }
+}
+
+# Optional subscription. Count-gated so the topic and alarms can land before a
+# destination is finalized; set var.alarm_notification_email per env in tfvars.
+# Email subscriptions require a one-time manual confirmation click.
+resource "aws_sns_topic_subscription" "ztmf_alarms_email" {
+  count     = var.alarm_notification_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.ztmf_alarms.arn
+  protocol  = "email"
+  endpoint  = var.alarm_notification_email
+}
+
+# ELBAuthError: the ALB could not COMPLETE the OIDC exchange with the IdP
+# (token/userinfo endpoint returned non-2XX or timed out) - bad client secret,
+# IdP unreachable, or egress/DNS. >0 in a 5-min window is actionable.
+resource "aws_cloudwatch_metric_alarm" "ztmf_login_elb_auth_error" {
+  alarm_name          = "ztmf-login-elb-auth-error-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ELBAuthError"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "ALB authenticate-oidc could not complete the IdP token/userinfo exchange (Okta or Entra). Check IdP client secret, endpoints, and ALB egress."
+  alarm_actions       = [aws_sns_topic.ztmf_alarms.arn]
+  ok_actions          = [aws_sns_topic.ztmf_alarms.arn]
+
+  dimensions = {
+    LoadBalancer = aws_lb.ztmf_api.arn_suffix
+  }
+
+  tags = {
+    Name        = "ZTMF Login ELB Auth Error Alarm"
+    Environment = var.environment
+  }
+}
+
+# ELBAuthFailure: the IdP response was REJECTED by the ALB (invalid id_token,
+# issuer/audience mismatch, or missing/invalid authorization code - i.e. a
+# redirect-URI or consent problem at the IdP). >0 in a 5-min window is
+# actionable and tells Batch 2 exactly what to look for in the IdP console.
+resource "aws_cloudwatch_metric_alarm" "ztmf_login_elb_auth_failure" {
+  alarm_name          = "ztmf-login-elb-auth-failure-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ELBAuthFailure"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "ALB authenticate-oidc rejected the IdP response (invalid id_token, issuer/audience mismatch, or missing/invalid code). Check IdP app config: redirect URI, consent, issuer/audience."
+  alarm_actions       = [aws_sns_topic.ztmf_alarms.arn]
+  ok_actions          = [aws_sns_topic.ztmf_alarms.arn]
+
+  dimensions = {
+    LoadBalancer = aws_lb.ztmf_api.arn_suffix
+  }
+
+  tags = {
+    Name        = "ZTMF Login ELB Auth Failure Alarm"
+    Environment = var.environment
+  }
+}

--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -12,6 +12,11 @@ ecs_service_task_count = 1
 entra_enabled = true
 
 
+# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS
+# topic; confirm the AWS subscription email once after first apply. Interim
+# destination — swap for a shared inbox / Slack webhook later.
+alarm_notification_email = "jono@aquia.us"
+
 # TLS cert rotation Lambda
 # ACM ARN sourced from SSM Parameter Store /ztmf/dev/cert-rotation/acm-arn
 enable_cert_rotation_lambda = true

--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -12,9 +12,12 @@ ecs_service_task_count = 1
 entra_enabled = true
 
 
-# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS
-# topic; confirm the AWS subscription email once after first apply. Interim
-# destination — swap for a shared inbox / Slack webhook later.
+# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS topic
+# (confirm the AWS subscription email once after first apply).
+# INTERIM destination only — an individual address used to stand up alerting for
+# the dev Entra pilot. Replace it with a shared team inbox or a Slack webhook
+# before this routing is relied on beyond dev / before prod, so paging never
+# depends on one person being reachable.
 alarm_notification_email = "jono@aquia.us"
 
 # TLS cert rotation Lambda

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -18,6 +18,12 @@ variable "entra_enabled" {
   default     = false
 }
 
+variable "alarm_notification_email" {
+  description = "Email subscribed to the ztmf-alarms SNS topic for login/OIDC alerting. Empty (default) creates the topic and alarms without a subscription so they can land before a destination is finalized; set per-environment in tfvars. For a Slack/PagerDuty endpoint, swap the subscription protocol in monitoring-login-auth.tf."
+  type        = string
+  default     = ""
+}
+
 variable "kion_rotate_schedule_enabled" {
   description = "Enable the daily EventBridge schedule for ztmf-kion-key-rotate. Kion NAT allowlist is in place (CMS-Enterprise/ztmf-misc#174) and real rotation was validated end to end on 2026-04-22, so this defaults to true. Set to false only for temporary maintenance windows when rotation must be paused."
   type        = bool


### PR DESCRIPTION
## Summary
Entra login on dev was failing, and the failure left no signal: the CloudFront -> internal ALB -> ECS path runs native authenticate-oidc at the ALB, and several backend rejection paths returned 401 without logging. This change closes the visibility gaps and instruments the backend login path so a failure is diagnosable in real time. A follow-up commit will add the targeted Entra fix once this instrumentation confirms the exact rejection cause on dev.

## Changes
- Enable ALB access logs on the internal ztmf-api ALB (per-request actions_executed / error_reason) to the existing ztmf-logs-<account>-use1 bucket and rest-api-alb prefix; the bucket policy and SSE-S3 are already in place, so no bucket change is needed.
- Add a ztmf-alarms SNS topic with ELBAuthError / ELBAuthFailure alarms on the ALB -- the first wired alarm route in this repo -- with a configurable email subscription.
- Instrument SessionHandler's 401 branches to log the failing branch, the error, and which claims were present (booleans only; no token values, no email/UPN/PII).

## Test plan
- [x] ALB access_logs.s3.enabled=true; per-request log objects present under rest-api-alb/AWSLogs/... (applied and verified on dev)
- [x] ELBAuthError / ELBAuthFailure alarms route to the ztmf-alarms SNS topic (verified with a synthetic alarm-state test)
- [x] Okta login succeeds end-to-end (verified on dev)
- [x] After this branch deploys to dev, reproduce the Entra login and read the `login: reject branch=...` line to confirm the exact rejection cause

Relates to the login canary follow-ups #376 and CMS-Enterprise/ztmf-ui#443.
