### PR TITLE
Publish compose-test ports instead of host networking so local e2e/integration work on macOS

### DIFF
--- a/backend/compose-test.yml
+++ b/backend/compose-test.yml
@@ -1,5 +1,11 @@
-# Isolated test environment - matches GitHub Actions behavior
-# Uses host networking like CI, fresh database each run, no volumes
+# Isolated test environment - fresh database each run, no volumes.
+# Uses a bridge network with published ports (not host networking) so the
+# host-side test runners work on every platform: emberfall (make test-e2e)
+# reaches the API at localhost:8090 and `go test` (make test-integration)
+# reaches the DB at localhost:54399. Docker Desktop on macOS does not expose
+# `network_mode: host` container ports to the host, so host networking silently
+# broke both targets on Apple Silicon; published ports behave identically on
+# Linux/CI. See CMS-Enterprise/ztmf#384.
 
 services:
   test-db:
@@ -8,7 +14,8 @@ services:
       POSTGRES_DB: ztmf
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: testpass
-    network_mode: host  # Use host network like CI
+    ports:
+      - "54399:54399"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d ztmf -p 54399"]
       interval: 2s
@@ -23,7 +30,7 @@ services:
       dockerfile: Dockerfile
     environment:
       PORT: 8090
-      DB_ENDPOINT: localhost
+      DB_ENDPOINT: test-db  # reach the DB by service name over the compose network
       DB_PORT: 54399
       DB_NAME: ztmf
       DB_USER: admin
@@ -32,7 +39,8 @@ services:
       AUTH_HS256_SECRET: zeroTrust
       AUTH_HEADER_FIELD: Authorization
       ENVIRONMENT: test
-    network_mode: host  # Use host network like CI
+    ports:
+      - "8090:8090"
     volumes:
       - ./_test_data_empire.sql:/app/_test_data_empire.sql:ro
     depends_on:

--- a/backend/compose-test.yml
+++ b/backend/compose-test.yml
@@ -5,7 +5,7 @@
 # reaches the DB at localhost:54399. Docker Desktop on macOS does not expose
 # `network_mode: host` container ports to the host, so host networking silently
 # broke both targets on Apple Silicon; published ports behave identically on
-# Linux/CI. See CMS-Enterprise/ztmf#384.
+# Linux/CI. See issue #384.
 
 services:
   test-db:


### PR DESCRIPTION
> **Note:** In-repo copy of #385 by @voidspooks. Moved from the fork so Snyk and the deploy CI gates can run — those jobs require org secrets unavailable to fork PRs. Commits and authorship are unchanged.
>
> Refs #385

---

The isolated test stack in `backend/compose-test.yml` ran both `test-db` and `test-api` with `network_mode: host`. Host networking bridges container ports onto the host only on native Linux (CI). On Docker Desktop for Mac the containers attach to the Docker VM's network and their ports are never exposed to the macOS host, so both local test targets silently broke on Apple Silicon:

- `make test-e2e`: the host-side emberfall runner could not reach the API at `localhost:8090` — 0 tests ran and every request failed with `connection refused`.
- `make test-integration`: the host-side `go test` could not reach the test DB at `localhost:54399`.

This is the follow-up to #383, which fixed the emberfall *installer*: the runner now installs and runs as a native `Darwin_arm64` binary, but the suite it drives still couldn't connect until this networking issue was resolved.

## Changes

- Drop `network_mode: host` from `test-db` and `test-api`; run them on Compose's default bridge network with published ports (`54399:54399`, `8090:8090`) so the host-side runners reach them on every platform.
- Point `test-api` at the DB by service name (`DB_ENDPOINT: test-db`) instead of `localhost`, since the two services no longer share host loopback.
- Rewrite the header comment (the old "matches GitHub Actions behavior / host network like CI" note was also inaccurate — CI uses `actions-compose.yml` + the emberfall action, not this file).

Published ports behave identically on Linux, and CI is unaffected because it does not use `compose-test.yml`. The seed flow, fresh-DB-per-run, healthcheck, and port numbers are all unchanged.

## Test plan

Verified on an Apple Silicon Mac (macOS 15.3.1, Docker Desktop):

- [x] `make test-e2e` runs the full suite — **Ran: 118, Failed: 0** (was 0 run / 118 failed on `connection refused` before the change)
- [x] Integration tests pass against the seeded test DB reachable at `localhost:54399`
- [x] `docker compose -f compose-test.yml config` validates; host can reach both `localhost:8090` and `localhost:54399` with the stack up
- [x] CI path unchanged — `compose-test.yml` is not referenced by any workflow

Fixes #384
