### PR TITLE
feat(datacalls): resolve current/latest by deadline, not datacallid

### DIFF
--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -22,14 +22,18 @@ opDivAdminHeaders: &opDivAdminHeaders
 opDivReadonlyHeaders: &opDivReadonlyHeaders
   authorization: "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6Im9wZGl2LnJlYWRvbmx5QGVtcGlyZS50ZXN0In0.enezNI1lnuNFcXzcxZqm0CTalZfbOV40dolVjoFxnII"
 
-# Data definitions using YAML anchors
+# Data definitions using YAML anchors.
+# The deadline is intentionally far-future — beyond the empire seed's
+# furthest-out call (Audit Fields Smoke Cycle, 2099-12-31) — so this
+# test-created call is the one GET /datacalls/latest returns. As of #393,
+# "latest"/"current" is the max-deadline call, not the max datacallid.
 dataCallData: &dataCallData
-  datacall: "FY2025 Q1"
-  deadline: "2025-03-31T17:59:59Z"
+  datacall: "FY2100 ZTM"
+  deadline: "2100-03-31T17:59:59Z"
 
 updatedDataCallData: &updatedDataCallData
-  datacall: "FY2025 Q1"
-  deadline: "2025-03-31T17:59:59Z"
+  datacall: "FY2100 ZTM"
+  deadline: "2100-03-31T17:59:59Z"
 
 fismaSystemData: &fismaSystemData
   fismauid: "12345678-ABCD-4321-AFAB-123456789ABC"

--- a/backend/internal/model/datacalls.go
+++ b/backend/internal/model/datacalls.go
@@ -53,7 +53,7 @@ func (d *DataCall) Save(ctx context.Context) (*DataCall, error) {
 func FindDataCalls(ctx context.Context) ([]*DataCall, error) {
 	sqlb := stmntBuilder.Select(dataCallColumns...).
 		From("datacalls").
-		OrderBy("datecreated DESC")
+		OrderBy("deadline DESC", "datacallid DESC")
 
 	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[DataCall])
 }
@@ -68,24 +68,27 @@ func FindDataCallByID(ctx context.Context, dataCallID int32) (*DataCall, error) 
 }
 
 func findPreviousDataCall(dataCallID int32) (*DataCall, error) {
-	// find the *previous* datacall
-	// using dataCallID-1 would not suffice because it could have been deleted
+	// find the *previous* datacall by deadline (not datacallid): once historical
+	// calls are loaded, a backfilled year can out-id the real prior call, so
+	// ordering by datacallid would pick the wrong "previous" for score rollover.
 	prevDcSqlb := stmntBuilder.
 		Select(dataCallColumns...).
 		From("datacalls").
 		Where("datacallid!=?", dataCallID).
-		OrderBy("datacallid DESC"). // descending because the primary key is serial auto-incrementing
+		OrderBy("deadline DESC", "datacallid DESC").
 		Limit(1)
 
 	return queryRow(context.TODO(), prevDcSqlb, pgx.RowToStructByName[DataCall])
 }
 
 func FindLatestDataCall(ctx context.Context) (*DataCall, error) {
-	// Find the latest datacall by sorting on datacallid in descending order
+	// The current/latest datacall is the one with the furthest-out deadline
+	// (datacallid DESC only as a tiebreak): the annual cadence is deadline-driven,
+	// and historical loads can carry a higher datacallid than the real current call.
 	sqlb := stmntBuilder.
 		Select(dataCallColumns...).
 		From("datacalls").
-		OrderBy("datacallid DESC"). // descending because the primary key is serial auto-incrementing
+		OrderBy("deadline DESC", "datacallid DESC").
 		Limit(1)
 
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[DataCall])

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -282,28 +282,30 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Release()
 
-	// Insert two datacalls explicitly ordered so copyPreviousScores'
-	// "latest-1 is previous" logic finds the right one. Each row gets
-	// a unique nano-precision suffix so reruns don't collide on the
-	// UNIQUE(datacall) constraint, and the integrationTestPrefix makes
-	// them discoverable by the sweep no matter how the test exits.
+	// Insert two datacalls so copyPreviousScores' "previous is the next call
+	// back" logic finds the right one. findPreviousDataCall now orders by
+	// deadline (see datacalls.go), so both deadlines must beat every seed
+	// datacall (the empire seed's furthest-out is 2099-12-31) with newDC later
+	// than prevDC; then prevDC is the unambiguous previous relative to newDC.
+	// datecreated no longer affects the ordering. Each row gets a unique
+	// nano-precision suffix so reruns don't collide on the UNIQUE(datacall)
+	// constraint, and the integrationTestPrefix makes them discoverable by the
+	// sweep no matter how the test exits.
 	var prevDC, newDC int32
-	prevTimestamp := time.Now().Add(-2 * time.Hour)
-	newTimestamp := time.Now().Add(-1 * time.Hour)
 	suffix := time.Now().UnixNano()
 
 	err = conn.QueryRow(ctx, `
 		INSERT INTO datacalls (datacall, datecreated, deadline)
-		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
+		VALUES ($1, NOW(), '2100-01-01T00:00:00Z'::timestamptz)
 		RETURNING datacallid
-	`, fmt.Sprintf("%sprev_%d", integrationTestPrefix, suffix), prevTimestamp).Scan(&prevDC)
+	`, fmt.Sprintf("%sprev_%d", integrationTestPrefix, suffix)).Scan(&prevDC)
 	require.NoError(t, err)
 
 	err = conn.QueryRow(ctx, `
 		INSERT INTO datacalls (datacall, datecreated, deadline)
-		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
+		VALUES ($1, NOW(), '2101-01-01T00:00:00Z'::timestamptz)
 		RETURNING datacallid
-	`, fmt.Sprintf("%snew_%d", integrationTestPrefix, suffix), newTimestamp).Scan(&newDC)
+	`, fmt.Sprintf("%snew_%d", integrationTestPrefix, suffix)).Scan(&newDC)
 	require.NoError(t, err)
 
 	// Pick a (fismasystemid, functionoptionid) that already references
@@ -348,6 +350,58 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, afterCount,
 		"copyPreviousScores must carry the marker (system, functionoption) into the new datacall")
+}
+
+// TestFindLatestDataCallByDeadlineIntegration verifies "latest" resolves by
+// deadline, not datacallid: a call inserted later (higher serial id) but with
+// an earlier deadline must NOT win over an earlier-inserted call with a
+// further-out deadline. This is the historical-load regression from #393 - a
+// re-imported past year can out-id the real current call.
+func TestFindLatestDataCallByDeadlineIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	suffix := time.Now().UnixNano()
+
+	// Insert the further-out deadline FIRST so it gets the LOWER datacallid.
+	// Both deadlines beat every seed datacall (empire seed's furthest-out is
+	// 2099-12-31), so this call is the global latest by deadline.
+	var laterDeadlineID int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), '2102-01-01T00:00:00Z'::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%slatest_deadline_%d", integrationTestPrefix, suffix)).Scan(&laterDeadlineID)
+	require.NoError(t, err)
+
+	// Insert an earlier deadline SECOND so it gets the HIGHER datacallid - the
+	// row that would wrongly win under datacallid ordering.
+	var higherIDEarlierDeadline int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), '2100-06-01T00:00:00Z'::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%shigher_id_%d", integrationTestPrefix, suffix)).Scan(&higherIDEarlierDeadline)
+	require.NoError(t, err)
+
+	require.Greater(t, higherIDEarlierDeadline, laterDeadlineID,
+		"second insert must have the higher datacallid for this test to be meaningful")
+
+	latest, err := FindLatestDataCall(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, laterDeadlineID, latest.DataCallID,
+		"FindLatestDataCall must return the furthest-out deadline, not the highest datacallid")
+	assert.NotEqual(t, higherIDEarlierDeadline, latest.DataCallID,
+		"the higher-datacallid/earlier-deadline call must not be treated as latest")
 }
 
 func boolPtr(b bool) *bool { return &b }


### PR DESCRIPTION
In-repo rehome of #396 by @voidspooks (fork PR), moved so the org-secret CI gates (Snyk, Infrastructure/Deploy) can run — they can't on a fork PR. Commit pushed unchanged; authorship preserved.

Part of #393 (the backend half; paired with the ztmf-ui PR for the picker/chip). The data-consolidation script (items 3-4 of the ticket) is a separate follow-up.

## Problem
"Current"/"latest" resolved by `datacallid`: `FindLatestDataCall` and the `FindDataCalls` list ordered by creation/id. A re-imported historical data call can be assigned a higher serial id than the real current call, so once the HHS historical load lands it would hijack the default/current view.

## Changes
- `FindLatestDataCall`: order by `deadline DESC` (`datacallid DESC` only as a tiebreak). This also fixes `GET /api/v1/datacalls/latest`.
- `FindDataCalls`: same ordering, so the list the UI renders already agrees with "latest".
- `findPreviousDataCall`: same ordering, so `copyPreviousScores`' rollover points at the true prior annual call rather than a high-id backfill. (Scope-adjacent, but the same bug in the rollover path — called out in the ticket discussion.)
- Integration test asserting a higher-`datacallid`/earlier-`deadline` call is **not** treated as latest, and updated the `copyPreviousScores` fixtures (which leaned on id ordering) to pin deadline ordering.

No schema change — `deadline` already exists on `datacalls` (and is `NOT NULL`, so `ORDER BY deadline DESC` has no NULL-ordering hazard).

## Testing
- `go build ./...`, `go vet`, `go test -short ./...` green (in the pinned `golang:1.25.11` container; host has no Go).
- Full `internal/model` integration suite green against a real Postgres, including the new `TestFindLatestDataCallByDeadlineIntegration`. The deadline tie-break and the backfill-conflict scenario were independently re-verified against a live Postgres.

## Follow-up note for #393 items 3-4 (historical-load consolidation)
`findPreviousDataCall` now resolves to the global latest by deadline excluding the given id. The consolidation/historical-load script must therefore **not** insert backfilled rows via `DataCall.Save()`, which fires `copyPreviousScores` and would roll current scores backward into a historical row. Reassign scores/junction rows directly instead.

Refs #393. Original contribution by @voidspooks.
