### PR TITLE
Map data-center environments to a shared scoring vocabulary (#392)

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -360,6 +360,20 @@ INSERT INTO public.questions VALUES (8016, 'How does your system authenticate an
 INSERT INTO public.questions VALUES (8017, 'What measures detect Force-sensitive individuals or Rebel infiltrators attempting system access?', 'Detail identity verification processes, behavioral analysis, and security screening protocols to identify potential security threats among personnel.', 6, 0) ON CONFLICT DO NOTHING;
 INSERT INTO public.questions VALUES (8018, 'How does your system manage Imperial identity lifecycle from recruitment to retirement?', 'Describe automated identity provisioning, access reviews, and deprovisioning processes for Imperial officers, contractors, and service accounts.', 6, 0) ON CONFLICT DO NOTHING;
 
+-- datacenterenvironments mapping rows for the Imperial (test) environments
+-- (ztmf#392). The migration seeds the real CMS/HHS vocabulary; these identity
+-- rows register the Star Wars environments so the scoring join and the answer
+-- form (both route fismasystems.datacenterenvironment -> scoring_key) resolve.
+-- Not selectable, so the /datacenterenvironments dropdown stays the canonical set.
+INSERT INTO public.datacenterenvironments (datacenterenvironment, category, scoring_key, selectable, ordr) VALUES
+    ('Imperial-Fleet',   'Imperial-Fleet',   'Imperial-Fleet',   FALSE, 0),
+    ('Space-Station',    'Space-Station',    'Space-Station',    FALSE, 0),
+    ('Forest-Moon',      'Forest-Moon',      'Forest-Moon',      FALSE, 0),
+    ('Ground-Assault',   'Ground-Assault',   'Ground-Assault',   FALSE, 0),
+    ('Surveillance-Net', 'Surveillance-Net', 'Surveillance-Net', FALSE, 0),
+    ('Shipyard-RnD',     'Shipyard-RnD',     'Shipyard-RnD',     FALSE, 0)
+ON CONFLICT DO NOTHING;
+
 -- Sample Functions (Imperial Zero Trust Functions) - MUST come before functionoptions
 -- Each datacenterenvironment needs functions with questionid set so FindQuestionsByFismaSystem works
 -- (INNER JOIN functions ON functions.questionid=questions.questionid)

--- a/backend/cmd/api/internal/controller/datacenterenvironments.go
+++ b/backend/cmd/api/internal/controller/datacenterenvironments.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+)
+
+// ListDataCenterEnvironments returns the datacenterenvironment reference list.
+// Open to any authenticated user because it carries no sensitive data and the
+// frontend needs it to build the system-environment dropdown from the backend
+// (ztmf#392) instead of a hardcoded list. Pass selectable_only=true to get only
+// the values offered for new/edited systems.
+//
+//	@Summary	List datacenterenvironment mappings
+//	@Tags		datacenterenvironments
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		selectable_only	query		bool	false	"Only environments offered in the system dropdown"
+//	@Success	200				{object}	apiResponse[[]model.DataCenterEnvironment]
+//	@Failure	500				{object}	apiResponse[any]
+//	@Router		/datacenterenvironments [get]
+func ListDataCenterEnvironments(w http.ResponseWriter, r *http.Request) {
+	input := model.FindDataCenterEnvironmentsInput{}
+
+	if err := decoder.Decode(&input, r.URL.Query()); err != nil {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+
+	envs, err := model.FindDataCenterEnvironments(r.Context(), input)
+	respond(w, r, envs, err)
+}

--- a/backend/cmd/api/internal/migrations/0045datacenterenvironments.go
+++ b/backend/cmd/api/internal/migrations/0045datacenterenvironments.go
@@ -1,0 +1,128 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"create datacenterenvironments mapping table, seed it, rename OPDC, add MAG and data-center-gov function sets",
+		`
+-- ZTMF scores a system by matching its datacenterenvironment against the
+-- functions catalog (functions.datacenterenvironment). That catalog is keyed to
+-- a small, fixed vocabulary. Real inventory values (HHS ScoreCard exports and
+-- other OpDivs) use free-text environment names that are not in it, so the
+-- scoring join returned no functions and those systems scored 0.00 (ztmf#392).
+--
+-- This reference table decouples the value stored on a system (kept untouched so
+-- each OpDiv keeps its own reporting label) from the scoring vocabulary:
+--
+--   datacenterenvironment  the raw value as stored on fismasystems.datacenterenvironment
+--   category               the reporting / dropdown bucket the raw value belongs to
+--   scoring_key            the functions.datacenterenvironment set to score against
+--                          (NULL = not scored, e.g. the legacy DECOMMISSIONED marker)
+--   selectable             TRUE for values offered in the new/edit-system dropdown
+--   ordr                   dropdown ordering
+--
+-- Every scored environment is a first-class function set with its own key, so
+-- scoring_key is an identity mapping today. It stays a distinct column so a
+-- future divergence (e.g. a shared cloud base) can point several environments at
+-- one set by changing data, not code. All agency-specific vocabulary lives in
+-- these rows, never in code, so a new OpDiv or deployment adds rows here.
+
+CREATE TABLE IF NOT EXISTS public.datacenterenvironments (
+    datacenterenvironment VARCHAR(255) PRIMARY KEY,
+    category              VARCHAR(255) NOT NULL,
+    scoring_key           VARCHAR(255),
+    selectable            BOOLEAN NOT NULL DEFAULT FALSE,
+    ordr                  SMALLINT NOT NULL DEFAULT 0
+);
+
+COMMENT ON TABLE public.datacenterenvironments IS 'Maps a system''s raw datacenterenvironment to a reporting category and the functions.datacenterenvironment set used to score it (ztmf#392). Reference data - extend per deployment.';
+
+-- Rename the cryptic OPDC ("Other People''s Data Center") function set to the
+-- self-describing data-center-contractor. Pure key rename: functionids (and every
+-- score that references them) are unchanged. On a fresh local/test database the
+-- functions catalog is empty at migration time and this - like the two copies
+-- below - affects zero rows; the empire seed supplies its own vocabulary.
+UPDATE public.functions SET datacenterenvironment = 'data-center-contractor'
+ WHERE datacenterenvironment = 'OPDC';
+
+-- MAG is a first-class copy of the CMS Azure/MAG question set. It gets its own
+-- functionids so MAG (non-CMS) systems score against it independently; stripping
+-- the CMS-specific wording is a follow-up content edit on these rows. The copy
+-- correlates options by function name, which is unique within an environment.
+INSERT INTO public.functions (function, description, datacenterenvironment, ordr, questionid, pillarid)
+SELECT function, description, 'MAG', ordr, questionid, pillarid
+  FROM public.functions WHERE datacenterenvironment = 'CMS-Cloud-MAG';
+
+INSERT INTO public.functionoptions (functionid, score, optionname, description)
+SELECT newf.functionid, fo.score, fo.optionname, fo.description
+  FROM public.functions newf
+  JOIN public.functions oldf
+    ON oldf.datacenterenvironment = 'CMS-Cloud-MAG'
+   AND newf.datacenterenvironment = 'MAG'
+   AND newf.function = oldf.function
+  JOIN public.functionoptions fo ON fo.functionid = oldf.functionid;
+
+-- data-center-gov starts as a copy of the data-center-contractor (former OPDC)
+-- question set - the HHS ScoreCard base Elizabeth identified. Distinct functionids
+-- let gov and contractor diverge later by editing these rows.
+INSERT INTO public.functions (function, description, datacenterenvironment, ordr, questionid, pillarid)
+SELECT function, description, 'data-center-gov', ordr, questionid, pillarid
+  FROM public.functions WHERE datacenterenvironment = 'data-center-contractor';
+
+INSERT INTO public.functionoptions (functionid, score, optionname, description)
+SELECT newf.functionid, fo.score, fo.optionname, fo.description
+  FROM public.functions newf
+  JOIN public.functions oldf
+    ON oldf.datacenterenvironment = 'data-center-contractor'
+   AND newf.datacenterenvironment = 'data-center-gov'
+   AND newf.function = oldf.function
+  JOIN public.functionoptions fo ON fo.functionid = oldf.functionid;
+
+-- Canonical categories: the values offered in the system dropdown going forward.
+-- Stored value, reporting category, and scoring key are the same (identity).
+INSERT INTO public.datacenterenvironments (datacenterenvironment, category, scoring_key, selectable, ordr) VALUES
+    ('CMS-Cloud-AWS',          'CMS-Cloud-AWS',          'CMS-Cloud-AWS',          TRUE, 10),
+    ('CMS-Cloud-MAG',          'CMS-Cloud-MAG',          'CMS-Cloud-MAG',          TRUE, 20),
+    ('CMSDC',                  'CMSDC',                  'CMSDC',                  TRUE, 30),
+    ('AWS',                    'AWS',                    'AWS',                    TRUE, 40),
+    ('MAG',                    'MAG',                    'MAG',                    TRUE, 50),
+    ('SaaS',                   'SaaS',                   'SaaS',                   TRUE, 60),
+    ('Other',                  'Other',                  'Other',                  TRUE, 70),
+    ('data-center-gov',        'data-center-gov',        'data-center-gov',        TRUE, 80),
+    ('data-center-contractor', 'data-center-contractor', 'data-center-contractor', TRUE, 90)
+ON CONFLICT DO NOTHING;
+
+-- Known raw-value aliases: free-text inventory strings already present on systems
+-- (HHS ScoreCard exports, legacy CMS values). Not selectable - they resolve an
+-- existing system to a category/scoring key but are not offered for new systems.
+-- DECOMMISSIONED is a legacy marker, not an environment: scoring_key NULL leaves
+-- those systems out of scoring (pending cleanup, ztmf#392 follow-up).
+INSERT INTO public.datacenterenvironments (datacenterenvironment, category, scoring_key, selectable, ordr) VALUES
+    ('OPDC',                                         'data-center-contractor', 'data-center-contractor', FALSE, 0),
+    ('Data Center: Gov-Owned, Multi-tenant',         'data-center-gov',        'data-center-gov',        FALSE, 0),
+    ('Data Center: Contractor-Owned, Single-tenant', 'data-center-contractor', 'data-center-contractor', FALSE, 0),
+    ('AWS (incl GovCloud)',                          'AWS',                    'AWS',                    FALSE, 0),
+    ('Azure (Commercial or MAG)',                    'MAG',                    'MAG',                    FALSE, 0),
+    ('Cloud-CMS-AWS',                                'CMS-Cloud-AWS',          'CMS-Cloud-AWS',          FALSE, 0),
+    ('Cloud-CMS-Azure',                              'CMS-Cloud-MAG',          'CMS-Cloud-MAG',          FALSE, 0),
+    ('DECOMMISSIONED',                               'DECOMMISSIONED',         NULL,                     FALSE, 0)
+ON CONFLICT DO NOTHING;
+		`,
+		`
+-- Drop the copied MAG and data-center-gov sets. Their functionoptions must go
+-- first (scores FK to functionoptions). A rollback after live scores have been
+-- re-pointed onto these sets requires re-pointing them back first; this down step
+-- assumes rollback happens before that data surgery.
+DELETE FROM public.functionoptions
+ WHERE functionid IN (SELECT functionid FROM public.functions
+                       WHERE datacenterenvironment IN ('MAG', 'data-center-gov'));
+DELETE FROM public.functions
+ WHERE datacenterenvironment IN ('MAG', 'data-center-gov');
+
+-- Reverse the rename. Assumes data-center-contractor still denotes the single
+-- renamed OPDC set (the state this migration leaves it in).
+UPDATE public.functions SET datacenterenvironment = 'OPDC'
+ WHERE datacenterenvironment = 'data-center-contractor';
+
+DROP TABLE IF EXISTS public.datacenterenvironments;
+		`)
+}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -97,6 +97,8 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/functions", controller.SaveFunction).Methods("POST")
 	router.HandleFunc("/api/v1/functions/{functionid:[0-9]+}", controller.SaveFunction).Methods("PUT")
 
+	router.HandleFunc("/api/v1/datacenterenvironments", controller.ListDataCenterEnvironments).Methods("GET")
+
 	router.HandleFunc("/api/v1/events", controller.GetEvents).Methods("GET")
 
 	router.HandleFunc("/api/v1/systemenrichment/{fisma_uuid:[a-zA-Z0-9-]+}", controller.GetSystemEnrichment).Methods("GET")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1999,3 +1999,32 @@ tests:
     expect:
       status: 403
 
+
+  # datacenterenvironments reference list (ztmf#392). Backend-driven source for
+  # the system-environment dropdown. Open to any authenticated user like opdivs.
+  - url: "http://localhost:8080/api/v1/datacenterenvironments?selectable_only=true"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # Full mapping (selectable + alias rows) also returns to any authed user.
+  - url: http://localhost:8080/api/v1/datacenterenvironments
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # Not admin-gated: an ISSO can read the reference list too.
+  - url: http://localhost:8080/api/v1/datacenterenvironments
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 200

--- a/backend/internal/model/datacenterenvironments.go
+++ b/backend/internal/model/datacenterenvironments.go
@@ -1,0 +1,81 @@
+package model
+
+import (
+	"context"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/jackc/pgx/v5"
+)
+
+// DataCenterEnvironment mirrors a row from the public.datacenterenvironments
+// reference table. It maps the raw value stored on a system to a reporting
+// category and the functions.datacenterenvironment set used to score it, so the
+// scoring vocabulary lives in data rather than code (ztmf#392).
+type DataCenterEnvironment struct {
+	DataCenterEnvironment string `json:"datacenterenvironment" db:"datacenterenvironment"`
+	Category              string `json:"category" db:"category"`
+	// ScoringKey is the functions.datacenterenvironment set this environment is
+	// scored against. NULL means the environment is not scored (e.g. the legacy
+	// DECOMMISSIONED marker), so it is a pointer to distinguish that from "".
+	ScoringKey *string `json:"scoring_key" db:"scoring_key"`
+	Selectable bool    `json:"selectable" db:"selectable"`
+	Ordr       int     `json:"ordr" db:"ordr"`
+}
+
+var dataCenterEnvironmentColumns = []string{"datacenterenvironment", "category", "scoring_key", "selectable", "ordr"}
+
+// FindDataCenterEnvironmentsInput holds optional filters for listing environments.
+type FindDataCenterEnvironmentsInput struct {
+	// SelectableOnly restricts the result to values offered in the system
+	// dropdown (selectable = TRUE). Used by the frontend to build the picker.
+	SelectableOnly *bool `schema:"selectable_only"`
+}
+
+// FindDataCenterEnvironments returns the datacenterenvironments reference rows.
+// The frontend calls it with SelectableOnly to build the system-environment
+// dropdown so that list is backend-driven instead of hardcoded in the UI.
+func FindDataCenterEnvironments(ctx context.Context, input FindDataCenterEnvironmentsInput) ([]*DataCenterEnvironment, error) {
+	sqlb := stmntBuilder.
+		Select(dataCenterEnvironmentColumns...).
+		From("public.datacenterenvironments").
+		OrderBy("ordr, category")
+
+	if input.SelectableOnly != nil && *input.SelectableOnly {
+		sqlb = sqlb.Where("selectable = ?", true)
+	}
+
+	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[DataCenterEnvironment])
+}
+
+// dataCenterEnvironmentExists reports whether raw is a known system environment
+// value (any row in the mapping table). Used to validate fismasystems writes
+// against the reference data instead of a compiled-in vocabulary.
+func dataCenterEnvironmentExists(ctx context.Context, raw string) (bool, error) {
+	return existsIn(ctx, "datacenterenvironment", raw)
+}
+
+// isValidScoringKey reports whether key is used as a scoring target by at least
+// one mapping row, i.e. a legal value for functions.datacenterenvironment. Used
+// to validate functions catalog writes.
+func isValidScoringKey(ctx context.Context, key string) (bool, error) {
+	return existsIn(ctx, "scoring_key", key)
+}
+
+// existsIn runs a single-column EXISTS check against the mapping table. col is a
+// trusted internal constant (never user input), val is bound as a parameter.
+func existsIn(ctx context.Context, col, val string) (bool, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return false, trapError(err)
+	}
+	defer conn.Release()
+
+	var exists bool
+	err = conn.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM public.datacenterenvironments WHERE "+col+" = $1)",
+		val).Scan(&exists)
+	if err != nil {
+		return false, trapError(err)
+	}
+	return exists, nil
+}

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -154,6 +154,20 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 		return nil, err
 	}
 
+	// datacenterenvironment is validated against the reference table (ztmf#392)
+	// rather than a compiled-in list, so the accepted vocabulary is data. The
+	// check lives here rather than in the pure validate() because it needs the
+	// request context for the DB lookup.
+	if f.DataCenterEnvironment != nil {
+		ok, err := dataCenterEnvironmentExists(ctx, *f.DataCenterEnvironment)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, &InvalidInputError{data: map[string]any{"datacenterenvironment": *f.DataCenterEnvironment}}
+		}
+	}
+
 	if f.FismaSystemID == 0 {
 		// INSERT - exclude decommissioned/reactivation audit fields. opdiv_id
 		// is NOT NULL on the table. Callers may pass an explicit OpDivID; if
@@ -435,9 +449,8 @@ func (f *FismaSystem) validate() error {
 		err.data["issoemail"] = *f.ISSOEmail
 	}
 
-	if f.DataCenterEnvironment != nil && !isValidDataCenterEnvironment(*f.DataCenterEnvironment) {
-		err.data["datacenterenvironment"] = *f.DataCenterEnvironment
-	}
+	// datacenterenvironment is validated against the datacenterenvironments
+	// reference table in Save(), which has the context needed for the lookup.
 
 	if len(err.data) > 0 {
 		return &err

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -68,6 +68,20 @@ func FindFismaSystems(ctx context.Context, input FindFismaSystemsInput) ([]*Fism
 
 	c := []string{"fismasystems.fismasystemid as fismasystemid"}
 	c = append(c, fismaSystemColumns[1:]...)
+
+	// Resolve a single ISSO display name for the systems table. HHS systems carry
+	// isso_name directly; CMS systems carry only issoemail, which maps to the
+	// ISSO's user record - so COALESCE yields one populated name column for both
+	// populations without a per-row lookup. email is unique, so the correlated
+	// subquery returns at most one row. Read-only: the write path never sets
+	// isso_name from this, so a resolved name is never persisted back. Applied to
+	// the list only; the single-system GET returns the stored value unchanged.
+	for i := range c {
+		if c[i] == "isso_name" {
+			c[i] = "COALESCE(fismasystems.isso_name, " +
+				"(SELECT fullname FROM users WHERE LOWER(email) = LOWER(fismasystems.issoemail) LIMIT 1)) AS isso_name"
+		}
+	}
 	sqlb := stmntBuilder.Select(c...).From("fismasystems")
 
 	// Filter decommissioned systems

--- a/backend/internal/model/functions.go
+++ b/backend/internal/model/functions.go
@@ -69,6 +69,17 @@ func (f *Function) Save(ctx context.Context) (*Function, error) {
 		return nil, err
 	}
 
+	// A function's datacenterenvironment must be a scoring key known to the
+	// datacenterenvironments mapping (ztmf#392). Checked here rather than in the
+	// pure validate() because it needs the request context for the DB lookup.
+	ok, err := isValidScoringKey(ctx, f.DataCenterEnvironment)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, &InvalidInputError{data: map[string]any{"datacenterenvironment": f.DataCenterEnvironment}}
+	}
+
 	if f.FunctionID == 0 {
 		sqlb = stmntBuilder.
 			Insert("functions").
@@ -101,9 +112,8 @@ func (f *Function) validate() error {
 		err.data["description"] = ""
 	}
 
-	if !isValidDataCenterEnvironment(f.DataCenterEnvironment) {
-		err.data["datacenterenvironment"] = f.DataCenterEnvironment
-	}
+	// datacenterenvironment is validated against the datacenterenvironments
+	// reference table in Save(), which has the context needed for the lookup.
 
 	if f.QuestionID != nil && !isValidIntID(f.QuestionID) {
 		err.data["questionid"] = f.QuestionID

--- a/backend/internal/model/questions.go
+++ b/backend/internal/model/questions.go
@@ -69,12 +69,17 @@ func FindQuestionByID(ctx context.Context, questionID int32) (*Question, error) 
 // FindQuestionsByFismaSystem joins questions with functions to return questions relevant to the fismasystem as determined by the datacenterenvironment.
 // It is used by all users to list questions relevant to the specified fisma system
 func FindQuestionsByFismaSystem(ctx context.Context, fismaSystemID int32) ([]*Question, error) {
+	// The system's raw datacenterenvironment is resolved to a scoring vocabulary
+	// through the datacenterenvironments mapping (ztmf#392); functions are matched
+	// on that key. This is the same indirection the scoring aggregate uses, so the
+	// answer form an ISSO sees matches the functions a system is scored against.
 	sqlb := stmntBuilder.
 		Select("questions.questionid, question, notesprompt, questions.ordr, pillars.pillarid, pillars.pillar, pillars.ordr, functionid, function, description").
 		From("questions").
 		InnerJoin("pillars ON pillars.pillarid=questions.pillarid").
 		InnerJoin("functions ON functions.questionid=questions.questionid").
-		InnerJoin("fismasystems ON fismasystems.datacenterenvironment=functions.datacenterenvironment AND fismasystems.fismasystemid=?", fismaSystemID).
+		InnerJoin("datacenterenvironments dce ON dce.scoring_key=functions.datacenterenvironment").
+		InnerJoin("fismasystems ON fismasystems.datacenterenvironment=dce.datacenterenvironment AND fismasystems.fismasystemid=?", fismaSystemID).
 		OrderBy("pillars.ordr, questions.ordr ASC")
 
 	return query(ctx, sqlb, func(row pgx.CollectableRow) (*Question, error) {

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -682,7 +682,13 @@ expected AS (
     FROM scored_pairs sp
     INNER JOIN fismasystems fs ON fs.fismasystemid = sp.fismasystemid
     INNER JOIN datacalls dc    ON dc.datacallid    = sp.datacallid
-    INNER JOIN functions f ON f.datacenterenvironment = fs.datacenterenvironment
+    -- Resolve the system's raw datacenterenvironment to its scoring vocabulary
+    -- via the mapping table (ztmf#392), then match functions on that key. A raw
+    -- value with no mapping row, or one whose scoring_key is NULL (e.g. the
+    -- DECOMMISSIONED marker), matches no functions and is excluded from scoring,
+    -- exactly as an unrecognized value was under the old direct join.
+    INNER JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+    INNER JOIN functions f ON f.datacenterenvironment = dce.scoring_key
     INNER JOIN questions q ON q.questionid = f.questionid
     INNER JOIN pillars p   ON p.pillarid   = q.pillarid
     %s

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -929,3 +929,81 @@ func TestFindScoresISSOScopeRetainsAuditFieldsIntegration(t *testing.T) {
 	assert.Equal(t, krennicUUID, found.LastEditedBy.UserID)
 	assert.Equal(t, "ISSO", found.LastEditedBy.Role)
 }
+
+// TestScoringResolvesEnvironmentAliasIntegration proves the ztmf#392 mechanism:
+// a system whose raw datacenterenvironment is NOT itself a functions catalog key
+// still scores, because the datacenterenvironments mapping redirects it to a
+// scoring_key. The redirect is transparent - routing an already-scored system
+// through an alias row that points at the same scoring_key yields the identical
+// aggregate it had under its real environment. This is the exact failure mode
+// behind the HHS 0.00 scores (free-text env values absent from the functions
+// catalog); before #392 the direct join returned nothing for such a system.
+func TestScoringResolvesEnvironmentAliasIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// Pick any scored system whose environment maps to a non-null scoring_key.
+	var sysID int32
+	var realEnv, scoringKey string
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT fs.fismasystemid, fs.datacenterenvironment, dce.scoring_key
+		FROM scores s
+		JOIN fismasystems fs           ON fs.fismasystemid = s.fismasystemid
+		JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		WHERE dce.scoring_key IS NOT NULL
+		LIMIT 1
+	`).Scan(&sysID, &realEnv, &scoringKey),
+		"need at least one scored, mapped system to alias")
+
+	// Baseline: the aggregate the system produces under its real environment.
+	base, err := FindScoresAggregate(ctx, FindScoresInput{
+		FismaSystemID:  &sysID,
+		IncludePillars: boolPtr(true),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, base, "baseline aggregate expected for the chosen system")
+
+	const alias = "integration_test_alias_env" // deliberately not a functions key
+
+	// Register the alias -> same scoring_key, and point the system at it.
+	_, err = conn.Exec(ctx, `
+		INSERT INTO datacenterenvironments (datacenterenvironment, category, scoring_key, selectable, ordr)
+		VALUES ($1, $1, $2, false, 0)
+		ON CONFLICT (datacenterenvironment) DO UPDATE SET scoring_key = EXCLUDED.scoring_key
+	`, alias, scoringKey)
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, `UPDATE fismasystems SET datacenterenvironment = $1 WHERE fismasystemid = $2`, alias, sysID)
+	require.NoError(t, err)
+
+	// Always restore the shared seed so other tests see the original env.
+	defer func() {
+		_, _ = conn.Exec(ctx, `UPDATE fismasystems SET datacenterenvironment = $1 WHERE fismasystemid = $2`, realEnv, sysID)
+		_, _ = conn.Exec(ctx, `DELETE FROM datacenterenvironments WHERE datacenterenvironment = $1`, alias)
+	}()
+
+	// Guard: the alias value must genuinely be absent from the functions
+	// catalog, otherwise the old direct join would have matched it and the
+	// test would prove nothing about the mapping indirection.
+	var directMatches int
+	require.NoError(t, conn.QueryRow(ctx,
+		`SELECT count(*) FROM functions WHERE datacenterenvironment = $1`, alias).Scan(&directMatches))
+	require.Zero(t, directMatches, "alias must not be a functions.datacenterenvironment value")
+
+	// Under the alias the aggregate must still be populated, and because the
+	// alias resolves to the same scoring_key, the score must be unchanged.
+	aliased, err := FindScoresAggregate(ctx, FindScoresInput{
+		FismaSystemID:  &sysID,
+		IncludePillars: boolPtr(true),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, aliased, "aliased env must still score via the mapping (ztmf#392)")
+	require.Len(t, aliased, len(base), "same system + scores must yield the same number of aggregate rows")
+	assert.InDelta(t, base[0].SystemScore, aliased[0].SystemScore, 1e-9,
+		"an alias pointing at the same scoring_key must not change the score")
+}

--- a/backend/internal/model/validations.go
+++ b/backend/internal/model/validations.go
@@ -23,17 +23,6 @@ var roles = map[string]interface{}{
 	"ISSM":                 nil, // system-scoped via users_fismasystems
 }
 
-var datacenterenvironments = map[string]interface{}{
-	"Other":          nil,
-	"SaaS":           nil,
-	"CMS-Cloud-AWS":  nil,
-	"CMSDC":          nil,
-	"CMS-Cloud-MAG":  nil,
-	"AWS":            nil,
-	"OPDC":           nil,
-	"DECOMMISSIONED": nil,
-}
-
 var rgxUUID = regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
 var rgxUUIDNoDashes = regexp.MustCompile("^[a-fA-F0-9]{32}$")
 var rgxDash = regexp.MustCompile("-+")
@@ -55,11 +44,6 @@ func isValidUUID(uuid string) bool {
 		return rgxUUIDNoDashes.MatchString(uuid)
 	}
 	return rgxUUID.MatchString(uuid)
-}
-
-func isValidDataCenterEnvironment(d string) bool {
-	_, ok := datacenterenvironments[d]
-	return ok
 }
 
 func isValidIntID(ID any) bool {

--- a/backend/internal/model/validations_test.go
+++ b/backend/internal/model/validations_test.go
@@ -84,31 +84,6 @@ func TestIsValidUUID(t *testing.T) {
 	}
 }
 
-func TestIsValidDataCenterEnvironment(t *testing.T) {
-	tests := []struct {
-		name string
-		env  string
-		want bool
-	}{
-		{"AWS is valid", "AWS", true},
-		{"SaaS is valid", "SaaS", true},
-		{"CMS-Cloud-AWS is valid", "CMS-Cloud-AWS", true},
-		{"CMSDC is valid", "CMSDC", true},
-		{"CMS-Cloud-MAG is valid", "CMS-Cloud-MAG", true},
-		{"Other is valid", "Other", true},
-		{"OPDC is valid", "OPDC", true},
-		{"DECOMMISSIONED is valid", "DECOMMISSIONED", true},
-		{"lowercase aws is invalid", "aws", false},
-		{"empty is invalid", "", false},
-		{"unknown is invalid", "GCP", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isValidDataCenterEnvironment(tt.env))
-		})
-	}
-}
-
 func TestIsValidIntID(t *testing.T) {
 	tests := []struct {
 		name string

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -38,6 +38,16 @@ components:
         error:
           type: string
       type: object
+    controller.apiResponse-array_model_DataCenterEnvironment:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/model.DataCenterEnvironment'
+          type: array
+          uniqueItems: false
+        error:
+          type: string
+      type: object
     controller.apiResponse-array_model_Event:
       properties:
         data:
@@ -259,6 +269,23 @@ components:
           type: string
         deadline:
           type: string
+      type: object
+    model.DataCenterEnvironment:
+      properties:
+        category:
+          type: string
+        datacenterenvironment:
+          type: string
+        ordr:
+          type: integer
+        scoring_key:
+          description: |-
+            ScoringKey is the functions.datacenterenvironment set this environment is
+            scored against. NULL means the environment is not scored (e.g. the legacy
+            DECOMMISSIONED marker), so it is a pointer to distinguish that from "".
+          type: string
+        selectable:
+          type: boolean
       type: object
     model.Event:
       properties:
@@ -890,6 +917,32 @@ paths:
       summary: Get the latest data call
       tags:
       - datacalls
+  /datacenterenvironments:
+    get:
+      parameters:
+      - description: Only environments offered in the system dropdown
+        in: query
+        name: selectable_only
+        schema:
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-array_model_DataCenterEnvironment'
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: List datacenterenvironment mappings
+      tags:
+      - datacenterenvironments
   /events:
     get:
       parameters:


### PR DESCRIPTION
## What and why

HHS inventory systems were scoring 0.00. The scoring engine matches a system to its Zero Trust functions by an exact `datacenterenvironment` string (`functions.datacenterenvironment = fismasystems.datacenterenvironment`). The functions catalog is keyed to a small fixed vocabulary, but real inventory values (for example `Data Center: Gov-Owned, Multi-tenant`, `AWS (incl GovCloud)`) are free text and absent from it, so the join returned no functions and roughly 69% of HHS systems scored 0.00.

Closes #392.

## Approach

Option B from the issue: leave each system's raw `datacenterenvironment` untouched (every OpDiv keeps its own reporting label) and add a reference table that maps the raw value to the scoring vocabulary.

New table `public.datacenterenvironments`:

- `datacenterenvironment` (PK) - the raw value stored on a system
- `category` - the reporting / dropdown bucket
- `scoring_key` - the `functions.datacenterenvironment` set to score against (NULL = not scored, e.g. the legacy DECOMMISSIONED marker)
- `selectable` - offered in the new/edit-system dropdown
- `ordr` - dropdown order

The scoring aggregate and the answer-form query both resolve a system's raw value through this table via `scoring_key` instead of matching functions directly, so a value that is not itself a catalog key still scores.

Every scored environment is a first-class function set with its own key, so `scoring_key` is an identity mapping today. The migration:

- renames the cryptic `OPDC` ("Other People's Data Center") set to `data-center-contractor` - a pure key rename, so its functionids and every score referencing them are unchanged.
- adds `MAG` (a copy of the CMS Azure/MAG set) and `data-center-gov` (a copy of the OPDC set) as first-class sets, so those environments score independently and can diverge later by editing data - de-CMS the MAG wording, drop SaaS's inapplicable questions, gov-vs-contractor tweaks - with no further migration.

`scoring_key` stays a distinct column so a future divergence can still point several environments at one set by changing data, not code.

## Category set

Matches the business owner's decision: keep `CMS-Cloud-AWS`, `CMS-Cloud-MAG`, `CMSDC`; generic `AWS`, `MAG`, `SaaS`, `Other`; and `data-center-gov` + `data-center-contractor` (both built on the former OPDC/HHS ScoreCard question base today).

## Changes

- `migrations/0045datacenterenvironments.go` - create + seed the table, rename OPDC, add the MAG and data-center-gov sets
- `scores.go`, `questions.go` - route both env joins through `scoring_key`
- `controller/datacenterenvironments.go` + router - `GET /api/v1/datacenterenvironments` so the UI environment dropdown is backend-driven (`selectable_only`)
- `datacenterenvironments.go` model + DB-backed validation in `fismasystems.Save` / `functions.Save`
- `validations.go` - removed the hardcoded vocabulary map
- `openapi.yaml` regenerated

## Existing data (companion cleanup, not in this PR)

This PR is the schema + code. On an environment that already has scores, the schema change alone is not enough: measured on a full local CMS+HHS dataset, ~78% of score rows reference a different env's functionids than the system now scores against (a pre-existing scatter, present in CMS data too), so they would render as "Not Assessed" until realigned. A separate, idempotent re-point script moves each such score to the matching option in its system's own set (same function, same score - lossless, because the option sets are byte-identical across envs). It is run manually per environment after a snapshot, matching the HHS load's prod discipline.

Validated end to end on real local data:
- re-point: 120,935 rows realigned, 0 ambiguous, 0 unmatchable
- HCAS (an HHS system that showed 0.00) now returns 3.47 "Advanced" with a full pillar breakdown through the live API
- 988 HHS systems in one data call now spread across all four tiers (Traditional through Optimal) instead of collapsing to Not Assessed

## Testing

- `make test-unit`, `make test-integration`, `make test-e2e` all pass (emberfall 132/132).
- Integration test proves an aliased environment (a raw value that is not a functions key) scores identically to its real environment through the mapping.
- The all-aggregate invariant test iterates every seeded system through the rewritten join, confirming no scoring regression.

## Follow-ups (tracked separately)

- The 7 new FY25 HHS questions need functions authored in each scoring env before they score.
- `DECOMMISSIONED` (7 systems) is a legacy marker, not an environment - small env-value cleanup.
- Frontend (ztmf-ui#449): backend-driven dropdown + re-key pillar filtering to the category.

## Also in this PR: ISSO name for the systems table

The main systems table read `issoemail` for its ISSO column, so HHS systems (which carry `isso_name`, not email) rendered blank. The list query now returns `COALESCE(isso_name, the ISSO user's fullname resolved by issoemail)`, giving one populated name column for both CMS and HHS in a single query with no per-row lookup. Read-only in the list; the single-system GET and the write path are unchanged, so no resolved value is persisted back.

Follow-up ztmf#395 covers turning the other HHS system attributes (FIPS, system type, cloud fields, etc.) into canonical validated select boxes; they ship as free-text fields for now.
