### PR TITLE
fix(api): return 400 not 500 for malformed list-endpoint query params (#420)

### DIFF
--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -97,6 +97,15 @@ func sanitizeErr(err error) (int, string, error) {
 	switch err.(type) {
 	case *model.InvalidInputError:
 		return 400, "", err
+	case schema.MultiError, schema.ConversionError, *schema.ConversionError,
+		schema.UnknownKeyError, *schema.UnknownKeyError,
+		schema.EmptyFieldError, *schema.EmptyFieldError:
+		// A gorilla/schema decode failure means the caller sent a query param
+		// that can't be parsed into the input struct (e.g. fismasystemid=abc).
+		// That's a client error across every GET list handler using the shared
+		// decoder.Decode + respond() pattern, so surface a clean 400 rather than
+		// falling through to a 500 that inflates 5xx metrics. (#420)
+		return 400, "", ErrInvalidQueryParam
 	}
 
 	var (

--- a/backend/cmd/api/internal/controller/controller_test.go
+++ b/backend/cmd/api/internal/controller/controller_test.go
@@ -1,0 +1,67 @@
+package controller
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// A malformed query param decoded via gorilla/schema must surface as a 400
+// (client error), not a 500. Regression for #420: the decode error fell through
+// sanitizeErr to the default 500 branch, inflating 5xx metrics for what is the
+// caller's mistake. Exercises the real decoder so the concrete error type
+// (schema.MultiError wrapping a ConversionError) matches what handlers pass in.
+func TestSanitizeErrMapsSchemaDecodeErrorTo400(t *testing.T) {
+	var input struct {
+		FismaSystemID int `schema:"fismasystemid"`
+	}
+	err := decoder.Decode(&input, url.Values{"fismasystemid": {"abc"}})
+	assert.Error(t, err, "decoding a non-numeric int param should error")
+
+	status, code, out := sanitizeErr(err)
+	assert.Equal(t, 400, status)
+	assert.Equal(t, "", code)
+	assert.Equal(t, ErrInvalidQueryParam, out, "message must be the sanitized sentinel, not the raw schema error")
+}
+
+// An unknown query param (gorilla/schema rejects unknown keys by default) is
+// likewise a client error -> 400.
+func TestSanitizeErrMapsUnknownQueryKeyTo400(t *testing.T) {
+	var input struct {
+		FismaSystemID int `schema:"fismasystemid"`
+	}
+	err := decoder.Decode(&input, url.Values{"bogus": {"1"}})
+	assert.Error(t, err)
+
+	status, _, out := sanitizeErr(err)
+	assert.Equal(t, 400, status)
+	assert.Equal(t, ErrInvalidQueryParam, out)
+}
+
+// The rest of the mapping is unchanged; pin the key cases so the added schema
+// branch can't accidentally shadow them.
+func TestSanitizeErrMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"invalid input -> 400", &model.InvalidInputError{}, 400},
+		{"no data -> 404", model.ErrNoData, 404},
+		{"not found -> 404", ErrNotFound, 404},
+		{"forbidden -> 403", ErrForbidden, 403},
+		{"past deadline -> 403", model.ErrPastDeadline, 403},
+		{"not unique -> 400", model.ErrNotUnique, 400},
+		{"db connection -> 503", model.ErrDbConnection, 503},
+		{"unknown -> 500", errors.New("boom"), 500},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _, _ := sanitizeErr(tc.err)
+			assert.Equal(t, tc.wantStatus, status)
+		})
+	}
+}

--- a/backend/cmd/api/internal/controller/errors.go
+++ b/backend/cmd/api/internal/controller/errors.go
@@ -10,6 +10,10 @@ var (
 	ErrServer             = errors.New("server error")
 	ErrServiceUnavailable = errors.New("service unavailable")
 	ErrMalformed          = errors.New("json malformed or type mismatch")
+	// Returned for gorilla/schema query-param decode failures (e.g.
+	// fismasystemid=abc). Client error, so it maps to 400 in sanitizeErr and
+	// avoids leaking the library's internal message to the caller. (#420)
+	ErrInvalidQueryParam = errors.New("invalid query parameter")
 	// lowercase, no period — Go error strings must not be capitalized or end with punctuation
 	ErrSelfDelete = errors.New("cannot delete your own account")
 )

--- a/backend/cmd/api/internal/controller/insights.go
+++ b/backend/cmd/api/internal/controller/insights.go
@@ -13,6 +13,7 @@ import (
 //	@Param		fismasystemid	query		int	false	"Filter by FISMA system ID"
 //	@Param		questionid		query		int	false	"Filter by question ID"
 //	@Success	200				{object}	apiResponse[[]model.SystemInsight]
+//	@Failure	400				{object}	apiResponse[any]
 //	@Failure	500				{object}	apiResponse[any]
 //	@Router		/insights [get]
 func ListSystemInsights(w http.ResponseWriter, r *http.Request) {

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -16,6 +16,7 @@ import (
 //	@Param		fismasystemid	query		int	false	"Filter by FISMA system ID"
 //	@Param		datacallid		query		int	false	"Filter by data call ID"
 //	@Success	200				{object}	apiResponse[[]model.Score]
+//	@Failure	400				{object}	apiResponse[any]
 //	@Failure	500				{object}	apiResponse[any]
 //	@Router		/scores [get]
 func ListScores(w http.ResponseWriter, r *http.Request) {

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1308,6 +1308,39 @@ tests:
       headers:
         content-type: "application/json"
 
+  # Malformed query params on GET list endpoints are the caller's fault and must
+  # return 400, not 500 (#420). The gorilla/schema decode fails before scope or
+  # any DB call, so the sanitizeErr mapping is what these pin. A non-numeric int
+  # param on /scores...
+  - url: "http://localhost:8080/api/v1/scores?fismasystemid=abc"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 400
+      headers:
+        content-type: "application/json"
+
+  # ...and on /insights. The decode error short-circuits before the
+  # insights-enabled gate, so this is 400 regardless of enablement.
+  - url: "http://localhost:8080/api/v1/insights?fismasystemid=abc"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 400
+      headers:
+        content-type: "application/json"
+
+  - url: "http://localhost:8080/api/v1/insights?questionid=xyz"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 400
+      headers:
+        content-type: "application/json"
+
   # PUT returns 204 (No Content) per controller.respond; assert the write
   # path completes cleanly. Audit-on-write is covered by the POST assertion
   # above.

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1709,6 +1709,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/controller.apiResponse-array_model_SystemInsight'
           description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
         "500":
           content:
             application/json:
@@ -2053,6 +2059,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/controller.apiResponse-array_model_Score'
           description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
         "500":
           content:
             application/json:


### PR DESCRIPTION
## Summary

In-repo rehome of #426 by @voidspooks (Cameron Testerman) so the repository CI gates (which fork PRs cannot run) execute against this commit. Original authorship is preserved on the cherry-picked commit; the original PR #426 stays open as a draft until this merges.

Fixes #420. GET list endpoints that decode query params via `gorilla/schema` returned **HTTP 500** when a param failed to parse. The decode error from `decoder.Decode(&input, r.URL.Query())` was passed straight into `respond()`, whose `sanitizeErr` had no case for a schema decode error, so it fell through to a 500. A malformed client-supplied param is the caller's fault and should surface as a **4xx** — a 500 inflates 5xx error metrics/alerts and gives the caller a misleading status. This is pre-existing and codebase-wide: it affected every GET list handler using the shared `decoder.Decode` + `respond()` pattern (scores, insights, and others), not one endpoint.

## Fix

Map `gorilla/schema` decode errors to **400** in the shared `sanitizeErr`, which fixes all list endpoints at once. `sanitizeErr` now matches `schema.MultiError` (and the `ConversionError` / `UnknownKeyError` / `EmptyFieldError` it wraps) and returns **400** with a dedicated `ErrInvalidQueryParam` sentinel. The sentinel keeps the response message clean instead of leaking the library's internal parse detail (e.g. `strconv.ParseInt: ... invalid syntax`).

Valid requests are unaffected: `gorilla/schema` `Decode` returns an untyped `nil` on success and only returns a non-empty `MultiError` on an actual decode failure, so the new case can never trip on a well-formed request. The case returns early, ahead of the existing `errors.Is` chain, so it does not shadow any current status mapping.

## Before / after

```
GET /api/v1/scores?fismasystemid=abc     500 -> 400
GET /api/v1/insights?fismasystemid=abc   500 -> 400
GET /api/v1/insights?questionid=xyz      500 -> 400
```

## Tests

- `controller_test.go` — unit coverage for `sanitizeErr`: drives the real `decoder` so the concrete error type (`schema.MultiError` wrapping a `ConversionError`) matches what handlers pass in, covers the unknown-key path, and adds a table pinning the existing status mappings so the new branch can't shadow them.
- `emberfall_tests.yml` — 400 cases for `scores?fismasystemid=abc` and `insights` with a non-numeric `fismasystemid` / `questionid` (the decode error short-circuits before the insights-enabled gate, so 400 regardless of enablement).
- Added `@Failure 400` to the `ListScores` / `ListSystemInsights` swag annotations and regenerated `openapi.yaml`.

## Provenance / verification

Commit cherry-picked verbatim from #426 (`voidspooks/ztmf:fix/list-endpoints-400-malformed-params`), authorship preserved. On this branch atop current `main`: `go build ./...`, `go vet`, and the `controller` unit-test package are green; `make generate-openapi` reproduces the committed `openapi.yaml` byte-for-byte (no drift). The `gorilla/schema` v1.4.1 error-type behavior above was confirmed against the library source.
