### PR TITLE
Parametrize compose postgres host port so dev and impl run side by side (main port of #422)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ SHELL := /bin/bash
 
 # Single source of truth for the local API port
 API_PORT ?= 8080
+# Postgres host port for the local dev compose stack. Overridable per worktree
+# (e.g. impl sets 54322) so dev and impl can run side by side without colliding
+# on the published host port. Container isolation is handled by COMPOSE_PROJECT_NAME.
+DB_PORT ?= 54321
 
 # Emberfall E2E runner install, resolved per platform. Releases are published as
 # emberfall_{Darwin,Linux}_{arm64,x86_64,i386}.tar.gz, so a hardcoded Linux URL
@@ -79,7 +83,7 @@ dev-setup: backend/compose-dev.yml backend/dev.compose.env
 	cd backend && docker compose -f compose-dev.yml up -d --build
 	@echo "✅ Development environment ready!"
 	@echo "📡 API available at: http://localhost:$(API_PORT)"
-	@echo "🗄️  Database available at: localhost:54321"
+	@echo "🗄️  Database available at: localhost:$(DB_PORT)"
 	@echo ""
 	@echo "🧪 Ready to test! Run:"
 	@echo "  make test-empire-data    # Get JWT tokens for all test users"
@@ -110,12 +114,12 @@ backend/compose-dev.yml:
 	@echo "    env_file:" >> backend/compose-dev.yml
 	@echo "      - dev.compose.env" >> backend/compose-dev.yml
 	@echo "    ports:" >> backend/compose-dev.yml
-	@echo "      - \"54321:54321\"" >> backend/compose-dev.yml
+	@echo "      - \"$(DB_PORT):$(DB_PORT)\"" >> backend/compose-dev.yml
 	@echo "    volumes:" >> backend/compose-dev.yml
 	@echo "      - postgres_data:/var/lib/postgresql/data" >> backend/compose-dev.yml
-	@echo "    command: -p 54321" >> backend/compose-dev.yml
+	@echo "    command: -p $(DB_PORT)" >> backend/compose-dev.yml
 	@echo "    healthcheck:" >> backend/compose-dev.yml
-	@echo "      test: [\"CMD-SHELL\", \"pg_isready -U admin -d ztmf -p 54321\"]" >> backend/compose-dev.yml
+	@echo "      test: [\"CMD-SHELL\", \"pg_isready -U admin -d ztmf -p $(DB_PORT)\"]" >> backend/compose-dev.yml
 	@echo "      interval: 5s" >> backend/compose-dev.yml
 	@echo "      timeout: 5s" >> backend/compose-dev.yml
 	@echo "      retries: 5" >> backend/compose-dev.yml
@@ -157,10 +161,10 @@ backend/dev.compose.env:
 	@echo "POSTGRES_PASSWORD=localdevpassword" >> backend/dev.compose.env
 	@echo "" >> backend/dev.compose.env
 	@echo "# Shared by api container (docker compose) and host shell (make test-full, pre-push hook)." >> backend/dev.compose.env
-	@echo "# Host needs localhost:54321 (port-mapped); the api container's DB_ENDPOINT is overridden" >> backend/dev.compose.env
+	@echo "# Host needs localhost:$(DB_PORT) (port-mapped); the api container's DB_ENDPOINT is overridden" >> backend/dev.compose.env
 	@echo "# to the docker service name 'postgre' in compose-dev.yml's environment: block." >> backend/dev.compose.env
 	@echo "DB_ENDPOINT=localhost" >> backend/dev.compose.env
-	@echo "DB_PORT=54321" >> backend/dev.compose.env
+	@echo "DB_PORT=$(DB_PORT)" >> backend/dev.compose.env
 	@echo "DB_NAME=ztmf" >> backend/dev.compose.env
 	@echo "DB_USER=admin" >> backend/dev.compose.env
 	@echo "DB_PASS=localdevpassword" >> backend/dev.compose.env
@@ -466,7 +470,7 @@ full-stack-up:
 	@echo "Services:"
 	@echo "  Frontend UI:  http://localhost:5174"
 	@echo "  Backend API:  http://localhost:$(API_PORT)"
-	@echo "  Database:     localhost:54321"
+	@echo "  Database:     localhost:$(DB_PORT)"
 	@echo ""
 	@echo "Logged in as: Grand Moff Tarkin (ADMIN)"
 	@echo "To switch user: make frontend-env EMAIL=Admiral.Piett@executor.empire"


### PR DESCRIPTION
Ports the impl-branch fix for #422 to `main`.

## Problem

The `compose-dev.yml` generator in the Makefile hardcoded the postgres host-port mapping (and the `-p` flag and healthcheck) as `54321`. On `main`, `DB_PORT` is 54321 so it happened to match and went unnoticed — but a worktree that overrides the port (impl uses 54322 via `Makefile.impl`) regenerated a mapping that still published host **54321**, colliding with the dev worktree's postgres and stopping dev + impl from running at the same time.

## Why this isn't just cherry-picking a39b3cc

The impl fix (`a39b3cc`) is one line — `"54321:54321"` → `"$(DB_PORT):$(DB_PORT)"` — because the impl branch already defines `DB_PORT` as a make variable and already uses it in the `-p` flag and healthcheck. **main defines only `API_PORT`, not `DB_PORT`**, so that one-liner would expand to `":"` and break the generator here.

So this adds the missing infra to match: `DB_PORT ?= 54321` (mirroring `API_PORT`), then threads it through every hardcoded db-port spot in the generator — the host-port mapping, the postgres `-p` flag, the healthcheck, the `dev.compose.env` `DB_PORT` line, and the info echoes.

## Behavior

- **main unchanged** — `DB_PORT` defaults to 54321, so the generated compose is byte-identical to before.
- A per-worktree override now works end to end: `make DB_PORT=54322 …` renders `54322:54322` / `-p 54322` / healthcheck 54322 / env `DB_PORT=54322`.
- Container/volume/network isolation is already handled by `COMPOSE_PROJECT_NAME`.

## Verification

- `DB_PORT=54322` renders 54322 throughout the generated `compose-dev.yml`; default renders 54321 (confirmed both).

Closes the main-side gap of #422.