### PR TITLE
Identifiable system questionnaire updates

### DIFF
--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -595,3 +595,92 @@ func TestDeleteUser_MissingIDIsNotFound(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
+
+// --- GetScoresProgress ---
+
+// int32PtrAuthz keeps the OpDiv fixture below readable without pulling in a
+// shared helper from another test file.
+func int32PtrAuthz(v int32) *int32 { return &v }
+
+// TestScopeScoreProgressInput pins the role matrix the progress endpoint
+// applies to its query input. This is the security boundary for /scores/
+// progress: the SQL builder is tested separately, so what matters here is
+// that each tier populates (or leaves empty) exactly the scope fields the
+// builder keys on.
+func TestScopeScoreProgressInput(t *testing.T) {
+	t.Run("OwnerUnrestricted", func(t *testing.T) {
+		input := model.FindScoreProgressInput{}
+		scopeScoreProgressInput(adminUser, &input)
+
+		assert.False(t, input.RestrictToOpDivIDs, "OWNER must not be OpDiv-restricted")
+		assert.Empty(t, input.OpDivIDs)
+		assert.Nil(t, input.UserID, "OWNER must not be limited to assigned systems")
+	})
+
+	t.Run("HHSReadonlyAdminUnrestricted", func(t *testing.T) {
+		input := model.FindScoreProgressInput{}
+		scopeScoreProgressInput(readonlyAdmin, &input)
+
+		assert.False(t, input.RestrictToOpDivIDs, "HHS_READONLY_ADMIN has unscoped read")
+		assert.Empty(t, input.OpDivIDs)
+		assert.Nil(t, input.UserID)
+	})
+
+	t.Run("OpDivAdminScopedToGrants", func(t *testing.T) {
+		opdivAdmin := &model.User{
+			UserID:           "44444444-4444-4444-4444-444444444444",
+			Role:             "OPDIV_ADMIN",
+			AssignedOpDivIDs: []*int32{int32PtrAuthz(7), int32PtrAuthz(9)},
+		}
+		input := model.FindScoreProgressInput{}
+		scopeScoreProgressInput(opdivAdmin, &input)
+
+		assert.True(t, input.RestrictToOpDivIDs, "OPDIV_ADMIN must be OpDiv-restricted")
+		assert.Equal(t, []int32{7, 9}, input.OpDivIDs)
+		assert.Nil(t, input.UserID, "OpDiv tier scopes by OpDiv, not by assignment")
+	})
+
+	t.Run("OpDivAdminWithNoGrantsFailsClosed", func(t *testing.T) {
+		opdivAdmin := &model.User{
+			UserID: "55555555-5555-5555-5555-555555555555",
+			Role:   "OPDIV_READONLY_ADMIN",
+		}
+		input := model.FindScoreProgressInput{}
+		scopeScoreProgressInput(opdivAdmin, &input)
+
+		assert.True(t, input.RestrictToOpDivIDs)
+		assert.Empty(t, input.OpDivIDs, "no grants must leave the id list empty so the query fails closed")
+	})
+
+	t.Run("ISSOScopedToAssignedSystems", func(t *testing.T) {
+		input := model.FindScoreProgressInput{}
+		scopeScoreProgressInput(issoUser, &input)
+
+		assert.False(t, input.RestrictToOpDivIDs)
+		if assert.NotNil(t, input.UserID, "ISSO must be limited to their assigned systems") {
+			assert.Equal(t, issoUser.UserID, *input.UserID)
+		}
+	})
+}
+
+// TestGetScoresProgress_MissingDataCall_BadRequest exercises the handler end
+// to end without a database: FindScoreProgress validates before touching the
+// pool, so a request missing the required datacallid must come back 400 for
+// every tier that can reach the endpoint.
+func TestGetScoresProgress_MissingDataCall_BadRequest(t *testing.T) {
+	for name, user := range map[string]*model.User{
+		"Owner":         adminUser,
+		"ReadonlyAdmin": readonlyAdmin,
+		"ISSO":          issoUser,
+	} {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/scores/progress", nil)
+			r = withUser(r, user)
+			w := httptest.NewRecorder()
+
+			GetScoresProgress(w, r)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -154,6 +154,49 @@ func GetScoresDiff(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, diffs, err)
 }
 
+//	@Summary		Get per-system questionnaire progress for a data call
+//	@Description	Returns, for each FISMA system the caller can see, how many questionnaire functions apply to the system, how many have been genuinely updated in the given data call (answers pre-populated from the previous cycle do not count until touched), and when the most recent update happened. Scoped to the caller's tier: unscoped admins see all systems, OpDiv-scoped admins their OpDivs' systems, and ISSO/ISSM their assigned systems.
+//	@Tags		scores
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		datacallid		query		int	true	"Data call ID to report progress for"
+//	@Param		fismasystemid	query		int	false	"Limit progress to a single FISMA system"
+//	@Success	200				{object}	apiResponse[[]model.ScoreProgress]
+//	@Failure	400				{object}	apiResponse[any]
+//	@Failure	500				{object}	apiResponse[any]
+//	@Router		/scores/progress [get]
+func GetScoresProgress(w http.ResponseWriter, r *http.Request) {
+	var (
+		progress []*model.ScoreProgress
+		err      error
+	)
+
+	user := model.UserFromContext(r.Context())
+	input := model.FindScoreProgressInput{}
+
+	err = decoder.Decode(&input, r.URL.Query())
+
+	// Same tier scoping as ListScores, applied AFTER decode so a client cannot
+	// widen scope via query params: unscoped admins see all; OPDIV tiers
+	// fail-closed to their granted OpDivs' systems; ISSO/ISSM keep the
+	// per-system (UserID) path.
+	switch {
+	case user.HasUnscopedRead():
+		// no scope filter
+	case user.IsOpDivTier():
+		input.RestrictToOpDivIDs = true
+		_, input.OpDivIDs = user.EffectiveOpDivScope()
+	default:
+		input.UserID = &user.UserID
+	}
+
+	if err == nil {
+		progress, err = model.FindScoreProgress(r.Context(), input)
+	}
+
+	respond(w, r, progress, err)
+}
+
 //	@Summary	Get aggregated scores
 //	@Tags		scores
 //	@Produce	json

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -176,10 +176,21 @@ func GetScoresProgress(w http.ResponseWriter, r *http.Request) {
 
 	err = decoder.Decode(&input, r.URL.Query())
 
-	// Same tier scoping as ListScores, applied AFTER decode so a client cannot
-	// widen scope via query params: unscoped admins see all; OPDIV tiers
-	// fail-closed to their granted OpDivs' systems; ISSO/ISSM keep the
-	// per-system (UserID) path.
+	scopeScoreProgressInput(user, &input)
+
+	if err == nil {
+		progress, err = model.FindScoreProgress(r.Context(), input)
+	}
+
+	respond(w, r, progress, err)
+}
+
+// scopeScoreProgressInput applies the caller's tier to the query input. Same
+// tier scoping as ListScores, applied AFTER decode so a client cannot widen
+// scope via query params: unscoped admins see all; OPDIV tiers fail-closed to
+// their granted OpDivs' systems; ISSO/ISSM keep the per-system (UserID) path.
+// Extracted so the role matrix is unit-testable without a database.
+func scopeScoreProgressInput(user *model.User, input *model.FindScoreProgressInput) {
 	switch {
 	case user.HasUnscopedRead():
 		// no scope filter
@@ -189,12 +200,6 @@ func GetScoresProgress(w http.ResponseWriter, r *http.Request) {
 	default:
 		input.UserID = &user.UserID
 	}
-
-	if err == nil {
-		progress, err = model.FindScoreProgress(r.Context(), input)
-	}
-
-	respond(w, r, progress, err)
 }
 
 //	@Summary	Get aggregated scores

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -84,6 +84,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/scores", controller.ListScores).Methods("GET")
 	router.HandleFunc("/api/v1/scores/aggregate", controller.GetScoresAggregate).Methods("GET") // yes "aggregate" is a noun
 	router.HandleFunc("/api/v1/scores/diff", controller.GetScoresDiff).Methods("GET")
+	router.HandleFunc("/api/v1/scores/progress", controller.GetScoresProgress).Methods("GET")
 	router.HandleFunc("/api/v1/scores", controller.SaveScore).Methods("POST")
 	router.HandleFunc("/api/v1/scores/{scoreid:[0-9]+}", controller.SaveScore).Methods("PUT")
 

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -27,7 +27,9 @@ type ScoreProgress struct {
 	// use, so the denominator matches what an ISSO actually sees).
 	QuestionsExpected int32 `json:"questionsexpected"`
 	// QuestionsUpdated is the number of distinct functions whose answer in
-	// this data call has at least one recorded edit event.
+	// this data call has at least one recorded edit event AND is still
+	// applicable to the system's current environment. Counted from the same
+	// applicable-function set as QuestionsExpected, so it can never exceed it.
 	QuestionsUpdated int32 `json:"questionsupdated"`
 	// LastUpdatedAt is the most recent edit event across the system's answers
 	// in this data call; nil when nothing has been touched this cycle.
@@ -100,10 +102,10 @@ func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
 	var args []any
 	argN := 1
 
-	// System-scope predicates applied to the expected CTE, which anchors the
-	// result set: a system outside the caller's scope produces no row at all,
-	// and a system inside scope with zero activity still produces a row (that
-	// zero-activity row is the entire point of the feature). Decommissioned
+	// System-scope predicates on the fismasystems anchor. Applied once in the
+	// scoped_systems CTE that both expected and updated read from, so updated
+	// never computes progress for a system the caller cannot see and a
+	// single-system request only touches that system's rows. Decommissioned
 	// systems are out of scope for data call participation entirely.
 	conds := []string{"fs.decommissioned = FALSE"}
 
@@ -134,33 +136,48 @@ func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
 	args = append(args, *input.DataCallID)
 	argN++
 
-	// expected: functions applicable to each in-scope system via the
-	// datacenterenvironments scoring-vocabulary mapping (same indirection as
-	// FindQuestionsByFismaSystem). LEFT joins so a system whose environment
-	// has no mapping still returns with an expected count of zero.
-	//
-	// updated: distinct functions whose score row in this data call has at
-	// least one edit event. The INNER lateral join is the filter - a
-	// pre-populated row copied by copyPreviousScores has no event and drops
-	// out here, which is exactly the "has a row but was not updated" case.
+	// Both count halves draw from the SAME applicable-function set - the exact
+	// set FindQuestionsByFismaSystem resolves for the questionnaire an ISSO
+	// fills out: functions with a question (INNER, so orphan functions are
+	// excluded), a valid pillar, matched to the system's environment through
+	// the datacenterenvironments scoring vocabulary. Because updated's set is
+	// that same set further restricted to answered-with-an-event functions, it
+	// is a subset of expected's - so questionsupdated can never exceed
+	// questionsexpected even when a carried-over answer references a function
+	// that is no longer applicable after an environment change (that answer
+	// simply fails the applicability join). COUNT(DISTINCT) on both guards
+	// against fan-out from the environment mapping.
 	sql := fmt.Sprintf(`
-WITH expected AS (
-    SELECT fs.fismasystemid, COUNT(f.functionid) AS questionsexpected
+WITH scoped_systems AS (
+    SELECT fs.fismasystemid, fs.datacenterenvironment
     FROM fismasystems fs
-    LEFT JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
-    LEFT JOIN functions f ON f.datacenterenvironment = dce.scoring_key
     WHERE %s
-    GROUP BY fs.fismasystemid
+),
+expected AS (
+    SELECT ss.fismasystemid, COUNT(DISTINCT f.functionid) AS questionsexpected
+    FROM scoped_systems ss
+    INNER JOIN datacenterenvironments dce ON dce.datacenterenvironment = ss.datacenterenvironment
+    INNER JOIN functions f ON f.datacenterenvironment = dce.scoring_key
+    INNER JOIN questions q ON q.questionid = f.questionid
+    INNER JOIN pillars p ON p.pillarid = q.pillarid
+    GROUP BY ss.fismasystemid
 ),
 updated AS (
-    SELECT s.fismasystemid,
-           COUNT(DISTINCT fo.functionid) AS questionsupdated,
+    SELECT ss.fismasystemid,
+           COUNT(DISTINCT f.functionid) AS questionsupdated,
            MAX(le.createdat) AS lastupdatedat -- newest across the system's rows; the lateral below is per-row
-    FROM scores s
+    FROM scoped_systems ss
+    INNER JOIN scores s ON s.fismasystemid = ss.fismasystemid AND s.datacallid = $%d
     INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+    INNER JOIN functions f ON f.functionid = fo.functionid
+    INNER JOIN datacenterenvironments dce ON dce.datacenterenvironment = ss.datacenterenvironment
+                                         AND dce.scoring_key = f.datacenterenvironment
+    INNER JOIN questions q ON q.questionid = f.questionid
+    INNER JOIN pillars p ON p.pillarid = q.pillarid
     -- One newest event per score row (LIMIT 1 keeps the lateral on the
     -- index fast path); the outer MAX then picks the newest across the
-    -- system's rows. Both layers are load-bearing.
+    -- system's rows. The INNER lateral is also the filter - a pre-populated
+    -- row copied by copyPreviousScores has no event and drops out here.
     INNER JOIN LATERAL (
         SELECT createdat
         FROM events
@@ -169,16 +186,16 @@ updated AS (
         ORDER BY createdat DESC
         LIMIT 1
     ) le ON TRUE
-    WHERE s.datacallid = $%d
-    GROUP BY s.fismasystemid
+    GROUP BY ss.fismasystemid
 )
-SELECT ex.fismasystemid,
-       ex.questionsexpected,
+SELECT ss.fismasystemid,
+       COALESCE(ex.questionsexpected, 0) AS questionsexpected,
        COALESCE(u.questionsupdated, 0) AS questionsupdated,
        u.lastupdatedat
-FROM expected ex
-LEFT JOIN updated u ON u.fismasystemid = ex.fismasystemid
-ORDER BY ex.fismasystemid
+FROM scoped_systems ss
+LEFT JOIN expected ex ON ex.fismasystemid = ss.fismasystemid
+LEFT JOIN updated u ON u.fismasystemid = ss.fismasystemid
+ORDER BY ss.fismasystemid
 `, strings.Join(conds, " AND "), dataCallArg)
 
 	return sql, args

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -1,0 +1,186 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ScoreProgress is one FISMA system's questionnaire progress within a single
+// data call, built for the "which systems have not updated their
+// questionnaires" dashboard view.
+//
+// QuestionsUpdated counts questions genuinely touched this cycle, not
+// questions that merely have an answer row: when a data call is created,
+// copyPreviousScores pre-populates the previous cycle's answers WITHOUT
+// recording events, so a carried-forward untouched answer has no event row.
+// Counting rows would therefore read ~100% for every carried-over system;
+// counting rows WITH events is what distinguishes real updates.
+type ScoreProgress struct {
+	FismaSystemID int32 `json:"fismasystemid"`
+	// QuestionsExpected is the number of questionnaire functions applicable to
+	// the system, resolved through the datacenterenvironments scoring
+	// vocabulary (the same join the questionnaire and the score aggregation
+	// use, so the denominator matches what an ISSO actually sees).
+	QuestionsExpected int32 `json:"questionsexpected"`
+	// QuestionsUpdated is the number of distinct functions whose answer in
+	// this data call has at least one recorded edit event.
+	QuestionsUpdated int32 `json:"questionsupdated"`
+	// LastUpdatedAt is the most recent edit event across the system's answers
+	// in this data call; nil when nothing has been touched this cycle.
+	LastUpdatedAt *time.Time `json:"lastupdatedat,omitempty"`
+	// UpdatedSinceStart is a convenience flag: true when at least one answer
+	// has been edited in this data call.
+	UpdatedSinceStart bool `json:"updatedsincestart"`
+}
+
+type FindScoreProgressInput struct {
+	DataCallID    *int32 `schema:"datacallid"`
+	FismaSystemID *int32 `schema:"fismasystemid"`
+	// UserID restricts progress to the requesting user's assigned systems
+	// (ISSO/ISSM tiers); set by the controller, not bindable from the query.
+	UserID *string
+	// OpDiv scope for OpDiv-scoped admin tiers, mirroring FindScores. Not
+	// schema-tagged - the controller sets them from the auth'd user.
+	OpDivIDs           []int32
+	RestrictToOpDivIDs bool
+}
+
+func (i FindScoreProgressInput) validate() error {
+	err := InvalidInputError{data: map[string]any{}}
+
+	if i.DataCallID == nil {
+		err.data["datacallid"] = "required"
+	}
+
+	if len(err.data) > 0 {
+		return &err
+	}
+	return nil
+}
+
+// FindScoreProgress returns one row per in-scope FISMA system with its
+// questionnaire progress for the given data call: how many questions apply to
+// the system, how many were genuinely updated this cycle, and when the most
+// recent update happened.
+//
+// Systems the caller cannot see are excluded by the same scoping rules as
+// FindScores (per-user assigned systems, OpDiv grants, or unrestricted).
+// Decommissioned systems are not filtered here - the caller joins progress
+// onto whatever system list it displays, so extra rows are inert.
+//
+// The query is hand-built parameterized SQL through the read-only rawQuery
+// path (never queryRow, which records events), mirroring FindScoreDiff. The
+// events lateral is the same shape FindScores uses for last_edited_at and is
+// served by the events_score_audit_idx partial index.
+func FindScoreProgress(ctx context.Context, input FindScoreProgressInput) ([]*ScoreProgress, error) {
+	if err := input.validate(); err != nil {
+		return nil, err
+	}
+
+	sql, args := buildScoreProgressSQL(input)
+	return query(ctx, rawQuery{sql: sql, args: args}, scanScoreProgress)
+}
+
+// buildScoreProgressSQL assembles the parameterized progress query. Extracted
+// so unit tests can pin the filter and scope shaping without a database
+// connection. validate() guarantees DataCallID is non-nil before this is
+// called.
+func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
+	var args []any
+	argN := 1
+
+	// System-scope predicates applied to the expected CTE, which anchors the
+	// result set: a system outside the caller's scope produces no row at all,
+	// and a system inside scope with zero activity still produces a row (that
+	// zero-activity row is the entire point of the feature).
+	conds := []string{"TRUE"}
+
+	if input.FismaSystemID != nil {
+		conds = append(conds, fmt.Sprintf("fs.fismasystemid = $%d", argN))
+		args = append(args, *input.FismaSystemID)
+		argN++
+	}
+
+	if input.UserID != nil {
+		conds = append(conds, fmt.Sprintf("fs.fismasystemid IN (SELECT fismasystemid FROM users_fismasystems WHERE userid = $%d)", argN))
+		args = append(args, *input.UserID)
+		argN++
+	}
+
+	// OpDiv scope (fail-closed): empty grants under RestrictToOpDivIDs -> no
+	// rows, matching FindScores.
+	switch {
+	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
+		conds = append(conds, "FALSE")
+	case len(input.OpDivIDs) > 0:
+		conds = append(conds, fmt.Sprintf("fs.opdiv_id = ANY($%d)", argN))
+		args = append(args, input.OpDivIDs)
+		argN++
+	}
+
+	dataCallArg := argN
+	args = append(args, *input.DataCallID)
+	argN++
+
+	// expected: functions applicable to each in-scope system via the
+	// datacenterenvironments scoring-vocabulary mapping (same indirection as
+	// FindQuestionsByFismaSystem). LEFT joins so a system whose environment
+	// has no mapping still returns with an expected count of zero.
+	//
+	// updated: distinct functions whose score row in this data call has at
+	// least one edit event. The INNER lateral join is the filter - a
+	// pre-populated row copied by copyPreviousScores has no event and drops
+	// out here, which is exactly the "has a row but was not updated" case.
+	sql := fmt.Sprintf(`
+WITH expected AS (
+    SELECT fs.fismasystemid, COUNT(f.functionid) AS questionsexpected
+    FROM fismasystems fs
+    LEFT JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+    LEFT JOIN functions f ON f.datacenterenvironment = dce.scoring_key
+    WHERE %s
+    GROUP BY fs.fismasystemid
+),
+updated AS (
+    SELECT s.fismasystemid,
+           COUNT(DISTINCT fo.functionid) AS questionsupdated,
+           MAX(le.createdat) AS lastupdatedat
+    FROM scores s
+    INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+    INNER JOIN LATERAL (
+        SELECT createdat
+        FROM events
+        WHERE resource = 'public.scores'
+          AND (payload->>'scoreid')::int = s.scoreid
+        ORDER BY createdat DESC
+        LIMIT 1
+    ) le ON TRUE
+    WHERE s.datacallid = $%d
+    GROUP BY s.fismasystemid
+)
+SELECT ex.fismasystemid,
+       ex.questionsexpected,
+       COALESCE(u.questionsupdated, 0) AS questionsupdated,
+       u.lastupdatedat
+FROM expected ex
+LEFT JOIN updated u ON u.fismasystemid = ex.fismasystemid
+ORDER BY ex.fismasystemid
+`, strings.Join(conds, " AND "), dataCallArg)
+
+	return sql, args
+}
+
+func scanScoreProgress(row pgx.CollectableRow) (*ScoreProgress, error) {
+	var p ScoreProgress
+
+	if err := row.Scan(&p.FismaSystemID, &p.QuestionsExpected, &p.QuestionsUpdated, &p.LastUpdatedAt); err != nil {
+		return nil, err
+	}
+
+	p.UpdatedSinceStart = p.QuestionsUpdated > 0
+
+	return &p, nil
+}

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -32,8 +32,12 @@ type ScoreProgress struct {
 	// LastUpdatedAt is the most recent edit event across the system's answers
 	// in this data call; nil when nothing has been touched this cycle.
 	LastUpdatedAt *time.Time `json:"lastupdatedat,omitempty"`
-	// UpdatedSinceStart is a convenience flag: true when at least one answer
-	// has been edited in this data call.
+	// UpdatedSinceStart is derivable (QuestionsUpdated > 0) but kept because
+	// it answers the ticket's literal question - "has this system updated
+	// since the start of the data call" - by name in the response, so a
+	// consumer rendering a boolean chip never touches the numeric fields.
+	// The anchor is real: events can only postdate the data call's creation,
+	// so any counted edit necessarily happened after the cycle started.
 	UpdatedSinceStart bool `json:"updatedsincestart"`
 }
 
@@ -69,8 +73,11 @@ func (i FindScoreProgressInput) validate() error {
 //
 // Systems the caller cannot see are excluded by the same scoping rules as
 // FindScores (per-user assigned systems, OpDiv grants, or unrestricted).
-// Decommissioned systems are not filtered here - the caller joins progress
-// onto whatever system list it displays, so extra rows are inert.
+// Decommissioned systems are excluded: they do not participate in data
+// calls, so a "not updated" row for one is pure noise in the triage view
+// this endpoint feeds. If a consumer ever needs historical progress for a
+// decommissioned system, add an opt-in query param rather than removing
+// the filter.
 //
 // The query is hand-built parameterized SQL through the read-only rawQuery
 // path (never queryRow, which records events), mirroring FindScoreDiff. The
@@ -96,8 +103,9 @@ func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
 	// System-scope predicates applied to the expected CTE, which anchors the
 	// result set: a system outside the caller's scope produces no row at all,
 	// and a system inside scope with zero activity still produces a row (that
-	// zero-activity row is the entire point of the feature).
-	conds := []string{"TRUE"}
+	// zero-activity row is the entire point of the feature). Decommissioned
+	// systems are out of scope for data call participation entirely.
+	conds := []string{"fs.decommissioned = FALSE"}
 
 	if input.FismaSystemID != nil {
 		conds = append(conds, fmt.Sprintf("fs.fismasystemid = $%d", argN))
@@ -147,9 +155,12 @@ WITH expected AS (
 updated AS (
     SELECT s.fismasystemid,
            COUNT(DISTINCT fo.functionid) AS questionsupdated,
-           MAX(le.createdat) AS lastupdatedat
+           MAX(le.createdat) AS lastupdatedat -- newest across the system's rows; the lateral below is per-row
     FROM scores s
     INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+    -- One newest event per score row (LIMIT 1 keeps the lateral on the
+    -- index fast path); the outer MAX then picks the newest across the
+    -- system's rows. Both layers are load-bearing.
     INNER JOIN LATERAL (
         SELECT createdat
         FROM events

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -59,12 +59,17 @@ func TestFindScoreProgressIntegration(t *testing.T) {
 
 	// Borrow a valid (system, functionoption) pair from seeded data so FK
 	// constraints hold.
+	// The system must be active: FindScoreProgress excludes decommissioned
+	// systems, so borrowing one would make the single-system lookup empty.
 	var fismaSystemID, functionOptionID int32
 	err = conn.QueryRow(ctx, `
 		SELECT s.fismasystemid, s.functionoptionid
-		FROM scores s LIMIT 1
+		FROM scores s
+		INNER JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		WHERE fs.decommissioned = FALSE
+		LIMIT 1
 	`).Scan(&fismaSystemID, &functionOptionID)
-	require.NoError(t, err, "need at least one existing score row to derive a valid (system, functionoption) pair")
+	require.NoError(t, err, "need at least one score row on an active system to derive a valid (system, functionoption) pair")
 
 	// Seed one answer in the previous cycle via raw SQL (no events, same as
 	// historical data), then roll it into the new cycle the way datacall

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -58,18 +58,27 @@ func TestFindScoreProgressIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Borrow a valid (system, functionoption) pair from seeded data so FK
-	// constraints hold.
-	// The system must be active: FindScoreProgress excludes decommissioned
-	// systems, so borrowing one would make the single-system lookup empty.
+	// constraints hold. The system must be active (FindScoreProgress excludes
+	// decommissioned systems) and the answered function must be applicable to
+	// the system's current environment and carry a question - otherwise the
+	// progress query's applicability filter would exclude the edited answer
+	// and the "counts as updated" assertion below would fail for the wrong
+	// reason.
 	var fismaSystemID, functionOptionID int32
 	err = conn.QueryRow(ctx, `
 		SELECT s.fismasystemid, s.functionoptionid
 		FROM scores s
 		INNER JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+		INNER JOIN functions f ON f.functionid = fo.functionid
+		INNER JOIN datacenterenvironments dce
+			ON dce.datacenterenvironment = fs.datacenterenvironment
+			AND dce.scoring_key = f.datacenterenvironment
+		INNER JOIN questions q ON q.questionid = f.questionid
 		WHERE fs.decommissioned = FALSE
 		LIMIT 1
 	`).Scan(&fismaSystemID, &functionOptionID)
-	require.NoError(t, err, "need at least one score row on an active system to derive a valid (system, functionoption) pair")
+	require.NoError(t, err, "need one seeded score on an active system whose function is applicable to its environment")
 
 	// Seed one answer in the previous cycle via raw SQL (no events, same as
 	// historical data), then roll it into the new cycle the way datacall
@@ -145,7 +154,110 @@ func TestFindScoreProgressIntegration(t *testing.T) {
 	assert.Equal(t, int32(1), after.QuestionsUpdated,
 		"a genuinely edited answer must count as updated")
 	assert.True(t, after.UpdatedSinceStart)
+	assert.LessOrEqual(t, after.QuestionsUpdated, after.QuestionsExpected,
+		"updated can never exceed the applicable-question denominator")
 	if assert.NotNil(t, after.LastUpdatedAt, "last update timestamp must surface from the edit event") {
 		assert.WithinDuration(t, time.Now(), *after.LastUpdatedAt, 5*time.Minute)
 	}
+}
+
+// TestFindScoreProgressExcludesInapplicableAnswers pins the fix for the
+// >100% edge case (PR #404 review): an edited answer for a function that is
+// NOT applicable to the system's current environment must not count toward
+// questionsupdated, so the numerator can never exceed the applicable-question
+// denominator. This is the carried-over-answer-after-an-environment-change
+// scenario - copyPreviousScores copies functionoptionid verbatim, so a system
+// whose environment changed between cycles can hold answers for functions that
+// dropped out of its questionnaire.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindScoreProgressExcludesInapplicableAnswers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// Find an active system that (a) has at least one applicable function of
+	// its own (so questionsexpected > 0) and (b) has a functionoption for a
+	// function that is NOT applicable to its environment - the cross-environment
+	// answer we want to prove is excluded.
+	var fismaSystemID, inapplicableFOID int32
+	err = conn.QueryRow(ctx, `
+		SELECT fs.fismasystemid, fo.functionoptionid
+		FROM fismasystems fs
+		INNER JOIN functionoptions fo ON TRUE
+		INNER JOIN functions f ON f.functionid = fo.functionid
+		INNER JOIN questions q ON q.questionid = f.questionid
+		WHERE fs.decommissioned = FALSE
+		  AND fs.datacenterenvironment IS NOT NULL
+		  AND f.datacenterenvironment NOT IN (
+		      SELECT dce.scoring_key FROM datacenterenvironments dce
+		      WHERE dce.datacenterenvironment = fs.datacenterenvironment
+		  )
+		  AND EXISTS (
+		      SELECT 1
+		      FROM datacenterenvironments dce2
+		      INNER JOIN functions f2 ON f2.datacenterenvironment = dce2.scoring_key
+		      INNER JOIN questions q2 ON q2.questionid = f2.questionid
+		      WHERE dce2.datacenterenvironment = fs.datacenterenvironment
+		  )
+		LIMIT 1
+	`).Scan(&fismaSystemID, &inapplicableFOID)
+	if err != nil {
+		t.Skip("seed has no active system with both applicable functions and a cross-environment functionoption; cannot exercise the inapplicable-answer path")
+	}
+
+	var dc int32
+	suffix := time.Now().UnixNano()
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), NOW() + INTERVAL '90 days')
+		RETURNING datacallid
+	`, fmt.Sprintf("%sinapplicable_%d", integrationTestPrefix, suffix)).Scan(&dc)
+	require.NoError(t, err)
+
+	// A real seeded editor - recordEvent's userid FK-references users and
+	// swallows a violation silently, which would make the edit invisible.
+	var editorID, editorRole string
+	err = conn.QueryRow(ctx, `
+		SELECT userid, role FROM users ORDER BY (role = 'OWNER') DESC LIMIT 1
+	`).Scan(&editorID, &editorRole)
+	require.NoError(t, err)
+	editorCtx := UserToContext(ctx, &User{UserID: editorID, Role: editorRole})
+
+	// Genuinely edit an answer for the inapplicable function (records an event).
+	notes := "cross-environment answer"
+	saved, err := (&Score{
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: inapplicableFOID,
+		DataCallID:       dc,
+		Notes:            &notes,
+	}).Save(editorCtx)
+	require.NoError(t, err, "saving the cross-environment answer must succeed")
+	require.NotZero(t, saved.ScoreID)
+
+	rows, err := FindScoreProgress(ctx, FindScoreProgressInput{
+		DataCallID:    &dc,
+		FismaSystemID: &fismaSystemID,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	p := rows[0]
+
+	assert.Greater(t, p.QuestionsExpected, int32(0),
+		"the system has applicable functions of its own")
+	assert.Equal(t, int32(0), p.QuestionsUpdated,
+		"an edited answer for a non-applicable function must not count as updated")
+	assert.False(t, p.UpdatedSinceStart,
+		"updating only a non-applicable answer is not questionnaire progress")
+	assert.LessOrEqual(t, p.QuestionsUpdated, p.QuestionsExpected,
+		"updated can never exceed the applicable-question denominator")
 }

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -1,0 +1,146 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindScoreProgressIntegration pins the central semantic of ztmf#299
+// against the real SQL: an answer pre-populated by copyPreviousScores does
+// NOT count as updated (the copy records no events), and the same answer
+// counts the moment a user actually saves it (the write path records an
+// event). Unit tests over the generated SQL cannot see this - it depends on
+// the interplay between the copy path, the event trigger in queryRow, and
+// the INNER lateral in the progress query.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database (the dev compose
+// stack). Skipped under `go test -short`.
+func TestFindScoreProgressIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// Two synthetic datacalls ordered so copyPreviousScores' "latest-1 is
+	// previous" logic finds the right one. Prefixed names make them (and
+	// their scores, via FK cascade) discoverable by the purge sweep no
+	// matter how the test exits.
+	var prevDC, newDC int32
+	prevTimestamp := time.Now().Add(-2 * time.Hour)
+	newTimestamp := time.Now().Add(-1 * time.Hour)
+	suffix := time.Now().UnixNano()
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
+		RETURNING datacallid
+	`, fmt.Sprintf("%sprogress_prev_%d", integrationTestPrefix, suffix), prevTimestamp).Scan(&prevDC)
+	require.NoError(t, err)
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
+		RETURNING datacallid
+	`, fmt.Sprintf("%sprogress_new_%d", integrationTestPrefix, suffix), newTimestamp).Scan(&newDC)
+	require.NoError(t, err)
+
+	// Borrow a valid (system, functionoption) pair from seeded data so FK
+	// constraints hold.
+	var fismaSystemID, functionOptionID int32
+	err = conn.QueryRow(ctx, `
+		SELECT s.fismasystemid, s.functionoptionid
+		FROM scores s LIMIT 1
+	`).Scan(&fismaSystemID, &functionOptionID)
+	require.NoError(t, err, "need at least one existing score row to derive a valid (system, functionoption) pair")
+
+	// Seed one answer in the previous cycle via raw SQL (no events, same as
+	// historical data), then roll it into the new cycle the way datacall
+	// creation does.
+	notes := "progress integration marker"
+	_, err = conn.Exec(ctx, `
+		INSERT INTO scores (fismasystemid, functionoptionid, datacallid, notes)
+		VALUES ($1, $2, $3, $4)
+	`, fismaSystemID, functionOptionID, prevDC, notes)
+	require.NoError(t, err)
+
+	copyPreviousScores(newDC)
+
+	findForSystem := func() *ScoreProgress {
+		t.Helper()
+		rows, err := FindScoreProgress(ctx, FindScoreProgressInput{
+			DataCallID:    &newDC,
+			FismaSystemID: &fismaSystemID,
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1, "single-system filter must return exactly that system")
+		require.Equal(t, fismaSystemID, rows[0].FismaSystemID)
+		return rows[0]
+	}
+
+	// Phase 1: the answer exists in the new cycle (copied), but nothing has
+	// been touched. Progress must read zero - this is the "has a row but was
+	// not updated" case the naive row count gets wrong.
+	before := findForSystem()
+	assert.Equal(t, int32(0), before.QuestionsUpdated,
+		"pre-populated answers must not count as updated")
+	assert.False(t, before.UpdatedSinceStart)
+	assert.Nil(t, before.LastUpdatedAt)
+	assert.GreaterOrEqual(t, before.QuestionsExpected, int32(0),
+		"expected count resolves through the environment mapping")
+
+	// Phase 2: a user saves the copied answer through the normal write path,
+	// which records an edit event. Progress must now count it.
+	var copiedScoreID int32
+	err = conn.QueryRow(ctx, `
+		SELECT scoreid FROM scores
+		WHERE datacallid = $1 AND fismasystemid = $2 AND functionoptionid = $3
+	`, newDC, fismaSystemID, functionOptionID).Scan(&copiedScoreID)
+	require.NoError(t, err, "the copied row must exist in the new datacall")
+
+	// The editor must be a real seeded user: recordEvent writes
+	// events.userid with an FK to users and silently swallows the insert
+	// error on violation, so a fabricated UUID would make the edit
+	// invisible to the progress query and this test would fail for the
+	// wrong reason.
+	var editorID, editorRole string
+	err = conn.QueryRow(ctx, `
+		SELECT userid, role FROM users ORDER BY (role = 'OWNER') DESC LIMIT 1
+	`).Scan(&editorID, &editorRole)
+	require.NoError(t, err, "need at least one seeded user to attribute the edit to")
+
+	editedNotes := "edited this cycle"
+	edited := &Score{
+		ScoreID:          copiedScoreID,
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       newDC,
+		Notes:            &editedNotes,
+	}
+	editorCtx := UserToContext(ctx, &User{
+		UserID: editorID,
+		Role:   editorRole,
+	})
+	_, err = edited.Save(editorCtx)
+	require.NoError(t, err, "editing the copied answer through Save must succeed")
+
+	after := findForSystem()
+	assert.Equal(t, int32(1), after.QuestionsUpdated,
+		"a genuinely edited answer must count as updated")
+	assert.True(t, after.UpdatedSinceStart)
+	if assert.NotNil(t, after.LastUpdatedAt, "last update timestamp must surface from the edit event") {
+		assert.WithinDuration(t, time.Now(), *after.LastUpdatedAt, 5*time.Minute)
+	}
+}

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -41,6 +41,7 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	in := FindScoreProgressInput{DataCallID: int32Ptr(4)}
 	sql, args := buildScoreProgressSQL(in)
 
+	assert.Contains(t, sql, "fs.decommissioned = FALSE", "decommissioned systems do not participate in data calls and must not appear")
 	assert.Contains(t, sql, "LEFT JOIN datacenterenvironments dce", "expected count must resolve environments through the scoring vocabulary")
 	assert.Contains(t, sql, "dce.datacenterenvironment = fs.datacenterenvironment", "system's raw environment maps into the vocabulary")
 	assert.Contains(t, sql, "f.datacenterenvironment = dce.scoring_key", "functions match on the scoring key")
@@ -97,7 +98,7 @@ func TestBuildScoreProgressSQL_OpDivScope(t *testing.T) {
 		sql, args := buildScoreProgressSQL(in)
 
 		assert.Contains(t, sql, "fs.opdiv_id = ANY($1)")
-		assert.NotContains(t, sql, "FALSE", "non-empty grants should not fail closed")
+		assert.NotContains(t, sql, "AND FALSE", "non-empty grants should not fail closed")
 		assert.Equal(t, []any{[]int32{7, 9}, int32(4)}, args)
 	})
 
@@ -108,7 +109,7 @@ func TestBuildScoreProgressSQL_OpDivScope(t *testing.T) {
 		}
 		sql, args := buildScoreProgressSQL(in)
 
-		assert.True(t, strings.Contains(sql, "FALSE"), "a scoped admin with no grants must match nothing")
+		assert.True(t, strings.Contains(sql, "AND FALSE"), "a scoped admin with no grants must match nothing")
 		assert.NotContains(t, sql, "opdiv_id = ANY($", "should not bind an OpDiv predicate when there are no grants")
 		assert.Equal(t, []any{int32(4)}, args)
 	})

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -29,35 +29,50 @@ func TestFindScoreProgressInputValidate(t *testing.T) {
 // TestBuildScoreProgressSQL_Shape verifies the structural invariants of the
 // query:
 //
-//   - expected counts flow through the datacenterenvironments scoring
-//     vocabulary (same indirection the questionnaire uses), with LEFT joins
-//     so an unmapped environment still yields a zero-count row;
-//   - the updated CTE keys on edit events via an INNER lateral, which is what
-//     excludes pre-populated rows (copyPreviousScores records no events), the
-//     core "has a row but was not updated" distinction of ztmf#299;
-//   - the outer join is LEFT from expected so zero-activity systems still
-//     return a row (that row is the entire point of the feature).
+//   - scope is applied once in a scoped_systems anchor CTE that both count
+//     halves read from, so updated never computes for out-of-scope systems;
+//   - both expected and updated resolve the applicable-function set the same
+//     way FindQuestionsByFismaSystem does (functions + questions + pillars +
+//     the datacenterenvironments vocabulary), so orphan functions are excluded
+//     and the two halves draw from the same set - guaranteeing updated cannot
+//     exceed expected;
+//   - updated additionally requires the answered function to still be
+//     applicable to the system's current environment (the dce join keyed on
+//     both the system env and the function's scoring key), which is what stops
+//     a carried-over answer to a now-inapplicable function from inflating the
+//     numerator past 100%;
+//   - the updated CTE keys on edit events via an INNER lateral, excluding
+//     pre-populated rows (copyPreviousScores records no events);
+//   - both halves LEFT JOIN back onto scoped_systems so a zero-activity or
+//     unmapped-environment system still returns a row (0 of N).
 func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	in := FindScoreProgressInput{DataCallID: int32Ptr(4)}
 	sql, args := buildScoreProgressSQL(in)
 
+	assert.Contains(t, sql, "WITH scoped_systems AS", "scope is applied once in a shared anchor CTE")
 	assert.Contains(t, sql, "fs.decommissioned = FALSE", "decommissioned systems do not participate in data calls and must not appear")
-	assert.Contains(t, sql, "LEFT JOIN datacenterenvironments dce", "expected count must resolve environments through the scoring vocabulary")
-	assert.Contains(t, sql, "dce.datacenterenvironment = fs.datacenterenvironment", "system's raw environment maps into the vocabulary")
+	// Both halves resolve applicability through the same canonical join chain.
+	assert.Contains(t, sql, "dce.datacenterenvironment = ss.datacenterenvironment", "environment maps into the scoring vocabulary")
 	assert.Contains(t, sql, "f.datacenterenvironment = dce.scoring_key", "functions match on the scoring key")
+	assert.Contains(t, sql, "INNER JOIN questions q ON q.questionid = f.questionid", "orphan functions (no question) must be excluded, matching the questionnaire")
+	assert.Contains(t, sql, "INNER JOIN pillars p ON p.pillarid = q.pillarid", "applicability mirrors FindQuestionsByFismaSystem")
+	// updated re-checks applicability against the system's CURRENT environment.
+	assert.Contains(t, sql, "dce.scoring_key = f.datacenterenvironment", "an answered function must still be applicable to the system's current environment")
+	assert.Equal(t, 2, strings.Count(sql, "COUNT(DISTINCT f.functionid)"), "both halves count distinct applicable functions from the same set")
 	assert.Contains(t, sql, "INNER JOIN LATERAL", "updated count must require an edit event so pre-populated rows drop out")
 	assert.Contains(t, sql, "resource = 'public.scores'", "the lateral must read score events")
-	assert.Contains(t, sql, "COUNT(DISTINCT fo.functionid)", "updated counts distinct functions, not raw rows")
+	assert.Contains(t, sql, "LEFT JOIN expected", "unmapped-environment systems must still return a row")
 	assert.Contains(t, sql, "LEFT JOIN updated", "zero-activity systems must still return a row")
 	assert.Contains(t, sql, "COALESCE(u.questionsupdated, 0)", "zero-activity systems report 0, not NULL")
+	assert.Contains(t, sql, "COALESCE(ex.questionsexpected, 0)", "unmapped-environment systems report 0 expected, not NULL")
 
 	// No scope filters: the single arg is the data call id.
 	assert.Equal(t, []any{int32(4)}, args)
 }
 
 // TestBuildScoreProgressSQL_FismaSystemScope verifies a single-system request
-// narrows the expected CTE (which anchors the result set) and binds the system
-// id before the data call id.
+// narrows the scoped_systems anchor (so both count halves only touch that
+// system's rows) and binds the system id before the data call id.
 func TestBuildScoreProgressSQL_FismaSystemScope(t *testing.T) {
 	in := FindScoreProgressInput{
 		DataCallID:    int32Ptr(4),
@@ -70,8 +85,8 @@ func TestBuildScoreProgressSQL_FismaSystemScope(t *testing.T) {
 }
 
 // TestBuildScoreProgressSQL_UserScope verifies the ISSO/ISSM path: the
-// expected CTE is restricted to the requesting user's assigned systems via a
-// users_fismasystems subquery.
+// scoped_systems anchor is restricted to the requesting user's assigned
+// systems via a users_fismasystems subquery.
 func TestBuildScoreProgressSQL_UserScope(t *testing.T) {
 	uid := "11111111-1111-1111-1111-111111111111"
 	in := FindScoreProgressInput{

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -1,0 +1,115 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFindScoreProgressInputValidate pins the request precondition: the data
+// call id is required (progress is meaningless without a cycle to measure).
+// The error is an *InvalidInputError so the controller surfaces it as a 400
+// with the offending field, matching the rest of the API.
+func TestFindScoreProgressInputValidate(t *testing.T) {
+	t.Run("DataCallPresent", func(t *testing.T) {
+		in := FindScoreProgressInput{DataCallID: int32Ptr(4)}
+		assert.NoError(t, in.validate())
+	})
+
+	t.Run("MissingDataCall", func(t *testing.T) {
+		err := FindScoreProgressInput{}.validate()
+		iie, ok := err.(*InvalidInputError)
+		if assert.True(t, ok, "want *InvalidInputError, got %T", err) {
+			assert.Contains(t, iie.Data(), "datacallid")
+		}
+	})
+}
+
+// TestBuildScoreProgressSQL_Shape verifies the structural invariants of the
+// query:
+//
+//   - expected counts flow through the datacenterenvironments scoring
+//     vocabulary (same indirection the questionnaire uses), with LEFT joins
+//     so an unmapped environment still yields a zero-count row;
+//   - the updated CTE keys on edit events via an INNER lateral, which is what
+//     excludes pre-populated rows (copyPreviousScores records no events), the
+//     core "has a row but was not updated" distinction of ztmf#299;
+//   - the outer join is LEFT from expected so zero-activity systems still
+//     return a row (that row is the entire point of the feature).
+func TestBuildScoreProgressSQL_Shape(t *testing.T) {
+	in := FindScoreProgressInput{DataCallID: int32Ptr(4)}
+	sql, args := buildScoreProgressSQL(in)
+
+	assert.Contains(t, sql, "LEFT JOIN datacenterenvironments dce", "expected count must resolve environments through the scoring vocabulary")
+	assert.Contains(t, sql, "dce.datacenterenvironment = fs.datacenterenvironment", "system's raw environment maps into the vocabulary")
+	assert.Contains(t, sql, "f.datacenterenvironment = dce.scoring_key", "functions match on the scoring key")
+	assert.Contains(t, sql, "INNER JOIN LATERAL", "updated count must require an edit event so pre-populated rows drop out")
+	assert.Contains(t, sql, "resource = 'public.scores'", "the lateral must read score events")
+	assert.Contains(t, sql, "COUNT(DISTINCT fo.functionid)", "updated counts distinct functions, not raw rows")
+	assert.Contains(t, sql, "LEFT JOIN updated", "zero-activity systems must still return a row")
+	assert.Contains(t, sql, "COALESCE(u.questionsupdated, 0)", "zero-activity systems report 0, not NULL")
+
+	// No scope filters: the single arg is the data call id.
+	assert.Equal(t, []any{int32(4)}, args)
+}
+
+// TestBuildScoreProgressSQL_FismaSystemScope verifies a single-system request
+// narrows the expected CTE (which anchors the result set) and binds the system
+// id before the data call id.
+func TestBuildScoreProgressSQL_FismaSystemScope(t *testing.T) {
+	in := FindScoreProgressInput{
+		DataCallID:    int32Ptr(4),
+		FismaSystemID: int32Ptr(1001),
+	}
+	sql, args := buildScoreProgressSQL(in)
+
+	assert.Contains(t, sql, "fs.fismasystemid = $1")
+	assert.Equal(t, []any{int32(1001), int32(4)}, args)
+}
+
+// TestBuildScoreProgressSQL_UserScope verifies the ISSO/ISSM path: the
+// expected CTE is restricted to the requesting user's assigned systems via a
+// users_fismasystems subquery.
+func TestBuildScoreProgressSQL_UserScope(t *testing.T) {
+	uid := "11111111-1111-1111-1111-111111111111"
+	in := FindScoreProgressInput{
+		DataCallID: int32Ptr(4),
+		UserID:     &uid,
+	}
+	sql, args := buildScoreProgressSQL(in)
+
+	assert.Contains(t, sql, "SELECT fismasystemid FROM users_fismasystems WHERE userid = $1")
+	assert.Equal(t, []any{uid, int32(4)}, args)
+}
+
+// TestBuildScoreProgressSQL_OpDivScope mirrors the OpDiv read-scope contract
+// from FindScores: granted OpDivs emit an ANY predicate on the systems table;
+// a restricted-but-empty grant set fails closed with FALSE so a scoped admin
+// with no grants matches nothing rather than everything.
+func TestBuildScoreProgressSQL_OpDivScope(t *testing.T) {
+	t.Run("ScopedToGrantedOpDivs", func(t *testing.T) {
+		in := FindScoreProgressInput{
+			DataCallID:         int32Ptr(4),
+			RestrictToOpDivIDs: true,
+			OpDivIDs:           []int32{7, 9},
+		}
+		sql, args := buildScoreProgressSQL(in)
+
+		assert.Contains(t, sql, "fs.opdiv_id = ANY($1)")
+		assert.NotContains(t, sql, "FALSE", "non-empty grants should not fail closed")
+		assert.Equal(t, []any{[]int32{7, 9}, int32(4)}, args)
+	})
+
+	t.Run("RestrictedWithNoGrantsFailsClosed", func(t *testing.T) {
+		in := FindScoreProgressInput{
+			DataCallID:         int32Ptr(4),
+			RestrictToOpDivIDs: true,
+		}
+		sql, args := buildScoreProgressSQL(in)
+
+		assert.True(t, strings.Contains(sql, "FALSE"), "a scoped admin with no grants must match nothing")
+		assert.NotContains(t, sql, "opdiv_id = ANY($", "should not bind an OpDiv predicate when there are no grants")
+		assert.Equal(t, []any{int32(4)}, args)
+	})
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -138,6 +138,16 @@ components:
         error:
           type: string
       type: object
+    controller.apiResponse-array_model_ScoreProgress:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/model.ScoreProgress'
+          type: array
+          uniqueItems: false
+        error:
+          type: string
+      type: object
     controller.apiResponse-array_model_User:
       properties:
         data:
@@ -551,6 +561,33 @@ components:
           type: integer
         scoreid:
           type: integer
+      type: object
+    model.ScoreProgress:
+      properties:
+        fismasystemid:
+          type: integer
+        lastupdatedat:
+          description: |-
+            LastUpdatedAt is the most recent edit event across the system's answers
+            in this data call; nil when nothing has been touched this cycle.
+          type: string
+        questionsexpected:
+          description: |-
+            QuestionsExpected is the number of questionnaire functions applicable to
+            the system, resolved through the datacenterenvironments scoring
+            vocabulary (the same join the questionnaire and the score aggregation
+            use, so the denominator matches what an ISSO actually sees).
+          type: integer
+        questionsupdated:
+          description: |-
+            QuestionsUpdated is the number of distinct functions whose answer in
+            this data call has at least one recorded edit event.
+          type: integer
+        updatedsincestart:
+          description: |-
+            UpdatedSinceStart is a convenience flag: true when at least one answer
+            has been edited in this data call.
+          type: boolean
       type: object
     model.SystemEnrichment:
       properties:
@@ -2069,6 +2106,50 @@ paths:
       security:
       - bearerAuth: []
       summary: Diff scores between two data calls
+      tags:
+      - scores
+  /scores/progress:
+    get:
+      description: 'Returns, for each FISMA system the caller can see, how many questionnaire
+        functions apply to the system, how many have been genuinely updated in the
+        given data call (answers pre-populated from the previous cycle do not count
+        until touched), and when the most recent update happened. Scoped to the caller''s
+        tier: unscoped admins see all systems, OpDiv-scoped admins their OpDivs''
+        systems, and ISSO/ISSM their assigned systems.'
+      parameters:
+      - description: Data call ID to report progress for
+        in: query
+        name: datacallid
+        required: true
+        schema:
+          type: integer
+      - description: Limit progress to a single FISMA system
+        in: query
+        name: fismasystemid
+        schema:
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-array_model_ScoreProgress'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Get per-system questionnaire progress for a data call
       tags:
       - scores
   /systemenrichment/{fisma_uuid}:


### PR DESCRIPTION
### Summary

Adds `GET /api/v1/scores/progress`, a per-system questionnaire-progress endpoint that lets OpDiv Admins (and ISSOs, for their own systems) see which systems have actually updated their questionnaires during a data call — the core of `ztmf#299`. This is the backend half; the dashboard column ships in a companion `ztmf-ui` PR: https://github.com/CMS-Enterprise/ztmf-ui/pull/480.

### The problem this solves

When a data call opens, the backend pre-populates every system's answers by copying the previous cycle's responses (`copyPreviousScores`). So on day one, every system already has a full set of `scores` rows — which means the obvious "count the answer rows" metric reads **100% for everyone** and answers the wrong question. It measures "was this ever answered," not "did anyone touch it this cycle."

### The mechanic

The pre-population copy **deliberately records no audit events**; genuine writes through the normal save path do. That asymmetry already draws the line we need:

| Row | Has a `scores` row? | Has an edit event this cycle? |
| --- | --- | --- |
| Carried over, untouched | yes | **no** |
| Edited this cycle | yes | **yes** |

So **"updated" = the answer has an edit event in this data call.** No schema change, no new tracking — the endpoint counts answers that have an event (via the same `events` lateral join `FindScores` already uses for `last_edited_at`) against the questions applicable to the system (via the `datacenterenvironments` scoring-vocabulary, so SaaS systems get their smaller denominator).

Response, per system: `questionsexpected`, `questionsupdated`, `lastupdatedat`, `updatedsincestart`.

### Scoping

Identical tier rules to `/scores/aggregate`, applied after query decode so a client cannot widen scope via params: OWNER and HHS admins see all systems, while OpDiv admins fail closed to their granted OpDiv systems. Decommissioned systems are excluded from the response.

### File changes

| Component | Files |
| --- | --- |
| Database model | `backend/internal/model/scoreprogress.go `, `scoreprogress_test.go`, `scoreprogress_integration_test.go` |
| Handler + route | `cmd/api/internal/controller/scores.go`, `router/router.go` |
| Controller tests | `cmd/api/internal/controller/authorization_test.go` |
| Spec | `openapi.yaml` (regenerated) |

6 commits, +683 / 7 files. No migration, no schema change.

### Notes for reviewers

* Additive only, meaning no existing endpoint or write path is touched.
* `updatedsincestart` is derivable from `questionsupdated > 0`. It is kept because it names the ticket's literal question in the response and the "since start" anchor is real, since an event can only postdate the data call's creation.
* Deferred to follow-ups: a downloadable progress report with contacts (can ride the existing `/datacalls/{id}/export` CSV) and "viewed but not answered" tracking (which needs a new event type and NIH product input).
