### PR TITLE
Skip local seed when the database already has data

### DIFF
--- a/backend/cmd/api/internal/migrations/populate.go
+++ b/backend/cmd/api/internal/migrations/populate.go
@@ -9,19 +9,53 @@ import (
 )
 
 func populate(path string) error {
-	log.Printf("Populating database with %s\n", path)
+	ctx := context.TODO()
+
+	// The seed script is not idempotent (it INSERTs fixed-key rows and fails with a
+	// duplicate-key error on a second run). A local dev volume persists across restarts,
+	// so on every `make dev-up` after the first the seed would otherwise re-run against
+	// an already-populated database and crash the api on boot. Skip seeding when the
+	// database already holds data, preserving whatever the developer has loaded (e.g. a
+	// dev/prod DB sync). Ephemeral test databases (Emberfall E2E) start empty each run,
+	// so they still seed normally.
+	seeded, err := alreadySeeded(ctx)
+	if err != nil {
+		return err
+	}
+	if seeded {
+		log.Print("Skipping populate: database already contains data")
+		return nil
+	}
+
+	log.Printf("Populating database with %s", path)
 	sql, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-
-	ctx := context.TODO()
 
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Release()
+
 	_, err = conn.Exec(ctx, string(sql))
 	return err
+}
+
+// alreadySeeded reports whether the database already holds seed data. It checks
+// fismasystems, a core table created by migrations and populated by the seed script.
+func alreadySeeded(ctx context.Context) (bool, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer conn.Release()
+
+	var count int
+	err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM fismasystems").Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }

--- a/backend/cmd/api/internal/migrations/populate_integration_test.go
+++ b/backend/cmd/api/internal/migrations/populate_integration_test.go
@@ -1,0 +1,39 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPopulateSkipsWhenSeededIntegration pins the seed gate against a real
+// database: once data exists, populate() must be a no-op rather than re-running
+// the non-idempotent seed script and crashing the api on boot with a
+// duplicate-key error. make test-integration seeds the ephemeral DB on startup,
+// so fismasystems already holds rows by the time this runs.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestPopulateSkipsWhenSeededIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	conn.Release()
+
+	seeded, err := alreadySeeded(ctx)
+	require.NoError(t, err)
+	require.True(t, seeded, "integration DB is seeded on startup, so alreadySeeded must report true")
+
+	// The path is deliberately nonexistent: if the gate works, populate() returns
+	// before ever reading the file. A missing-file error here would mean the gate
+	// let execution fall through to os.ReadFile on an already-seeded database.
+	err = populate("/does-not-exist-populate-gate-test.sql")
+	require.NoError(t, err, "populate must skip (without touching the filesystem) when the database already has data")
+}


### PR DESCRIPTION
Fixes #414.

## Problem

Restarting the local backend with `make dev-up` after the first run crash-loops the api container. The seed script (`_test_data_empire.sql`) is not idempotent, and the local docker volume persists across `docker compose down`, so every boot after the first re-runs the seed against an already-populated database and dies with:

```
ERROR: duplicate key value violates unique constraint "datacall_key" (SQLSTATE 23505)
```

This is especially painful after loading real data into the local volume (e.g. a dev/prod sync), because the only workaround was to wipe the volume - destroying exactly the data you wanted to keep.

## Change

Gate `populate()` on an empty-database check. Before loading the seed, it counts rows in `fismasystems` (a core table created by migrations and populated by the seed). If the database already holds data, seeding is skipped and the existing data is left untouched. A fresh, empty volume still seeds as before.

The check runs before any connection is acquired for the load, and only reads the filesystem when it actually intends to seed, so an already-seeded restart neither touches the seed file nor holds a pooled connection unnecessarily.

## Why this is safe for CI

The Emberfall E2E stack and the Go integration stack both spin up an ephemeral database with no persistent volume, so they start empty every run and continue to seed normally. Only a persisted local dev volume is affected.

## Testing

- Added `TestPopulateSkipsWhenSeededIntegration`, which asserts the gate reports an already-seeded DB and that a second `populate()` is a no-op (it passes a nonexistent path to prove the gate returns before any file read).
- `make test-full` passes locally: 143 Emberfall E2E checks, 0 failures, plus the integration suite.
- Manually verified `make dev-down && make dev-up` on a persisted volume now logs `Skipping populate: database already contains data` and boots cleanly, with the loaded data (1369 systems) intact.