### PR TITLE
Fix score-progress integration test and gate integration tests in CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,6 +9,37 @@ on:
         required: true
         
 jobs:
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          # Read the required Go from go.mod (setup-go v6 sets GOTOOLCHAIN=local,
+          # so a pinned version below go.mod's would not auto-download).
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      # Runs `go test -run Integration ./...` against an isolated, freshly-seeded
+      # DB brought up and torn down by backend/compose-test.yml. This is the only
+      # place on main that executes the Go integration tests; without it, an
+      # integration regression (e.g. #407's red TestFindScoreProgressIntegration)
+      # merges green.
+      #
+      # This is a peer of `build`, so it gates the MERGE (mark it a required check
+      # in branch protection) but does not block `build`'s deploy steps, which run
+      # in parallel. That is intentional: merge-gating keeps a red integration test
+      # out of main, and prod (deployed post-merge) therefore never runs on red.
+      # A PR auto-deploying to dev while red is acceptable and self-corrects on the
+      # next green push. To gate the deploy itself, add `needs: [integration-tests]`
+      # to `build`.
+      - name: Integration tests (isolated ephemeral DB)
+        run: make test-integration
+
   build:
     name: Build and Smoke Test
     runs-on: ubuntu-latest

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -34,27 +34,36 @@ func TestFindScoreProgressIntegration(t *testing.T) {
 	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
 	defer conn.Release()
 
-	// Two synthetic datacalls ordered so copyPreviousScores' "latest-1 is
-	// previous" logic finds the right one. Prefixed names make them (and
-	// their scores, via FK cascade) discoverable by the purge sweep no
-	// matter how the test exits.
+	// copyPreviousScores resolves "previous" via findPreviousDataCall, which
+	// returns the datacall with the furthest deadline other than the target (it
+	// is only ever called on the newest cycle, so "latest, excluding me" is the
+	// real previous). The seed carries a far-future cycle (the 2099 "Audit Fields
+	// Smoke Cycle", datacallid 5), so the synthetic cycle must sit ABOVE every
+	// existing deadline: newDC must be the global latest and prevDC the next one
+	// down, or findPreviousDataCall(newDC) rolls a seed datacall forward instead
+	// of our marker. Anchor both deadlines above the current max. Prefixed names
+	// make them (and their scores, via FK cascade) discoverable by the purge
+	// sweep no matter how the test exits.
 	var prevDC, newDC int32
-	prevTimestamp := time.Now().Add(-2 * time.Hour)
-	newTimestamp := time.Now().Add(-1 * time.Hour)
+	var maxDeadline time.Time
+	err = conn.QueryRow(ctx, `SELECT COALESCE(MAX(deadline), NOW()) FROM datacalls`).Scan(&maxDeadline)
+	require.NoError(t, err)
+	prevDeadline := maxDeadline.Add(24 * time.Hour)
+	newDeadline := maxDeadline.Add(48 * time.Hour)
 	suffix := time.Now().UnixNano()
 
 	err = conn.QueryRow(ctx, `
 		INSERT INTO datacalls (datacall, datecreated, deadline)
-		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
+		VALUES ($1, $2::timestamptz, $3::timestamptz)
 		RETURNING datacallid
-	`, fmt.Sprintf("%sprogress_prev_%d", integrationTestPrefix, suffix), prevTimestamp).Scan(&prevDC)
+	`, fmt.Sprintf("%sprogress_prev_%d", integrationTestPrefix, suffix), time.Now().Add(-2*time.Hour), prevDeadline).Scan(&prevDC)
 	require.NoError(t, err)
 
 	err = conn.QueryRow(ctx, `
 		INSERT INTO datacalls (datacall, datecreated, deadline)
-		VALUES ($1, $2::timestamptz, $2::timestamptz + INTERVAL '90 days')
+		VALUES ($1, $2::timestamptz, $3::timestamptz)
 		RETURNING datacallid
-	`, fmt.Sprintf("%sprogress_new_%d", integrationTestPrefix, suffix), newTimestamp).Scan(&newDC)
+	`, fmt.Sprintf("%sprogress_new_%d", integrationTestPrefix, suffix), time.Now().Add(-1*time.Hour), newDeadline).Scan(&newDC)
 	require.NoError(t, err)
 
 	// Borrow a valid (system, functionoption) pair from seeded data so FK


### PR DESCRIPTION
Two deliverables, one PR.

## 1. Fix `TestFindScoreProgressIntegration`

The test (added in #407) has been red on main since it merged, because no CI job on main runs the Go integration tests (see deliverable 2). Root cause:

`copyPreviousScores` resolves "previous" via `findPreviousDataCall`, which post-#397 returns the datacall with the **globally furthest deadline** other than the target (correct in prod, where the new cycle always has the furthest deadline). The empire seed carries a far-future cycle - the "Audit Fields Smoke Cycle", datacallid 5, deadline `2099-12-31`. So `findPreviousDataCall(newDC)` returned that 2099 seed datacall, `copyPreviousScores` rolled its scores rather than the test's marker into `newDC`, and the marker lookup found no rows.

Fix: anchor the two synthetic datacalls' deadlines above the current `MAX(deadline)` (`prevDC` at max+24h, `newDC` at max+48h), so `newDC` is the global latest and `prevDC` is the one `findPreviousDataCall` rolls forward - independent of whatever the seed holds, and self-healing across reruns. The copy-then-edit semantics under test are unchanged (progress is computed from event presence, not deadlines).

## 2. Gate integration tests in CI

`go test -run Integration` ran nowhere on main - only impl's pre-push hook executed it. Added an `integration-tests` job to `backend.yml` that runs `make test-integration` (isolated, freshly-seeded compose-test DB, brought up and torn down). It is a **peer of `build`**, so it gates the merge (mark it a required check in branch protection); prod, which deploys post-merge, therefore never runs on a red integration test. The comment documents that `build`'s deploy runs in parallel and how to gate the deploy itself if wanted later.

## Verification

- `make test-integration` green (was red before the fix).
- `make test-full` green (unit + 143 e2e, 0 failures).
- `gofmt` / `go vet` clean.

## Follow-ups (out of scope, filed)

- **#411** - `copyPreviousScores` silently swallows both its errors (and runs as a goroutine), so a bad previous cycle can open a new data call with zero carried-over answers with no signal. The happy path is now covered by this test; the sad path deserves loud failure.
- Minor: `make test-integration` uses a fixed `sleep 15` rather than a readiness poll; fine locally, could flake on a cold CI runner now that it is on the critical path.