### PR TITLE
Publish compose-test ports instead of host networking for macOS (rehome of #385)

### DIFF
--- a/backend/compose-test.yml
+++ b/backend/compose-test.yml
@@ -1,5 +1,11 @@
-# Isolated test environment - matches GitHub Actions behavior
-# Uses host networking like CI, fresh database each run, no volumes
+# Isolated test environment - fresh database each run, no volumes.
+# Uses a bridge network with published ports (not host networking) so the
+# host-side test runners work on every platform: emberfall (make test-e2e)
+# reaches the API at localhost:8090 and `go test` (make test-integration)
+# reaches the DB at localhost:54399. Docker Desktop on macOS does not expose
+# `network_mode: host` container ports to the host, so host networking silently
+# broke both targets on Apple Silicon; published ports behave identically on
+# Linux/CI. See CMS-Enterprise/ztmf#384.
 
 services:
   test-db:
@@ -8,7 +14,8 @@ services:
       POSTGRES_DB: ztmf
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: testpass
-    network_mode: host  # Use host network like CI
+    ports:
+      - "54399:54399"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d ztmf -p 54399"]
       interval: 2s
@@ -23,7 +30,7 @@ services:
       dockerfile: Dockerfile
     environment:
       PORT: 8090
-      DB_ENDPOINT: localhost
+      DB_ENDPOINT: test-db  # reach the DB by service name over the compose network
       DB_PORT: 54399
       DB_NAME: ztmf
       DB_USER: admin
@@ -32,7 +39,8 @@ services:
       AUTH_HS256_SECRET: zeroTrust
       AUTH_HEADER_FIELD: Authorization
       ENVIRONMENT: test
-    network_mode: host  # Use host network like CI
+    ports:
+      - "8090:8090"
     volumes:
       - ./_test_data_empire.sql:/app/_test_data_empire.sql:ro
     depends_on:


### PR DESCRIPTION
Rehomes #385 by @voidspooks so CI and Snyk can run against an in-repo branch. Fork-head PRs cannot reach the org secrets Snyk needs. No history was rewritten; the commit is authored by @voidspooks.

Original PR #385 has the review and approval.

## Summary

Follow-up to #383. `compose-test.yml` used `network_mode: host`, which does not publish container ports to the host on Docker Desktop for Mac, so `make test-e2e` and `make test-integration` silently broke on Apple Silicon. Switches to a bridge network with published ports (54399, 8090) and points `test-api` at the DB by service name. Verified 118 passed / 0 failed on both Linux and macOS; CI is unaffected (`compose-test.yml` is referenced by no workflow).

Fixes #384
