### PR TITLE
Add GET /api/v1/insights reader for per-system per-question ZTMF Insights

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -571,6 +571,36 @@ INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
     '2026-05-20 00:00:00+00'
 ) ON CONFLICT (fisma_uuid) DO NOTHING;
 
+-- Generic system_insights rows (issue #416), keyed on (fismasystemid, questionid).
+-- The payload is opaque to ztmf core (owned by the insights pipeline); these are
+-- Star Wars themed mocks that mirror the real payload shape (per-source suggested
+-- score/label, evidence_sources, and a nested findings object with id / nist /
+-- description / remediation). They give /insights E2E + integration coverage:
+--   1003 (Shield Gen)  - EMPIRE (insights_enabled), assigned to the Emberfall ISSO
+--   1001 (Death Star)  - EMPIRE (insights_enabled), NOT assigned to that ISSO,
+--                        so an ISSO read must return 1003 but never 1001 (scope)
+INSERT INTO public.system_insights (fismasystemid, questionid, payload, synced_at) VALUES
+  (1003, 1,
+   '{"pillar":"Identity","question_text":"How does the system authorize access?","suggested_score":2,"suggested_label":"Initial","evidence_sources":"Kion, SecurityHub","score_floor_source":"Kion (failing checks)","findings":{"kion":[{"id":"shield-relay-without-mfa","nist_controls":"IA-2","description":"Shield generator control relays must enforce multi-factor authentication for operator access.","remediation":"Enable Force-signature MFA on all shield relay operator accounts."}],"sechub":[{"id":"SG.1","title":"Shield frequency should rotate on a fixed schedule","severity":"MEDIUM","description":"Static shield frequencies are predictable and can be mapped by an adversary.","remediation":"Rotate deflector shield frequency per operational window."}]}}',
+   '2026-05-20 00:00:00+00'),
+  (1003, 2,
+   '{"pillar":"Applications","question_text":"How is application access controlled?","suggested_score":1,"suggested_label":"Traditional","evidence_sources":"SecurityHub","findings":{"sechub":[{"id":"SG.2","title":"Console access should not use shared credentials","severity":"LOW","description":"Shared bridge credentials prevent per-operator attribution.","remediation":"Issue individual operator credentials."}]}}',
+   '2026-05-20 00:00:00+00'),
+  (1001, 1,
+   '{"pillar":"Identity","question_text":"How does the system authorize access?","suggested_score":1,"suggested_label":"Traditional","evidence_sources":"Kion","score_floor_source":"Kion (failing checks)","findings":{"kion":[{"id":"exhaust-port-unshielded","nist_controls":"SC-7","description":"The thermal exhaust port is reachable without boundary protection.","remediation":"Add a ray shield and defensive boundary controls to the exhaust port."}]}}',
+   '2026-05-20 00:00:00+00')
+ON CONFLICT (fismasystemid, questionid) DO NOTHING;
+
+-- Insight row for a REBELLION system (RB-1, 1005). REBELLION has insights_enabled
+-- = FALSE, so the OpDiv gate must hide this row: even an unscoped admin reading
+-- /insights gets no row for it. Proves the gate is the OpDiv flag, not a missing
+-- row or an access failure.
+INSERT INTO public.system_insights (fismasystemid, questionid, payload, synced_at) VALUES
+  (1005, 1,
+   '{"pillar":"Identity","suggested_score":1,"suggested_label":"Traditional","evidence_sources":"Kion","findings":{"kion":[{"id":"base-shield-offline","nist_controls":"SC-7","description":"The base shield is offline during the attack window.","remediation":"Restore shield power before exposure."}]}}',
+   '2026-05-20 00:00:00+00')
+ON CONFLICT (fismasystemid, questionid) DO NOTHING;
+
 -- ============================================================================
 -- EXPANDED EMPIRE FIXTURE (dev/demo): multi-OpDiv org, more systems and
 -- officers, a 4-cycle (FY2022-FY2025) data-call history with maturity that

--- a/backend/cmd/api/internal/controller/insights.go
+++ b/backend/cmd/api/internal/controller/insights.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+)
+
+//	@Summary	List per-system per-question insights
+//	@Tags		insights
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		fismasystemid	query		int	false	"Filter by FISMA system ID"
+//	@Param		questionid		query		int	false	"Filter by question ID"
+//	@Success	200				{object}	apiResponse[[]model.SystemInsight]
+//	@Failure	500				{object}	apiResponse[any]
+//	@Router		/insights [get]
+func ListSystemInsights(w http.ResponseWriter, r *http.Request) {
+	var (
+		insights []*model.SystemInsight
+		err      error
+	)
+	user := model.UserFromContext(r.Context())
+	in := model.FindSystemInsightsInput{}
+
+	err = decoder.Decode(&in, r.URL.Query())
+
+	// Scope by tier AFTER decode so a client cannot widen scope via query
+	// params: unscoped admins see all; OpDiv tiers fail-closed to their granted
+	// OpDivs' systems; ISSO/ISSM keep the per-system (UserID) path.
+	switch {
+	case user.HasUnscopedRead():
+		// no scope filter
+	case user.IsOpDivTier():
+		in.RestrictToOpDivIDs = true
+		_, in.OpDivIDs = user.EffectiveOpDivScope()
+	default:
+		in.UserID = &user.UserID
+	}
+
+	if err == nil {
+		insights, err = model.FindSystemInsights(r.Context(), in)
+	}
+
+	respond(w, r, insights, err)
+}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -112,6 +112,8 @@ func Handler() http.Handler {
 
 	router.HandleFunc("/api/v1/systemenrichment/{fisma_uuid:[a-zA-Z0-9-]+}", controller.GetSystemEnrichment).Methods("GET")
 
+	router.HandleFunc("/api/v1/insights", controller.ListSystemInsights).Methods("GET")
+
 	// massemails resource only supports a single verb as there are no records to get list and details for, but the operation is non-idempotent
 	router.HandleFunc("/api/v1/massemails", controller.SaveMassEmail).Methods("POST")
 

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1570,6 +1570,40 @@ tests:
     expect:
       status: 404
 
+  # ZTMF Insights (issue #416). /insights is a LIST endpoint: scope and the
+  # OpDiv gate yield an empty array (200), never 403/404. Array bodies assert
+  # since aquia-inc/emberfall#36 closed, but only the scalar key columns are
+  # pinned here; the nested jsonb payload and exhaustive scope/gate coverage
+  # live in internal/model/systeminsights_integration_test.go.
+  #
+  # Admin (unscoped) reads a single insight row by key.
+  - url: "http://localhost:8080/api/v1/insights?fismasystemid=1003&questionid=1"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - fismasystemid: 1003
+              questionid: 1
+
+  # OpDiv gate: RB-1 (1005, REBELLION) HAS an insight row, but REBELLION is not
+  # insights_enabled, so even an unscoped admin gets an empty array. Proves the
+  # gate is the OpDiv flag, not a missing row.
+  - url: "http://localhost:8080/api/v1/insights?fismasystemid=1005"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      body:
+        json:
+          data: []
+
   # massemails only supports this one route
   # test that it errors on invalid input
   - url: http://localhost:8080/api/v1/massemails
@@ -1882,6 +1916,35 @@ tests:
       <<: *issoHeaders
     expect:
       status: 403
+
+  # ISSO can GET /api/v1/insights for an assigned system (Shield Gen, 1003).
+  - url: "http://localhost:8080/api/v1/insights?fismasystemid=1003&questionid=1"
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - fismasystemid: 1003
+              questionid: 1
+
+  # ISSO reading an assigned but UNSCOPED system gets an empty array, not 403:
+  # /insights filters by users_fismasystems, so an unassigned system (Death Star,
+  # 1001) simply yields no rows rather than a forbidden. This is the list-endpoint
+  # counterpart to the systemenrichment 403 above.
+  - url: "http://localhost:8080/api/v1/insights?fismasystemid=1001"
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 200
+      body:
+        json:
+          data: []
 
   # ISSO gets 403 on GET /api/v1/users (user management restricted)
   - url: http://localhost:8080/api/v1/users

--- a/backend/internal/model/systeminsights.go
+++ b/backend/internal/model/systeminsights.go
@@ -1,0 +1,76 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// SystemInsight is one per-system x question insight record served from the
+// system_insights cache. Payload is the opaque insight document written by the
+// ztmf-insights sync (Kion / SecurityHub / Hardenize / CFACTS / ARS scoring and
+// evidence); fields inside it are added and removed upstream without a change
+// here.
+type SystemInsight struct {
+	FismaSystemID int32           `json:"fismasystemid" db:"fismasystemid"`
+	QuestionID    int32           `json:"questionid" db:"questionid"`
+	Payload       json.RawMessage `json:"payload" db:"payload" swaggertype:"object"`
+	SyncedAt      time.Time       `json:"synced_at" db:"synced_at"`
+}
+
+// FindSystemInsightsInput scopes a system_insights read. FismaSystemID and
+// QuestionID are optional client filters. UserID / OpDivIDs / RestrictToOpDivIDs
+// carry the auth'd user's access scope and are set by the controller, never by
+// the client, mirroring FindScoresInput.
+type FindSystemInsightsInput struct {
+	input
+	FismaSystemID *int32 `schema:"fismasystemid"`
+	QuestionID    *int32 `schema:"questionid"`
+	UserID        *string
+	// OpDiv scope for the per-OpDiv admin tiers. RestrictToOpDivIDs with an
+	// empty slice fails closed (no rows).
+	OpDivIDs           []int32
+	RestrictToOpDivIDs bool
+}
+
+// FindSystemInsights returns per-system x question insight rows, scoped both by
+// the caller's access (same predicates as FindScores) and by the CMS-conditional
+// data gate: a row is visible only if its owning OpDiv has insights_enabled =
+// TRUE. Insights data exists for CMS OpDivs only, so a system in a non-enabled
+// OpDiv yields no rows rather than an error.
+func FindSystemInsights(ctx context.Context, in FindSystemInsightsInput) ([]*SystemInsight, error) {
+	sqlb := stmntBuilder.
+		Select("si.fismasystemid", "si.questionid", "si.payload", "si.synced_at").
+		From("system_insights si").
+		Where(`EXISTS (
+			SELECT 1 FROM fismasystems fs
+			JOIN opdivs o ON o.opdiv_id = fs.opdiv_id
+			WHERE fs.fismasystemid = si.fismasystemid
+			  AND o.insights_enabled = TRUE
+		)`)
+
+	// Per-system tier: only systems the user is granted through users_fismasystems.
+	if in.UserID != nil {
+		sqlb = sqlb.InnerJoin("users_fismasystems ON users_fismasystems.fismasystemid=si.fismasystemid AND users_fismasystems.userid=?", *in.UserID)
+	}
+
+	if in.FismaSystemID != nil {
+		sqlb = sqlb.Where("si.fismasystemid=?", *in.FismaSystemID)
+	}
+	if in.QuestionID != nil {
+		sqlb = sqlb.Where("si.questionid=?", *in.QuestionID)
+	}
+
+	// OpDiv-scoped admin tiers (fail-closed): restrict to systems in the admin's
+	// granted OpDivs. Empty grants under RestrictToOpDivIDs -> no rows.
+	switch {
+	case in.RestrictToOpDivIDs && len(in.OpDivIDs) == 0:
+		sqlb = sqlb.Where("FALSE")
+	case len(in.OpDivIDs) > 0:
+		sqlb = sqlb.Where("si.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY(?))", in.OpDivIDs)
+	}
+
+	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[SystemInsight])
+}

--- a/backend/internal/model/systeminsights_integration_test.go
+++ b/backend/internal/model/systeminsights_integration_test.go
@@ -1,0 +1,86 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Emberfall ISSO from the empire seed, granted Shield Gen (1003) only.
+const emberfallISSOUserID = "66666666-6666-6666-6666-666666666666"
+
+func systemsOf(rows []*SystemInsight) map[int32]bool {
+	m := make(map[int32]bool, len(rows))
+	for _, r := range rows {
+		m[r.FismaSystemID] = true
+	}
+	return m
+}
+
+// TestFindSystemInsightsIntegration pins the /insights read behavior against the
+// real SQL and empire seed (issue #416): the users_fismasystems scope, the
+// fail-closed OpDiv restriction, and the insights_enabled OpDiv gate that hides
+// rows for systems in a non-enabled OpDiv even from an unscoped admin. Unit tests
+// over the generated SQL cannot see these - they depend on the joins against the
+// seeded fismasystems / opdivs / users_fismasystems rows.
+//
+// Seed facts (backend/_test_data_empire.sql): system_insights rows at questionid
+// 1 exist for 1001 (Death Star, EMPIRE/enabled), 1003 (Shield Gen, EMPIRE/enabled,
+// assigned to emberfallISSOUserID) and 1005 (RB-1, REBELLION/NOT enabled). The
+// Emberfall ISSO is granted 1003 only.
+//
+// Requires DB_* env vars pointing at the seeded ephemeral test DB (make
+// test-integration). Skipped under `go test -short`.
+func TestFindSystemInsightsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	q1 := int32(1)
+	isso := emberfallISSOUserID
+
+	// Unscoped admin: sees both enabled systems at q1; the OpDiv gate hides the
+	// REBELLION system (1005, insights_enabled = FALSE) entirely.
+	admin, err := FindSystemInsights(ctx, FindSystemInsightsInput{QuestionID: &q1})
+	require.NoError(t, err)
+	got := systemsOf(admin)
+	assert.True(t, got[1001], "admin should see enabled system 1001 at q1")
+	assert.True(t, got[1003], "admin should see enabled system 1003 at q1")
+	assert.False(t, got[1005], "OpDiv gate must hide 1005 (insights_enabled = FALSE) even for an unscoped admin")
+
+	// Payload is served as opaque JSON: confirm a seeded key round-trips (proves
+	// the jsonb column is passed through, which Emberfall cannot assert on a list).
+	for _, r := range admin {
+		if r.FismaSystemID == 1003 {
+			assert.Contains(t, string(r.Payload), "shield-relay-without-mfa", "payload jsonb should pass through untouched")
+		}
+	}
+
+	// ISSO scoped to grants: assigned to 1003, so sees 1003 but never 1001
+	// (enabled but unassigned) or 1005 (gated).
+	issoRows, err := FindSystemInsights(ctx, FindSystemInsightsInput{QuestionID: &q1, UserID: &isso})
+	require.NoError(t, err)
+	scoped := systemsOf(issoRows)
+	assert.True(t, scoped[1003], "ISSO assigned to 1003 should see its insight row")
+	assert.False(t, scoped[1001], "ISSO must NOT see an enabled but unassigned system (1001)")
+	assert.False(t, scoped[1005], "ISSO must NOT see a gated system (1005)")
+
+	// ISSO filtered to an unassigned system -> empty (scoped out, no leak).
+	unassigned := int32(1001)
+	rows, err := FindSystemInsights(ctx, FindSystemInsightsInput{FismaSystemID: &unassigned, UserID: &isso})
+	require.NoError(t, err)
+	assert.Empty(t, rows, "ISSO must get no rows for an unassigned system")
+
+	// Fail-closed OpDiv tier: restrict with no granted OpDivs -> empty.
+	failClosed, err := FindSystemInsights(ctx, FindSystemInsightsInput{QuestionID: &q1, RestrictToOpDivIDs: true})
+	require.NoError(t, err)
+	assert.Empty(t, failClosed, "RestrictToOpDivIDs with empty OpDivIDs must fail closed to no rows")
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -155,6 +155,16 @@ components:
         error:
           type: string
       type: object
+    controller.apiResponse-array_model_SystemInsight:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/model.SystemInsight'
+          type: array
+          uniqueItems: false
+        error:
+          type: string
+      type: object
     controller.apiResponse-array_model_User:
       properties:
         data:
@@ -616,6 +626,17 @@ components:
           type: string
         payload:
           type: object
+        synced_at:
+          type: string
+      type: object
+    model.SystemInsight:
+      properties:
+        fismasystemid:
+          type: integer
+        payload:
+          type: object
+        questionid:
+          type: integer
         synced_at:
           type: string
       type: object
@@ -1668,6 +1689,37 @@ paths:
       summary: List options for a function
       tags:
       - functions
+  /insights:
+    get:
+      parameters:
+      - description: Filter by FISMA system ID
+        in: query
+        name: fismasystemid
+        schema:
+          type: integer
+      - description: Filter by question ID
+        in: query
+        name: questionid
+        schema:
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-array_model_SystemInsight'
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: List per-system per-question insights
+      tags:
+      - insights
   /massemails:
     post:
       requestBody:


### PR DESCRIPTION
## What

Adds `GET /api/v1/insights`, the read side of the `system_insights` seam (table added in #417). Serves per-system x question insight records - the Kion / SecurityHub / Hardenize / CFACTS / ARS scoring and evidence written from Snowflake by the ztmf-insights sync - so the UI can surface a suggested maturity score and its supporting findings alongside each questionnaire item.

New `model.FindSystemInsights`, `controller.ListSystemInsights`, and the route. Optional `fismasystemid` and `questionid` query filters.

## Access control (same model as the score pages)

1. **Authenticated** - behind `auth.Middleware`; no token is a 401.
2. **Scoped by tier**, identical to `FindScores`: unscoped admin tiers see everything; per-OpDiv admin tiers fail closed to their granted OpDivs' systems; ISSO/ISSM/OWNER are scoped to their `users_fismasystems` grants. Scope is applied server-side after query decode, so a client cannot widen it via params.
3. **OpDiv gate** - on top of the above, a row is visible only if its owning OpDiv has `insights_enabled = TRUE`. Insights data exists for CMS OpDivs only, so a system in a non-enabled OpDiv returns no rows.

Net: only people assigned to a system (or admins) can see its insights.

## Payload is opaque passthrough

`payload` is returned as-is (generic JSONB), same approach as `system_enrichment`. When the upstream Snowflake view adds a field, it appears in the API on the next sync with no change here - verified locally by adding a nested `findings` object (Kion/SecurityHub/Hardenize arrays with id, NIST control, description, remediation) to the view and watching it flow straight through.

## Testing

- **Integration** (`systeminsights_integration_test.go`): the RBAC proof against real SQL + the empire seed - users_fismasystems scope, fail-closed OpDiv restriction, the `insights_enabled` gate hiding a REBELLION system's row from an unscoped admin, and jsonb passthrough. Passes under `make test-integration`.
- **Emberfall**: status + array-body smoke for the admin and ISSO paths, plus the empty-array behavior for the gated and unassigned cases (the list-endpoint counterpart to systemenrichment's 403/404). Passes under `make test-e2e`.
- **Fixtures**: Star Wars themed `system_insights` rows in `_test_data_empire.sql` (no real data).
- OpenAPI regenerated (`make generate-openapi`).

## Notes

- `payload` is typed as a generic object in OpenAPI (`swaggertype:"object"`) on purpose - typing all ~75 keys would kill the additive property.
- Depends on #417 (merged).