### PR TITLE
fix(model): make users_fismasystems Save idempotent on duplicate assignment (#429)

### DIFF
--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1341,6 +1341,56 @@ tests:
       headers:
         content-type: "application/json"
 
+  # System assignment is idempotent (#429). Save uses ON CONFLICT ... DO UPDATE
+  # ... RETURNING so a duplicate POST returns the existing row; the old
+  # DO NOTHING RETURNING produced zero rows on conflict, which surfaced as a
+  # 404. Target user must have a version-4 UUID: FindUserByID and validate()
+  # gate on the v4-strict isValidUUID, so the all-digits placeholder users
+  # (11111111-..., 22222222-...) 404 before reaching Save. Thrawn (aa000088-...)
+  # is v4 and carries no seed assignments.
+  - url: "http://localhost:8080/api/v1/users/aa000088-8888-4888-8888-888888888888/assignedfismasystems"
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1003
+    expect:
+      status: 201
+      body:
+        json:
+          data:
+            userid: "aa000088-8888-4888-8888-888888888888"
+            fismasystemid: 1003
+
+  # Identical POST again - the regression target. Must return the same row,
+  # not 404/500.
+  - url: "http://localhost:8080/api/v1/users/aa000088-8888-4888-8888-888888888888/assignedfismasystems"
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1003
+    expect:
+      status: 201
+      body:
+        json:
+          data:
+            userid: "aa000088-8888-4888-8888-888888888888"
+            fismasystemid: 1003
+
+  # Remove the assignment so Thrawn's scope stays as seeded for any tests
+  # that follow.
+  - url: "http://localhost:8080/api/v1/users/aa000088-8888-4888-8888-888888888888/assignedfismasystems/1003"
+    method: DELETE
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+
   # PUT returns 204 (No Content) per controller.respond; assert the write
   # path completes cleanly. Audit-on-write is covered by the POST assertion
   # above.

--- a/backend/internal/model/usersfismasystems.go
+++ b/backend/internal/model/usersfismasystems.go
@@ -37,11 +37,15 @@ func (uf *UserFismaSystem) Save(ctx context.Context) (*UserFismaSystem, error) {
 		return nil, err
 	}
 
-	// TODO: fix issue where inserting the same (userid, fismasystemid) twice returns error. It should effectively upsert
+	// Idempotent by design: assigning a system the user already has returns the
+	// existing row instead of erroring (#429). DO NOTHING is not enough here —
+	// on conflict it suppresses the insert, RETURNING yields zero rows, and
+	// queryRow surfaces pgx.ErrNoRows as a 404. The no-op DO UPDATE makes the
+	// conflicting row visible to RETURNING, preserving the single-row contract.
 	sqlb := stmntBuilder.Insert("userid, fismasystemid").
 		Into("users_fismasystems").
 		Values(uf.UserID, uf.FismaSystemID).
-		Suffix("ON CONFLICT DO NOTHING RETURNING userid, fismasystemid")
+		Suffix("ON CONFLICT (userid, fismasystemid) DO UPDATE SET userid = EXCLUDED.userid RETURNING userid, fismasystemid")
 
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[UserFismaSystem])
 }

--- a/backend/internal/model/usersfismasystems_integration_test.go
+++ b/backend/internal/model/usersfismasystems_integration_test.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+)
+
+// Empire-seed ISSO with a v4 userid. The v4 shape matters: both the model's
+// validate() and FindUserByID gate on the version-4-strict isValidUUID, so the
+// all-digits placeholder users (11111111-..., 22222222-...) are rejected before
+// any DB work and cannot exercise this path.
+const upsertTestUserID = "aa000088-8888-4888-8888-888888888888"
+
+// Not assigned to upsertTestUserID in the empire seed; the test also clears the
+// pair up front so a leftover row from an interrupted run can't skew it.
+const upsertTestSystemID int32 = 1003
+
+func countUserFismaSystemRows(t *testing.T, userID string, systemID int32) int {
+	t.Helper()
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer conn.Release()
+	var n int
+	err = conn.QueryRow(context.Background(),
+		"SELECT count(*) FROM users_fismasystems WHERE userid=$1 AND fismasystemid=$2",
+		userID, systemID).Scan(&n)
+	require.NoError(t, err)
+	return n
+}
+
+// Regression for #429: Save used ON CONFLICT DO NOTHING RETURNING, which
+// returns zero rows on conflict, so re-assigning an existing (userid,
+// fismasystemid) surfaced pgx.ErrNoRows as ErrNoData (a 404 at the API layer)
+// instead of being idempotent.
+func TestUserFismaSystemSaveIsIdempotentIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	uf := &UserFismaSystem{UserID: upsertTestUserID, FismaSystemID: upsertTestSystemID}
+
+	// Belt-and-suspenders: clear the pair so an interrupted prior run can't
+	// turn the "first" save into a duplicate. ErrNoData just means it was
+	// already absent.
+	if err := uf.Delete(ctx); err != nil && !errors.Is(err, ErrNoData) {
+		t.Fatalf("pre-test cleanup failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := uf.Delete(context.Background()); err != nil && !errors.Is(err, ErrNoData) {
+			t.Errorf("post-test cleanup failed: %v", err)
+		}
+	})
+
+	// First save inserts and returns the row.
+	first, err := uf.Save(ctx)
+	require.NoError(t, err, "fresh assignment must succeed")
+	require.NotNil(t, first)
+	assert.Equal(t, upsertTestUserID, first.UserID)
+	assert.Equal(t, upsertTestSystemID, first.FismaSystemID)
+	assert.Equal(t, 1, countUserFismaSystemRows(t, upsertTestUserID, upsertTestSystemID))
+
+	// Duplicate save is a no-op that still returns the existing row.
+	second, err := uf.Save(ctx)
+	require.NoError(t, err, "duplicate assignment must be idempotent, not an error (#429)")
+	require.NotNil(t, second)
+	assert.Equal(t, upsertTestUserID, second.UserID)
+	assert.Equal(t, upsertTestSystemID, second.FismaSystemID)
+
+	// Still exactly one row — the upsert must not duplicate.
+	assert.Equal(t, 1, countUserFismaSystemRows(t, upsertTestUserID, upsertTestSystemID))
+}


### PR DESCRIPTION
Closes #429.

## Problem

`UserFismaSystem.Save` is meant to be idempotent, but re-assigning a system a user already had returned a 404 instead of succeeding.

The insert used `ON CONFLICT DO NOTHING RETURNING`. On a duplicate `(userid, fismasystemid)`, `DO NOTHING` suppresses the insert, so `RETURNING` yields zero rows; `queryRow` surfaces that as `pgx.ErrNoRows` → `model.ErrNoData`, which the API layer maps to a 404. This was the long-standing `// TODO: fix issue where inserting the same (userid, fismasystemid) twice returns error` marker.

## Fix

Switch to a no-op `DO UPDATE` so the conflicting row is visible to `RETURNING`:

```
ON CONFLICT (userid, fismasystemid) DO UPDATE SET userid = EXCLUDED.userid RETURNING userid, fismasystemid
```

`DO UPDATE SET userid = EXCLUDED.userid` writes the row's own value back to itself — a no-op to the data — but marks the row as affected so `RETURNING` returns it. This preserves `queryRow`'s single-row contract on both paths: a fresh insert returns the new row, a duplicate returns the existing one.

## Tests

- **Integration** (`usersfismasystems_integration_test.go`): first `Save` inserts and returns the row (exactly 1 row); duplicate `Save` is a no-op that still returns the existing row (still exactly 1 row — no duplication).
- **Emberfall e2e**: POST `.../assignedfismasystems` twice returns 201 with the same row both times (was 404 on the second), then DELETE restores seed state.

Ran locally and passing: `make test-unit`, `make test-integration`, `make test-e2e` (153 emberfall cases, 0 failed).

> Note: the target user in the e2e/integration tests must have a version-4 UUID — both `validate()` and `FindUserByID` gate on the v4-strict `isValidUUID`, so the all-digits empire placeholder users 404 before reaching `Save`. Thrawn (`aa000088-…`) is v4 and carries no seed assignments.
