### PR TITLE
Add system_insights table (JSONB seam for ZTMF Insights)

### DIFF
--- a/backend/cmd/api/internal/migrations/0047systeminsights.go
+++ b/backend/cmd/api/internal/migrations/0047systeminsights.go
@@ -1,0 +1,24 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add generic system_insights extension table",
+		// UP: Generic, insight-agnostic per-question extension point owned by ztmf
+		// core. The ztmf-insights sync lambda populates the jsonb payload from
+		// Snowflake, keyed on (fismasystemid, questionid). Adding or removing
+		// insight fields (Kion, SecurityHub, Hardenize, CFACTS, ARS scores or
+		// evidence) is a payload-key change in that pipeline and requires no change
+		// here. Keyed on fismasystemid (the app PK, always populated and matching
+		// the API param + users_fismasystems RBAC) rather than fisma_uuid, which is
+		// kept inside the payload for display. No FK: this is a disposable
+		// TRUNCATE+INSERT sync cache, mirroring system_enrichment.
+		`CREATE TABLE IF NOT EXISTS public.system_insights (
+			fismasystemid INTEGER     NOT NULL,
+			questionid    INTEGER     NOT NULL,
+			payload       JSONB       NOT NULL,
+			synced_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			PRIMARY KEY (fismasystemid, questionid)
+		);`,
+		// DOWN
+		`DROP TABLE IF EXISTS public.system_insights;`)
+}


### PR DESCRIPTION
## What

Adds `public.system_insights` via migration `0047systeminsights.go`, following the pattern of `0038systemenrichment.go`.

```
public.system_insights (
  fismasystemid INTEGER     NOT NULL,
  questionid    INTEGER     NOT NULL,
  payload       JSONB       NOT NULL,
  synced_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  PRIMARY KEY (fismasystemid, questionid)
)
```

## Why

This carries per-system x question ZTMF Insights scoring (Kion / SecurityHub / Hardenize / CFACTS / ARS) from Snowflake into Aurora so the API can serve it for the HHS data-call user testing. It is a distinct grain from `system_enrichment`, which carries per-system CFACTS metadata keyed on `fisma_uuid`; `system_insights` is the per-question seam.

## Design decisions

- **Generic JSONB payload, not typed columns.** All scoring and evidence live in `payload`, so adding a field later is a pipeline payload-key change with no further migration - same approach as `system_enrichment`.
- **Key is `(fismasystemid, questionid)`.** `fismasystemid` is the app's own PK and matches both the API param and the `users_fismasystems` RBAC scoping directly, for reads and writes. `fisma_uuid` stays inside the payload for display.
- **No foreign key (deliberate).** Mirrors `system_enrichment`: a disposable TRUNCATE+INSERT sync cache written by the lambda. A FK to `fismasystems` / `questions` would only risk sync failures on a system or question mid-change; referential integrity is the sync's responsibility.
- **No datacall dimension.** Grain is current-state per system x question.
- **Table owned by ztmf core.** The migration lives here; the ztmf-insights sync lambda only writes to it.

## Testing

- `make dev-setup` applies the migration clean on a fresh database.
- `\d public.system_insights` shows the composite primary key.
- Backend compiles.

Closes #416