### PR TITLE
feat(auth): logout endpoint clearing app + ALB OIDC sessions (#402)

### DIFF
--- a/backend/.redocly.lint-ignore.yaml
+++ b/backend/.redocly.lint-ignore.yaml
@@ -4,14 +4,18 @@
 # `redocly lint` in CI, while every other instance of these rules stays a hard
 # error. Keep it minimal — do not add an entry to silence a real problem.
 #
-# security-defined on GET /auth/lookup: this is the single deliberately public,
-# pre-auth route (per-user IdP lookup for the login landing page). It has no
-# `@Security bearerAuth` by design; the auth boundary is the ALB/OIDC handshake
-# downstream, not this endpoint. Every other operation still carries bearerAuth,
-# and the rule stays an error for them so a new handler that forgets `@Security`
-# fails the build. The shared-handler `path-parameters-defined` warnings and the
-# `info-license` warning are intentionally NOT ignored here — they stay visible
-# as warnings (see redocly.yaml) rather than silenced.
+# security-defined on the deliberately public, pre-auth auth routes:
+#   - GET  /auth/lookup: per-user IdP lookup for the login landing page.
+#   - POST /auth/logout: clears the session, and must work when the session is
+#     already expired, so it cannot sit behind auth either.
+# Both have no `@Security bearerAuth` by design; the auth boundary is the
+# ALB/OIDC handshake downstream, not these endpoints (logout additionally runs
+# its own same-origin CSRF check). Every other operation still carries
+# bearerAuth, and the rule stays an error for them so a new handler that forgets
+# `@Security` fails the build. The shared-handler `path-parameters-defined`
+# warnings and the `info-license` warning are intentionally NOT ignored here —
+# they stay visible as warnings (see redocly.yaml) rather than silenced.
 openapi.yaml:
   security-defined:
     - '#/paths/~1auth~1lookup/get'
+    - '#/paths/~1auth~1logout/post'

--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -212,3 +212,72 @@ func ClearSessionCookie(w http.ResponseWriter) {
 		SameSite: http.SameSiteStrictMode,
 	})
 }
+
+// albSessionCookieNames are the OIDC session cookies the ALB sets, mirrored by
+// hand from the authenticate-oidc rules in infrastructure/alb-internal.tf: the
+// AWS-default AWSELBAuthSessionCookie used by the Okta login rule, and the
+// explicit AWSELBAuthSessionCookie-Entra on the Entra rule. Clearing only
+// ztmf_session ends the app session, but the ALB keeps its own session in these
+// cookies; without expiring them too, a still-valid ALB session silently
+// re-authenticates on the next /login in dual-IdP mode, and in single-IdP mode
+// the ALB session is what gates /api/* in the first place. Keep in sync with the
+// terraform session_cookie_name values.
+var albSessionCookieNames = []string{
+	"AWSELBAuthSessionCookie",
+	"AWSELBAuthSessionCookie-Entra",
+}
+
+// ClearALBSessionCookies expires the ALB OIDC session cookies so logout drops
+// the load balancer's session, not just the app session.
+func ClearALBSessionCookies(w http.ResponseWriter) {
+	for _, base := range albSessionCookieNames {
+		// The ALB stores the session in the base cookie, or splits it into
+		// indexed shards (name-0, name-1, ...) when it exceeds one cookie's
+		// size. Expire the base plus the first two shards, which covers the
+		// OIDC tokens this app receives (comfortably under three shards).
+		// Expiring a shard the browser never received is a harmless no-op.
+		for _, name := range []string{base, base + "-0", base + "-1"} {
+			http.SetCookie(w, &http.Cookie{
+				Name:  name,
+				Value: "",
+				Path:  "/",
+				// No Domain: the ALB sets these as host-only cookies, so the
+				// expiring cookie must also be host-only to match and delete
+				// them. A Domain here would create a distinct domain-scoped
+				// cookie and leave the ALB's original in place.
+				MaxAge:   -1,
+				HttpOnly: true,
+				Secure:   true,
+			})
+		}
+	}
+}
+
+// LogoutHandler ends the user's session. It is intentionally unauthenticated and
+// registered outside auth.Middleware so a request can still clear a session that
+// is already expired or invalid. It clears the app session cookie and expires
+// the ALB OIDC session cookies, then returns 204. IdP-side single logout
+// (Okta/Entra end-session) is out of scope: no end-session endpoint is
+// configured, so this ends the ZTMF and ALB sessions only.
+//
+//	@Summary		Log out
+//	@Description	Clears the ZTMF application session cookie and the ALB OIDC session cookies, ending the session. Unauthenticated so an already-expired session can still be cleared. Does not perform IdP-side single logout.
+//	@Tags			auth
+//	@Success		204	"Session cleared"
+//	@Failure		403	{object}	errorBody
+//	@Router			/auth/logout [post]
+func LogoutHandler(w http.ResponseWriter, r *http.Request) {
+	// Mirror the middleware's CSRF posture for state-changing session requests:
+	// SameSite=Strict already blocks cross-site cookie attachment; this rejects a
+	// cross-origin forced-logout on top. A request with no Origin/Referer (e.g.
+	// the bearer-token E2E path) is allowed, exactly as in Middleware.
+	if !sameOrigin(r) {
+		writeJSONError(w, http.StatusForbidden,
+			"Request blocked: origin not allowed.",
+			CodeForbiddenOrigin)
+		return
+	}
+	ClearSessionCookie(w)
+	ClearALBSessionCookies(w)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/cmd/api/internal/auth/session_test.go
+++ b/backend/cmd/api/internal/auth/session_test.go
@@ -1,11 +1,13 @@
 package auth
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -88,4 +90,74 @@ func TestSessionHandler_Unauthorized(t *testing.T) {
 	SessionHandler(w, r)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Empty(t, w.Result().Cookies())
+}
+
+func TestClearALBSessionCookies_Attributes(t *testing.T) {
+	w := httptest.NewRecorder()
+	ClearALBSessionCookies(w)
+
+	byName := map[string]*http.Cookie{}
+	for _, c := range w.Result().Cookies() {
+		byName[c.Name] = c
+	}
+
+	// Both IdP cookie families, each with its base name and the first two shards.
+	want := []string{
+		"AWSELBAuthSessionCookie", "AWSELBAuthSessionCookie-0", "AWSELBAuthSessionCookie-1",
+		"AWSELBAuthSessionCookie-Entra", "AWSELBAuthSessionCookie-Entra-0", "AWSELBAuthSessionCookie-Entra-1",
+	}
+	require.Len(t, byName, len(want))
+	for _, name := range want {
+		c, ok := byName[name]
+		require.True(t, ok, "expected %s to be cleared", name)
+		assert.Empty(t, c.Value, "%s must be emptied", name)
+		assert.True(t, c.MaxAge < 0, "%s must be expired", name)
+		assert.Equal(t, "/", c.Path)
+		// Host-only: the ALB sets these without a Domain, so the expiring cookie
+		// must not set one either, or it would not match and delete the original.
+		assert.Empty(t, c.Domain, "%s must stay host-only", name)
+	}
+}
+
+func TestLogoutHandler_ClearsSessionAndALBCookies(t *testing.T) {
+	// Same-origin (no Origin/Referer is treated as same-origin) POST logs out.
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	w := httptest.NewRecorder()
+	LogoutHandler(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	byName := map[string]*http.Cookie{}
+	for _, c := range w.Result().Cookies() {
+		byName[c.Name] = c
+	}
+	// The app session cookie plus both ALB cookie families (base + two shards).
+	require.Len(t, byName, 1+6)
+
+	session, ok := byName[config.GetInstance().Auth.SessionCookieName]
+	require.True(t, ok, "session cookie must be cleared")
+	assert.Empty(t, session.Value)
+	assert.True(t, session.MaxAge < 0, "session cookie must be expired")
+
+	_, ok = byName["AWSELBAuthSessionCookie"]
+	assert.True(t, ok, "Okta ALB cookie must be cleared")
+	_, ok = byName["AWSELBAuthSessionCookie-Entra"]
+	assert.True(t, ok, "Entra ALB cookie must be cleared")
+}
+
+func TestLogoutHandler_RejectsForeignOrigin(t *testing.T) {
+	// A cross-origin forced-logout is rejected with the same code/shape the
+	// middleware uses for CSRF, and clears nothing.
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	r.Host = "ztmf.example.gov"
+	r.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	LogoutHandler(w, r)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Empty(t, w.Result().Cookies(), "must not clear cookies on a blocked origin")
+
+	var body errorBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, CodeForbiddenOrigin, body.Code)
 }

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -22,6 +22,12 @@ func Handler() http.Handler {
 	lookupLimiter := auth.NewRateLimiter(rate.Limit(5), 10, 10*time.Minute)
 	root.Handle("/api/v1/auth/lookup", lookupLimiter.Middleware(http.HandlerFunc(controller.LookupIdP))).Methods("GET")
 
+	// Logout is likewise unauthenticated: it must be able to clear a session
+	// that is already expired or invalid, so it cannot sit behind auth.Middleware.
+	// POST-only; it clears the app session cookie and the ALB OIDC session
+	// cookies (LogoutHandler runs its own same-origin CSRF check).
+	root.HandleFunc("/api/v1/auth/logout", auth.LogoutHandler).Methods("POST")
+
 	// Post-OIDC login. The ALB authenticates /login* per IdP and forwards here
 	// with the IdP token in the auth header; SessionHandler mints the app
 	// session cookie. These live outside auth.Middleware because no app session

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -321,6 +321,25 @@ tests:
     expect:
       status: 400
 
+  # Logout - unauthenticated (must clear an already-expired session), POST-only.
+  # No Authorization header and no Origin by design: a request with no Origin is
+  # treated as same-origin, so this succeeds and returns 204.
+  - url: "http://localhost:8080/api/v1/auth/logout"
+    method: POST
+    expect:
+      status: 204
+
+  # A cross-origin forced-logout is rejected by the same-origin CSRF check.
+  - url: "http://localhost:8080/api/v1/auth/logout"
+    method: POST
+    headers:
+      Origin: "https://evil.example.com"
+    expect:
+      status: 403
+      body:
+        json:
+          code: "FORBIDDEN_ORIGIN"
+
   # OpDivs Endpoint - reference list used by frontend selectors
   - url: http://localhost:8080/api/v1/opdivs
     method: GET

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,5 +1,12 @@
 components:
   schemas:
+    auth.errorBody:
+      properties:
+        code:
+          type: string
+        error:
+          type: string
+      type: object
     controller.DecommissionRequest:
       properties:
         decommissioned_date:
@@ -626,6 +633,23 @@ info:
   version: 1.0.0
 openapi: 3.1.0
 paths:
+  /auth/logout:
+    post:
+      description: Clears the ZTMF application session cookie and the ALB OIDC session
+        cookies, ending the session. Unauthenticated so an already-expired session
+        can still be cleared. Does not perform IdP-side single logout.
+      responses:
+        "204":
+          description: Session cleared
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/auth.errorBody'
+          description: Forbidden
+      summary: Log out
+      tags:
+      - auth
   /auth/lookup:
     get:
       description: 'Unauthenticated pre-auth lookup the landing page uses to route


### PR DESCRIPTION
> **Note:** In-repo copy of #403 by @voidspooks. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #403

---

Closes #402.

## What

Adds `POST /api/v1/auth/logout`, registered on the unauthenticated `root` router (alongside `/auth/lookup` and `/login`) so it can clear a session that is already expired or invalid — it must not sit behind `auth.Middleware`.

The handler:
- Clears the `ztmf_session` app session cookie (via the existing `ClearSessionCookie`).
- Expires the ALB OIDC session cookies — `AWSELBAuthSessionCookie` (Okta) and `AWSELBAuthSessionCookie-Entra` (Entra), plus their `-0`/`-1` shards — as **host-only** deletes (no `Domain`) to match how the ALB sets them.
- Runs the same same-origin CSRF check the middleware applies to state-changing session requests (it's outside the middleware, so it does this itself), returning the standard `FORBIDDEN_ORIGIN` error shape on a cross-origin request.
- Returns `204 No Content`.

## Why the ALB cookies matter

Clearing `ztmf_session` alone is not a complete logout:
- **Dual-IdP mode** (`entra_enabled=true`): `/api/*` is gated by `ztmf_session`, so clearing it blocks API access — but a still-valid ALB session silently re-authenticates the user on their next `/login` with no credential prompt.
- **Single-IdP mode**: `/api/*` is gated by the ALB OIDC session itself, so expiring the ALB cookies is required, not best-effort.

The cookie names mirror the `session_cookie_name` values in `infrastructure/alb-internal.tf` (documented in a comment kept in sync by hand).

## Out of scope

IdP-side single logout (Okta/Entra `end_session` redirect). No end-session endpoint is configured anywhere in code or Terraform today; that's a separate config + infra change. This ends the ZTMF and ALB sessions only.

## Tests

- **Unit** (`session_test.go`): cookie clearing (session + ALB families, host-only attributes, expired), and CSRF rejection on a foreign origin returning `FORBIDDEN_ORIGIN`.
- **E2E** (`emberfall_tests.yml`): `204` on same-origin POST, `403` + `FORBIDDEN_ORIGIN` on a cross-origin POST.
- Regenerated `openapi.yaml`; the deliberately-public logout route is added to the redocly `security-defined` ignore list next to `/auth/lookup` (the rule stays a hard error for every other handler).

Ran locally and passing: `make test-unit`, `make test-integration`, `make test-e2e` (143 emberfall, 0 failed), `make lint-openapi`.

The frontend logout button is the partner ticket, CMS-Enterprise/ztmf-ui#477.
