### PR TITLE
Parametrize compose postgres host port so dev and impl run side by side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ backend/compose-dev.yml:
 	@echo "    env_file:" >> backend/compose-dev.yml
 	@echo "      - dev.compose.env" >> backend/compose-dev.yml
 	@echo "    ports:" >> backend/compose-dev.yml
-	@echo "      - \"54321:54321\"" >> backend/compose-dev.yml
+	@echo "      - \"$(DB_PORT):$(DB_PORT)\"" >> backend/compose-dev.yml
 	@echo "    volumes:" >> backend/compose-dev.yml
 	@echo "      - postgres_data:/var/lib/postgresql/data" >> backend/compose-dev.yml
 	@echo "    command: -p $(DB_PORT)" >> backend/compose-dev.yml


### PR DESCRIPTION
## Problem
(This is for local dev environments)
The `compose-dev.yml` generator in the Makefile hardcoded the postgres host-port mapping as `"54321:54321"`, while every other port in the generator already used the per-environment variable (`command: -p $(DB_PORT)`, the healthcheck, and the api `$(API_PORT):$(API_PORT)`).

Because dev's `DB_PORT` is 54321, the hardcode happened to match dev and went unnoticed. But impl sets `DB_PORT=54322` (via `Makefile.impl`), so every `make dev-setup` in the impl worktree regenerated a mapping that published host **54321** — colliding with the dev worktree's postgres and stopping dev + impl from running at the same time. The workaround was hand-editing the generated compose file, which the next regeneration wiped, so the collision kept coming back.

## Fix

One line — use `"$(DB_PORT):$(DB_PORT)"` so the host mapping honors the per-env port like the rest of the generator:

- dev -> `54321:54321`
- impl -> `54322:54322`

No macOS/Linux special-casing needed: a published `ports:` mapping behaves identically on both, unlike `network_mode: host`. Container/volume/network isolation is already handled by `COMPOSE_PROJECT_NAME` (`ztmf` vs `ztmf-impl`).

## Verification

- On a `feature/impl-*` branch the generator renders `54322:54322` + `-p 54322`; `ZTMF_ENV=main` resolves `DB_PORT=54321`.
- Brought dev (54321) and impl (54322) up concurrently, both reachable from the host.
- Reviewed by Codex: host:container both `$(DB_PORT)` is correct (postgres binds $(DB_PORT) via `-p`, not 5432), make-expansion is right, and this was the last hardcoded port in the generator.