### PR TITLE
fix(scorediff): ignore whitespace-only note differences in data-call diff

### DIFF
--- a/backend/internal/model/scorediff.go
+++ b/backend/internal/model/scorediff.go
@@ -59,9 +59,11 @@ type FindScoreDiffInput struct {
 // differs between them, each annotated with who made the later change and when.
 //
 // "Differs" means the selected functionoption changed, the notes changed, or
-// the function was answered in exactly one of the two cycles. nil and empty
-// notes are treated as equal so a NULL-vs-"" notes box does not surface as a
-// spurious change (matching scoresEqualForUpdate's normalization).
+// the function was answered in exactly one of the two cycles. Notes are
+// compared with whitespace normalized (nil and empty treated as equal, leading
+// and trailing whitespace trimmed, internal runs collapsed) so neither a
+// NULL-vs-"" notes box nor a spacing-only difference surfaces as a spurious
+// change (see #409).
 //
 // The query is hand-built parameterized SQL rather than squirrel because the
 // FULL OUTER JOIN between the two cycles, the catalog joins for the function /
@@ -114,6 +116,12 @@ func buildScoreDiffSQL(input FindScoreDiffInput) (string, []any) {
 	// because the later write is what "who made the change" refers to; the
 	// partial index events_score_audit_idx serves it. The IS DISTINCT FROM
 	// pair is the "drop the unchanged rows" filter.
+	//
+	// Notes are compared with whitespace normalized (leading/trailing trimmed
+	// and internal runs collapsed to a single space) so a note that differs
+	// only in spacing -- e.g. the FY23 two-spaces-after-a-period vintage vs
+	// FY24 single spaces -- is not reported as a change. Only the comparison is
+	// normalized; the stored notes are returned verbatim (see #409).
 	sql := fmt.Sprintf(`
 WITH from_scores AS (%s),
      to_scores AS (%s)
@@ -141,7 +149,9 @@ LEFT JOIN LATERAL (
 ) le ON TRUE
 LEFT JOIN users eu ON eu.userid = le.userid
 WHERE f.functionoptionid IS DISTINCT FROM t.functionoptionid
-   OR COALESCE(f.notes, '') IS DISTINCT FROM COALESCE(t.notes, '')
+   OR btrim(regexp_replace(COALESCE(f.notes, ''), '\s+', ' ', 'g'))
+      IS DISTINCT FROM
+      btrim(regexp_replace(COALESCE(t.notes, ''), '\s+', ' ', 'g'))
    OR f.notes_is_ai_summary IS DISTINCT FROM t.notes_is_ai_summary
 ORDER BY fismasystemid, fn.ordr, functionid
 `, fromCTE, toCTE)

--- a/backend/internal/model/scorediff_test.go
+++ b/backend/internal/model/scorediff_test.go
@@ -67,7 +67,7 @@ func TestBuildScoreDiffSQL_Shape(t *testing.T) {
 
 	assert.Contains(t, sql, "FULL OUTER JOIN to_scores", "must outer-join the two cycles so one-sided answers surface")
 	assert.Contains(t, sql, "f.functionoptionid IS DISTINCT FROM t.functionoptionid", "must drop rows with an unchanged option")
-	assert.Contains(t, sql, "COALESCE(f.notes, '') IS DISTINCT FROM COALESCE(t.notes, '')", "nil/empty notes must compare equal")
+	assert.Contains(t, sql, `regexp_replace(COALESCE(f.notes, ''), '\s+', ' ', 'g')`, "notes must be whitespace-normalized before comparison (nil/empty equal, spacing-only differences ignored)")
 	assert.Contains(t, sql, "resource = 'public.scores'", "attribution lateral must read score events")
 	assert.Contains(t, sql, "(payload->>'scoreid')::int = t.scoreid", "attribution must key on the later (To) write")
 

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -496,7 +496,15 @@ func TestScoreSaveStampsAuditFieldsIntegration(t *testing.T) {
 		Role:     "OWNER",
 	})
 
-	before := time.Now().UTC()
+	// Capture "before" from the DATABASE clock, not time.Now(): LastEditedAt
+	// is stamped by Postgres CURRENT_TIMESTAMP (events.createdat), and on
+	// macOS the Docker VM clock wanders tens of ms relative to the host, so a
+	// host-clock 'before' intermittently reads later than the DB-stamped edit
+	// and fails the ordering assertion. Same clock on both sides = exact
+	// comparison with no tolerance, on every platform. (Mirrors Save's own
+	// rationale for reading the stamp back instead of using time.Now().)
+	var before time.Time
+	require.NoError(t, conn.QueryRow(ctx, `SELECT clock_timestamp()`).Scan(&before))
 	saved, err := s.Save(tarkinCtx)
 	require.NoError(t, err)
 	require.NotNil(t, saved)

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -891,6 +891,104 @@ func TestFindScoreDiffIntegration(t *testing.T) {
 	}
 }
 
+// TestFindScoreDiffNotesWhitespaceIntegration pins the #409 fix against the
+// real Postgres regexp: with the selected option identical across both cycles,
+// a note that differs only in whitespace (the FY23 two-spaces-after-a-period
+// vintage vs FY24 single spaces) must NOT surface as a change, while a genuine
+// content change to a note must. Exercises the whitespace-normalizing
+// IS DISTINCT FROM clause, which pure-Go builder tests cannot see execute.
+//
+// Empire fixtures only (see [[feedback_no_real_pii_in_tests]]).
+func TestFindScoreDiffNotesWhitespaceIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	suffix := time.Now().UnixNano()
+	var dcFrom, dcTo int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), NOW() + INTERVAL '30 days') RETURNING datacallid
+	`, fmt.Sprintf("%swsdiff_from_%d", integrationTestPrefix, suffix)).Scan(&dcFrom))
+	require.NoError(t, conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), NOW() + INTERVAL '30 days') RETURNING datacallid
+	`, fmt.Sprintf("%swsdiff_to_%d", integrationTestPrefix, suffix)).Scan(&dcTo))
+
+	// Two distinct functions, one option each. Same option is reused in both
+	// cycles so ONLY the notes vary between from and to.
+	var fWS, fReal, optWS, optReal int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT functionid, functionoptionid FROM functionoptions ORDER BY functionid LIMIT 1
+	`).Scan(&fWS, &optWS))
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT functionid, functionoptionid FROM functionoptions WHERE functionid <> $1 ORDER BY functionid LIMIT 1
+	`, fWS).Scan(&fReal, &optReal))
+
+	var sys int32
+	require.NoError(t, conn.QueryRow(ctx, `SELECT fismasystemid FROM scores LIMIT 1`).Scan(&sys))
+
+	tarkin := UserToContext(ctx, &User{
+		UserID: "11111111-1111-1111-1111-111111111111", Email: "Grand.Moff@DeathStar.Empire",
+		FullName: "Grand Moff Tarkin", Role: "OWNER",
+	})
+
+	saveNote := func(fo, dc int32, notes string) int32 {
+		t.Helper()
+		s, err := (&Score{FismaSystemID: sys, FunctionOptionID: fo, DataCallID: dc, Notes: &notes}).Save(tarkin)
+		require.NoError(t, err)
+		return s.ScoreID
+	}
+
+	createdScoreIDs := []int32{
+		// fWS: same answer, notes differ ONLY by whitespace -> must be dropped.
+		saveNote(optWS, dcFrom, "Segmentation complete.  Controls verified."),
+		saveNote(optWS, dcTo, "Segmentation complete. Controls verified."),
+		// fReal: same answer, note CONTENT changed -> must surface.
+		saveNote(optReal, dcFrom, "Encryption at rest enabled."),
+		saveNote(optReal, dcTo, "Encryption at rest and in transit enabled."),
+	}
+	defer func() {
+		for _, id := range createdScoreIDs {
+			_, _ = conn.Exec(ctx, `DELETE FROM events WHERE resource='public.scores' AND (payload->>'scoreid')::int = $1`, id)
+			_, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid = $1`, id)
+		}
+	}()
+
+	diffs, err := FindScoreDiff(ctx, FindScoreDiffInput{
+		FismaSystemID:  &sys,
+		FromDataCallID: &dcFrom,
+		ToDataCallID:   &dcTo,
+	})
+	require.NoError(t, err)
+
+	byFunction := map[int32]*ScoreDiff{}
+	for _, d := range diffs {
+		byFunction[d.FunctionID] = d
+	}
+
+	assert.NotContains(t, byFunction, fWS,
+		"a note differing only by whitespace (same answer) must not surface as a change (#409)")
+
+	if assert.Contains(t, byFunction, fReal,
+		"a genuine note content change (same answer) must still surface") {
+		d := byFunction[fReal]
+		require.NotNil(t, d.From)
+		require.NotNil(t, d.To)
+		assert.Equal(t, "Encryption at rest enabled.", derefString(d.From.Notes))
+		assert.Equal(t, "Encryption at rest and in transit enabled.", derefString(d.To.Notes),
+			"stored notes are returned verbatim; only the comparison is normalized")
+	}
+}
+
 // countScoreEvents is a small helper used by the no-op preservation test
 // to assert that read-through Saves do not append event rows.
 func countScoreEvents(t *testing.T, ctx context.Context, conn *pgxpool.Conn, scoreID int32) int {


### PR DESCRIPTION
## Summary

Fixes #409 — the "Compare Data Calls" diff (`GET /api/v1/scores/diff`) flagged a function as changed when its notes differed by even a single whitespace character. The HHS historical import surfaced it: FY23 notes used the two-spaces-after-a-period convention while FY24 used single spaces, so 96% (22,658 / 23,637) of notes-flagged functions on the HHS FY23→FY24 boundary were whitespace-only diffs with identical wording.

## Change

Normalize whitespace on both sides of the notes comparison in `buildScoreDiffSQL`:

```sql
OR btrim(regexp_replace(COALESCE(f.notes, ''), '\s+', ' ', 'g'))
   IS DISTINCT FROM
   btrim(regexp_replace(COALESCE(t.notes, ''), '\s+', ' ', 'g'))
```

- Trim + collapse internal whitespace runs before comparing (`'g'` = all runs, not just the first).
- Only the **comparison** is normalized — stored notes and returned values are verbatim.
- Answer changes, AI-summary-flag changes, and genuine note-content changes still surface.

## Tests

- New `TestFindScoreDiffNotesWhitespaceIntegration`: with the same answer in both cycles, a whitespace-only note difference produces **no** diff row while a genuine content change still does, and returned notes are verbatim.
- Updated `TestBuildScoreDiffSQL_Shape` to pin the normalized clause.
- Second commit fixes a pre-existing macOS-only flake found while validating: `TestScoreSaveStampsAuditFieldsIntegration` compared a host-clock `time.Now()` against the Postgres-stamped `LastEditedAt` (DB container clock) with zero tolerance, so Docker VM clock wander made it fail intermittently on Macs (never on Linux CI). It now captures `before` from `SELECT clock_timestamp()` — same clock on both sides, exact assertion on every platform.

## Validation

Full local suite green: `make test-unit`, `make test-integration` (isolated seeded DB), and `make test-e2e` (emberfall, 143/143 passed).

Note: Snyk / secret-dependent CI checks will show red as usual for fork PRs (no repo secrets).