### PR TITLE
feat(fismasystems): per-system target maturity tier + justification (#398 MVP)

### DIFF
--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -233,6 +233,38 @@ func TestSaveScore_ISSONotAssignedForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// --- SaveFismaSystemTargetMaturity (#398) ---
+
+func TestSaveFismaSystemTargetMaturity_ReadonlyAdminForbidden(t *testing.T) {
+	body := jsonBody(t, map[string]any{
+		"target_maturity_tier":          "Advanced",
+		"target_maturity_justification": "should never write",
+	})
+	r := httptest.NewRequest("PUT", "/api/v1/fismasystems/1/target-maturity", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = mux.SetURLVars(r, map[string]string{"fismasystemid": "1"})
+	r = withUser(r, readonlyAdmin)
+	w := httptest.NewRecorder()
+
+	SaveFismaSystemTargetMaturity(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestSaveFismaSystemTargetMaturity_ISSONotAssignedForbidden(t *testing.T) {
+	body := jsonBody(t, map[string]any{
+		"target_maturity_tier":          "Advanced",
+		"target_maturity_justification": "should never write",
+	})
+	r := httptest.NewRequest("PUT", "/api/v1/fismasystems/999/target-maturity", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = mux.SetURLVars(r, map[string]string{"fismasystemid": "999"})
+	r = withUser(r, issoUser)
+	w := httptest.NewRecorder()
+
+	SaveFismaSystemTargetMaturity(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 // --- ListScores ---
 
 func TestListScores_ReadonlyAdminAllowed(t *testing.T) {

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -381,3 +381,70 @@ func ReactivateFismaSystem(w http.ResponseWriter, r *http.Request) {
 
 	respondOK(w, system)
 }
+
+// SaveFismaSystemTargetMaturity records a system's risk-based target maturity
+// tier and justification (#398). Unlike the full-system PUT (admin only), this
+// is writable by the ISSO/ISSM assigned to the system - it is the one field
+// pair they own. Admin-tier writers stay OpDiv-scoped via
+// guardManageFismaSystem, mirroring the scores write path.
+//
+//	@Summary	Set a system's target maturity tier and justification
+//	@Tags		fismasystems
+//	@Accept		json
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		fismasystemid	path		int							true	"FISMA system ID"
+//	@Param		body			body		model.TargetMaturityInput	true	"Target tier (Initial, Advanced, or Optimal) and required justification"
+//	@Success	200				{object}	apiResponse[model.FismaSystem]
+//	@Failure	400				{object}	apiResponse[any]
+//	@Failure	403				{object}	apiResponse[any]
+//	@Failure	404				{object}	apiResponse[any]
+//	@Failure	500				{object}	apiResponse[any]
+//	@Router		/fismasystems/{fismasystemid}/target-maturity [put]
+func SaveFismaSystemTargetMaturity(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+
+	vars := mux.Vars(r)
+	fismaSystemIDStr, ok := vars["fismasystemid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	var fismaSystemID int32
+	fmt.Sscan(fismaSystemIDStr, &fismaSystemID)
+
+	// Same gate shape as SaveScore: read-only tiers never write; non-admins
+	// must be assigned to the system; admin tiers are OpDiv-scoped.
+	if authdUser.IsReadOnlyAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+	if !authdUser.IsAdmin() && !authdUser.IsAssignedFismaSystem(fismaSystemID) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+	if authdUser.IsAdmin() {
+		if _, err := guardManageFismaSystem(r.Context(), authdUser, fismaSystemID); err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+	}
+
+	var input model.TargetMaturityInput
+	if err := getJSON(r.Body, &input); err != nil {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+	input.FismaSystemID = fismaSystemID
+
+	system, err := model.SaveTargetMaturity(r.Context(), input)
+	if err != nil {
+		log.Println(err)
+		respond(w, r, nil, err)
+		return
+	}
+
+	respondOK(w, system)
+}

--- a/backend/cmd/api/internal/migrations/0046targetmaturity.go
+++ b/backend/cmd/api/internal/migrations/0046targetmaturity.go
@@ -1,0 +1,27 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add target maturity tier and justification to fismasystems",
+		`
+-- Risk-based target maturity level per system (#398, GAO audit response).
+-- Stored as the tier NAME, not a CISA stage number: the app's internal score
+-- scale is 1-5 and Tier() maps 3.10-4.09 to Advanced, so a raw integer target
+-- (e.g. 3) must never be compared against systemscore directly. Storing the
+-- name makes tier-vs-tier the only expressible comparison.
+-- Nullable on purpose: NULL means "no ISSO has asserted a target yet" and the
+-- UI presents the Advanced default. No backfill - fabricating an explicit
+-- assertion for every system would defeat the audit purpose.
+
+ALTER TABLE public.fismasystems
+  ADD COLUMN IF NOT EXISTS target_maturity_tier varchar(20)
+    CONSTRAINT fismasystems_target_maturity_tier_check
+    CHECK (target_maturity_tier IN ('Initial', 'Advanced', 'Optimal')),
+  ADD COLUMN IF NOT EXISTS target_maturity_justification varchar(1000);
+		`,
+		`
+ALTER TABLE public.fismasystems
+  DROP COLUMN IF EXISTS target_maturity_tier,
+  DROP COLUMN IF EXISTS target_maturity_justification;
+		`)
+}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -52,6 +52,8 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}", controller.SaveFismaSystem).Methods("PUT")
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}", controller.DeleteFismaSystem).Methods("DELETE")
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/reactivate", controller.ReactivateFismaSystem).Methods("PUT")
+	// target maturity is ISSO-writable (unlike the admin-only system PUT); see SaveFismaSystemTargetMaturity
+	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/target-maturity", controller.SaveFismaSystemTargetMaturity).Methods("PUT")
 	// returns a list of data calls that this fisma system has marked complete
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/datacalls", controller.ListFismaSystemDataCalls).Methods("GET")
 

--- a/backend/cmd/api/internal/spreadsheet/spreadsheet.go
+++ b/backend/cmd/api/internal/spreadsheet/spreadsheet.go
@@ -23,6 +23,8 @@ func Excel(answers []*model.Answer) (*excelize.File, error) {
 	f.SetCellValue(sheet, "H1", "Maturity Tier")
 	f.SetCellValue(sheet, "I1", "Score")
 	f.SetCellValue(sheet, "J1", "ADO Answer Details")
+	f.SetCellValue(sheet, "K1", "Target Maturity Level")
+	f.SetCellValue(sheet, "L1", "Target Justification")
 
 	for i, a := range answers {
 		row := i + 2 // i starts at 0 and headers are in row 1
@@ -36,6 +38,18 @@ func Excel(answers []*model.Answer) (*excelize.File, error) {
 		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), a.OptionName)
 		f.SetCellValue(sheet, fmt.Sprintf("I%d", row), a.Score)
 		f.SetCellValue(sheet, fmt.Sprintf("J%d", row), a.Notes)
+		// NULL target = no explicit assertion yet; the app-wide default is
+		// Advanced, and the export says so rather than leaving readers to guess.
+		targetTier := "Advanced (default)"
+		targetJustification := ""
+		if a.TargetMaturityTier != nil {
+			targetTier = *a.TargetMaturityTier
+		}
+		if a.TargetMaturityJustification != nil {
+			targetJustification = *a.TargetMaturityJustification
+		}
+		f.SetCellValue(sheet, fmt.Sprintf("K%d", row), targetTier)
+		f.SetCellValue(sheet, fmt.Sprintf("L%d", row), targetJustification)
 	}
 
 	return f, nil

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -807,6 +807,142 @@ tests:
           data:
             <<: *reactivatedFismaSystemData
 
+  # Target Maturity Endpoints (#398)
+  # PUT /fismasystems/{id}/target-maturity is the one system field pair an
+  # assigned ISSO may write; admin tiers stay OpDiv-scoped and read-only tiers
+  # are always 403. Tier vocabulary is the tier NAME (Initial/Advanced/Optimal).
+
+  # OWNER sets a target on the created system - 200 with both fields echoed
+  - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}/target-maturity"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Optimal"
+        target_maturity_justification: "Internet-facing HVA; risk posture warrants the highest target."
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            target_maturity_tier: "Optimal"
+            target_maturity_justification: "Internet-facing HVA; risk posture warrants the highest target."
+
+  # ISSO assigned to 1003 (Shield Gen) may set its target - 200
+  - url: http://localhost:8080/api/v1/fismasystems/1003/target-maturity
+    method: PUT
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Initial"
+        target_maturity_justification: "Isolated internal system with no PII."
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            target_maturity_tier: "Initial"
+
+  # Target fields flow through the normal system read
+  - url: http://localhost:8080/api/v1/fismasystems/1003
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            target_maturity_tier: "Initial"
+            target_maturity_justification: "Isolated internal system with no PII."
+
+  # Same ISSO is NOT assigned to 1002 - 403
+  - url: http://localhost:8080/api/v1/fismasystems/1002/target-maturity
+    method: PUT
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Advanced"
+        target_maturity_justification: "Should never be written."
+    expect:
+      status: 403
+
+  # Read-only admin tier never writes - 403
+  - url: http://localhost:8080/api/v1/fismasystems/1001/target-maturity
+    method: PUT
+    headers:
+      <<: *readonlyAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Advanced"
+        target_maturity_justification: "Should never be written."
+    expect:
+      status: 403
+
+  # OpDiv read-only tier never writes - 403
+  - url: http://localhost:8080/api/v1/fismasystems/1001/target-maturity
+    method: PUT
+    headers:
+      <<: *opDivReadonlyHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Advanced"
+        target_maturity_justification: "Should never be written."
+    expect:
+      status: 403
+
+  # OPDIV_ADMIN with EMPIRE grant cannot write a REBELLION system (1005) - 403
+  - url: http://localhost:8080/api/v1/fismasystems/1005/target-maturity
+    method: PUT
+    headers:
+      <<: *opDivAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Advanced"
+        target_maturity_justification: "Should never be written."
+    expect:
+      status: 403
+
+  # Traditional is outside the selectable vocabulary - 400
+  - url: http://localhost:8080/api/v1/fismasystems/1001/target-maturity
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Traditional"
+        target_maturity_justification: "Below the minimum selectable target."
+    expect:
+      status: 400
+
+  # Justification is required on every save - 400
+  - url: http://localhost:8080/api/v1/fismasystems/1001/target-maturity
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Advanced"
+    expect:
+      status: 400
+
 
   # Functions Endpoints
   - id: createFunction

--- a/backend/internal/model/answers.go
+++ b/backend/internal/model/answers.go
@@ -21,6 +21,10 @@ type Answer struct {
 	Score                 int
 	Notes                 string
 	NotesIsAISummary      *bool `db:"notes_is_ai_summary"`
+	// Per-system target maturity (#398); nil when no target has been asserted
+	// (the export renders the Advanced default in that case).
+	TargetMaturityTier          *string `db:"target_maturity_tier"`
+	TargetMaturityJustification *string `db:"target_maturity_justification"`
 }
 
 type FindAnswersInput struct {
@@ -34,7 +38,7 @@ type FindAnswersInput struct {
 // if using lower-level methods such as FindFismaSystems, FindScores, FindQuestions, etc
 // this is primarily meant for use in exporting to spreadsheets
 func FindAnswers(ctx context.Context, input FindAnswersInput) ([]*Answer, error) {
-	sqlb := stmntBuilder.Select("datacalls.datacall, fismasystems.fismasystemid, fismasystems.fismaacronym, fismasystems.datacenterenvironment, pillars.pillar, questions.question, functions.function, functions.description, functionoptions.description AS optiondescription, functionoptions.optionname, functionoptions.score, scores.notes, scores.notes_is_ai_summary").
+	sqlb := stmntBuilder.Select("datacalls.datacall, fismasystems.fismasystemid, fismasystems.fismaacronym, fismasystems.datacenterenvironment, fismasystems.target_maturity_tier, fismasystems.target_maturity_justification, pillars.pillar, questions.question, functions.function, functions.description, functionoptions.description AS optiondescription, functionoptions.optionname, functionoptions.score, scores.notes, scores.notes_is_ai_summary").
 		From("scores").
 		InnerJoin("datacalls ON datacalls.datacallid=scores.datacallid AND datacalls.datacallid=?", input.DataCallID).
 		InnerJoin("fismasystems ON fismasystems.fismasystemid=scores.fismasystemid").

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -11,7 +11,19 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-var fismaSystemColumns = []string{"fismasystemid", "fismauid", "fismaacronym", "fismaname", "fismasubsystem", "component", "groupacronym", "groupname", "divisionname", "datacenterenvironment", "datacallcontact", "issoemail", "sdl_sync_enabled", "decommissioned", "decommissioned_date", "decommissioned_by", "decommissioned_notes", "reactivated_by", "reactivated_date", "reactivation_notes", "opdiv_id", "hva", "fips", "system_type", "cloud_system", "cloud_service_model", "cloud_vendor", "system_operator", "goco_coco_gogo", "system_owner", "system_owner_email", "legacy", "isso_name"}
+var fismaSystemColumns = []string{"fismasystemid", "fismauid", "fismaacronym", "fismaname", "fismasubsystem", "component", "groupacronym", "groupname", "divisionname", "datacenterenvironment", "datacallcontact", "issoemail", "sdl_sync_enabled", "decommissioned", "decommissioned_date", "decommissioned_by", "decommissioned_notes", "reactivated_by", "reactivated_date", "reactivation_notes", "opdiv_id", "hva", "fips", "system_type", "cloud_system", "cloud_service_model", "cloud_vendor", "system_operator", "goco_coco_gogo", "system_owner", "system_owner_email", "legacy", "isso_name", "target_maturity_tier", "target_maturity_justification"}
+
+// validTargetMaturityTiers is the selectable vocabulary for a system's
+// risk-based target maturity level (#398). Deliberately the tier NAMES from
+// Tier(), not CISA stage numbers: the app's score scale is 1-5 (Advanced is
+// 3.10-4.09), so a numeric target could be mis-compared against systemscore.
+// Traditional is not offered - per the GAO response a target below Initial is
+// not a valid risk posture.
+var validTargetMaturityTiers = map[string]bool{
+	"Initial":  true,
+	"Advanced": true,
+	"Optimal":  true,
+}
 
 type FismaSystem struct {
 	FismaSystemID         int32      `json:"fismasystemid"`
@@ -47,6 +59,11 @@ type FismaSystem struct {
 	SystemOwnerEmail      *string    `json:"system_owner_email" db:"system_owner_email"`
 	Legacy                *string    `json:"legacy" db:"legacy"`
 	ISSOName              *string    `json:"isso_name" db:"isso_name"`
+	// Risk-based target maturity (#398). NULL = no ISSO has asserted a target
+	// yet; the UI presents the Advanced default. Written only via
+	// SaveTargetMaturity, never through Save().
+	TargetMaturityTier          *string `json:"target_maturity_tier" db:"target_maturity_tier"`
+	TargetMaturityJustification *string `json:"target_maturity_justification" db:"target_maturity_justification"`
 }
 
 type FindFismaSystemsInput struct {
@@ -446,6 +463,48 @@ func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSy
 		return nil, trapError(err)
 	}
 	return &system, nil
+}
+
+// TargetMaturityInput carries an explicit target-maturity assertion for one
+// system (#398).
+type TargetMaturityInput struct {
+	FismaSystemID int32   `json:"-"`
+	Tier          *string `json:"target_maturity_tier"`
+	Justification *string `json:"target_maturity_justification"`
+}
+
+// SaveTargetMaturity records a system's risk-based target maturity tier and
+// its one-sentence justification. Both are required on every save: the
+// justification IS the deliverable (GAO-audit rationale), so a tier without
+// one is rejected. Kept separate from Save() so the ISSO-writable surface is
+// exactly these two columns and nothing else. queryRow's recordEvent hook
+// audits the write like every other fismasystems mutation.
+func SaveTargetMaturity(ctx context.Context, input TargetMaturityInput) (*FismaSystem, error) {
+	if !isValidIntID(input.FismaSystemID) {
+		return nil, ErrNoData
+	}
+
+	invalid := InvalidInputError{data: map[string]any{}}
+	if input.Tier == nil || !validTargetMaturityTiers[*input.Tier] {
+		invalid.data["target_maturity_tier"] = "must be one of Initial, Advanced, Optimal"
+	}
+	if input.Justification == nil || strings.TrimSpace(*input.Justification) == "" {
+		invalid.data["target_maturity_justification"] = "required"
+	} else if len(*input.Justification) > 1000 {
+		invalid.data["target_maturity_justification"] = "must be 1000 characters or fewer"
+	}
+	if len(invalid.data) > 0 {
+		return nil, &invalid
+	}
+
+	sqlb := stmntBuilder.
+		Update("fismasystems").
+		Set("target_maturity_tier", *input.Tier).
+		Set("target_maturity_justification", strings.TrimSpace(*input.Justification)).
+		Where("fismasystemid=?", input.FismaSystemID).
+		Suffix("RETURNING " + strings.Join(fismaSystemColumns, ", "))
+
+	return queryRow(ctx, sqlb, pgx.RowToStructByName[FismaSystem])
 }
 
 func (f *FismaSystem) validate() error {

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 	"github.com/Masterminds/squirrel"
@@ -490,7 +491,7 @@ func SaveTargetMaturity(ctx context.Context, input TargetMaturityInput) (*FismaS
 	}
 	if input.Justification == nil || strings.TrimSpace(*input.Justification) == "" {
 		invalid.data["target_maturity_justification"] = "required"
-	} else if len(*input.Justification) > 1000 {
+	} else if utf8.RuneCountInString(strings.TrimSpace(*input.Justification)) > 1000 {
 		invalid.data["target_maturity_justification"] = "must be 1000 characters or fewer"
 	}
 	if len(invalid.data) > 0 {

--- a/backend/internal/model/fismasystems_test.go
+++ b/backend/internal/model/fismasystems_test.go
@@ -2,10 +2,12 @@ package model
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -306,4 +308,125 @@ func TestFismaSystemReactivationFields(t *testing.T) {
 // Helper function for creating string pointers
 func stringPtr(s string) *string {
 	return &s
+}
+
+// TestSaveTargetMaturityValidation exercises the pre-DB validation paths of
+// SaveTargetMaturity (#398). These all return before any connection is
+// opened, so they run under -short.
+func TestSaveTargetMaturityValidation(t *testing.T) {
+	ctx := context.Background()
+	tier := "Advanced"
+	justification := "Handles PII and is internet-facing."
+	long := strings.Repeat("x", 1001)
+
+	t.Run("InvalidID", func(t *testing.T) {
+		_, err := SaveTargetMaturity(ctx, TargetMaturityInput{FismaSystemID: 0, Tier: &tier, Justification: &justification})
+		assert.Equal(t, ErrNoData, err)
+	})
+
+	t.Run("UnknownTier", func(t *testing.T) {
+		bad := "Traditional" // deliberately excluded from the selectable set
+		_, err := SaveTargetMaturity(ctx, TargetMaturityInput{FismaSystemID: 1001, Tier: &bad, Justification: &justification})
+		var iie *InvalidInputError
+		assert.ErrorAs(t, err, &iie)
+	})
+
+	t.Run("NilTier", func(t *testing.T) {
+		_, err := SaveTargetMaturity(ctx, TargetMaturityInput{FismaSystemID: 1001, Justification: &justification})
+		var iie *InvalidInputError
+		assert.ErrorAs(t, err, &iie)
+	})
+
+	t.Run("MissingJustification", func(t *testing.T) {
+		_, err := SaveTargetMaturity(ctx, TargetMaturityInput{FismaSystemID: 1001, Tier: &tier})
+		var iie *InvalidInputError
+		assert.ErrorAs(t, err, &iie)
+	})
+
+	t.Run("BlankJustification", func(t *testing.T) {
+		blank := "   "
+		_, err := SaveTargetMaturity(ctx, TargetMaturityInput{FismaSystemID: 1001, Tier: &tier, Justification: &blank})
+		var iie *InvalidInputError
+		assert.ErrorAs(t, err, &iie)
+	})
+
+	t.Run("JustificationTooLong", func(t *testing.T) {
+		_, err := SaveTargetMaturity(ctx, TargetMaturityInput{FismaSystemID: 1001, Tier: &tier, Justification: &long})
+		var iie *InvalidInputError
+		assert.ErrorAs(t, err, &iie)
+	})
+}
+
+// TestSaveTargetMaturityIntegration writes a target against a real Postgres,
+// reads it back through FindFismaSystem, and restores the columns to NULL so
+// the seeded dev DB is left as found. Skipped under -short.
+func TestSaveTargetMaturityIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+
+	// Pick any existing system rather than hardcoding a seed id.
+	systems, err := FindFismaSystems(ctx, FindFismaSystemsInput{})
+	if err != nil || len(systems) == 0 {
+		t.Fatalf("need at least one seeded fismasystem: %v", err)
+	}
+	target := systems[0]
+
+	// Restore whatever was there before (normally NULL in seed data).
+	defer func() {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("cleanup conn: %v", err)
+		}
+		defer conn.Release()
+		_, err = conn.Exec(ctx,
+			"UPDATE fismasystems SET target_maturity_tier=$1, target_maturity_justification=$2 WHERE fismasystemid=$3",
+			target.TargetMaturityTier, target.TargetMaturityJustification, target.FismaSystemID)
+		if err != nil {
+			t.Fatalf("cleanup restore: %v", err)
+		}
+	}()
+
+	tier := "Optimal"
+	justification := "  Integration test justification.  "
+
+	saved, err := SaveTargetMaturity(ctx, TargetMaturityInput{
+		FismaSystemID: target.FismaSystemID,
+		Tier:          &tier,
+		Justification: &justification,
+	})
+	if err != nil {
+		t.Fatalf("SaveTargetMaturity: %v", err)
+	}
+	if assert.NotNil(t, saved.TargetMaturityTier) {
+		assert.Equal(t, "Optimal", *saved.TargetMaturityTier)
+	}
+	if assert.NotNil(t, saved.TargetMaturityJustification) {
+		// stored trimmed
+		assert.Equal(t, "Integration test justification.", *saved.TargetMaturityJustification)
+	}
+
+	// Read back through the normal read path - the new columns flow through
+	// fismaSystemColumns, so every GET carries them.
+	id := target.FismaSystemID
+	fetched, err := FindFismaSystem(ctx, FindFismaSystemsInput{FismaSystemID: &id})
+	if err != nil {
+		t.Fatalf("FindFismaSystem: %v", err)
+	}
+	if assert.NotNil(t, fetched.TargetMaturityTier) {
+		assert.Equal(t, "Optimal", *fetched.TargetMaturityTier)
+	}
+
+	// CHECK constraint is live: a value outside the vocabulary must fail even
+	// if it somehow bypassed Go validation.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("db.Conn: %v", err)
+	}
+	defer conn.Release()
+	_, err = conn.Exec(ctx,
+		"UPDATE fismasystems SET target_maturity_tier='Bogus' WHERE fismasystemid=$1", id)
+	assert.Error(t, err, "CHECK constraint must reject values outside the tier vocabulary")
 }

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -372,6 +372,14 @@ components:
           type: string
         system_type:
           type: string
+        target_maturity_justification:
+          type: string
+        target_maturity_tier:
+          description: |-
+            Risk-based target maturity (#398). NULL = no ISSO has asserted a target
+            yet; the UI presents the Advanced default. Written only via
+            SaveTargetMaturity, never through Save().
+          type: string
       type: object
     model.Function:
       properties:
@@ -559,6 +567,13 @@ components:
         payload:
           type: object
         synced_at:
+          type: string
+      type: object
+    model.TargetMaturityInput:
+      properties:
+        target_maturity_justification:
+          type: string
+        target_maturity_tier:
           type: string
       type: object
     model.User:
@@ -1351,6 +1366,63 @@ paths:
       security:
       - bearerAuth: []
       summary: Reactivate a decommissioned FISMA system
+      tags:
+      - fismasystems
+  /fismasystems/{fismasystemid}/target-maturity:
+    put:
+      parameters:
+      - description: FISMA system ID
+        in: path
+        name: fismasystemid
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/model.TargetMaturityInput'
+                description: Target tier (Initial, Advanced, or Optimal) and required
+                  justification
+                summary: body
+        description: Target tier (Initial, Advanced, or Optimal) and required justification
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-model_FismaSystem'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Set a system's target maturity tier and justification
       tags:
       - fismasystems
   /functions:


### PR DESCRIPTION
> **Note:** In-repo copy of #400 by @voidspooks. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #400

---

Backend half of #398 (MVP scope per the ticket discussion with @MackOverflow — system-level only; pillar/function targets, gap views, and audit-history UI stay tracked by the epic). Paired frontend PR on ztmf-ui. MERGE THIS PR BEFORE THE REHOME OF 398

## What

Each system gets a risk-based **target maturity tier** plus a **required one-sentence justification**, settable by the assigned ISSO/ISSM or an admin, stored per system, audited, and included in the export.

## Design decisions (from the review of the draft AC)

- **Tier stored by NAME** (`Initial`/`Advanced`/`Optimal`, CHECK-constrained), not a CISA stage integer. The app's internal score scale is 1–5 and `Tier()` maps 3.10–4.09 → Advanced, so a stored `3` invites an invalid raw-number comparison against `systemscore`. Storing the name makes tier-vs-tier the only expressible comparison; the UI renders the stage numerals as display labels ("3 — Advanced").
- **No backfill; NULL = "no target asserted."** Backfilling Advanced would fabricate a GAO-auditable assertion nobody made. The UI/export present the Advanced default explicitly labeled as such.
- **Justification required on every save** — the risk rationale is the deliverable.
- **Dedicated endpoint** `PUT /fismasystems/{id}/target-maturity` instead of widening the admin-only system PUT: the assigned ISSO/ISSM owns exactly this field pair. Gate mirrors the scores write path — read-only tiers 403, non-admins must be assigned, admin tiers OpDiv-scoped via `guardManageFismaSystem`. Writes are audited through the standard `events` hook.

## Changes

- Migration `0046`: `target_maturity_tier` (varchar, CHECK) + `target_maturity_justification` (varchar 1000), nullable.
- Model: fields flow through all reads; `SaveTargetMaturity` validates tier/justification and records the audit event.
- Controller/route + swag annotations; `openapi.yaml` regenerated.
- Export: **Target Maturity Level** / **Target Justification** columns; NULL renders `Advanced (default)`.
- Emberfall: 8 new cases (ISSO-assigned 200, unassigned ISSO 403, read-only tiers 403, out-of-scope OPDIV_ADMIN 403, bad tier 400, missing justification 400, read-through).

## Test plan

- [x] `make test-unit` — incl. new validation tests (run pre-DB, `-short`-safe)
- [x] `make test-integration` — write → read-back, trim behavior, live CHECK-constraint rejection
- [x] `make test-e2e` — **141 ran / 0 failed** incl. the 8 new target-maturity cases
- [x] Full flow validated in the local stack (admin + ISSO roles, export, audit events)

## Screenshots

<img width="2055" height="1096" alt="Screenshot 2026-07-08 at 4 53 24 PM" src="https://github.com/user-attachments/assets/978c64df-2a73-4408-a865-abab02276f01" />
<img width="2056" height="1103" alt="Screenshot 2026-07-08 at 4 54 41 PM" src="https://github.com/user-attachments/assets/717c28a3-a94e-4049-a318-cd280fe8f244" />

Refs #398
