### PR TITLE
ci: skip Go lint and Snyk Go scan on infra-only PRs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -4,8 +4,37 @@ on:
   workflow_call:
 
 jobs:
+  # Detect whether this change touches Go/backend files so the Go-specific
+  # Analysis jobs (lint go, snyk test) can be skipped on infra-only PRs. Mirrors
+  # the backend diff signal the orchestration workflows use to gate the Backend
+  # deploy. Outside the PR-open context (a merge to main/prod, or any push) the
+  # signal is forced non-empty so the Go scans always run there.
+  changes:
+    name: detect backend changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      backend: ${{ steps.backend.outputs.backend }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes in backend/
+        id: backend
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ] || [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+            echo "backend=always" >> $GITHUB_OUTPUT
+          else
+            echo "backend=$(git --no-pager diff --name-only "origin/${{ github.base_ref }}" -- backend/ .github/workflows/backend.yml .github/workflows/analysis.yml | grep -E '\.go$|go\.mod$|\.sum$|Dockerfile|workflows/(backend|analysis)\.yml' | head -n 1)" >> $GITHUB_OUTPUT
+          fi
+
   Lint-Go:
     name: lint go
+    needs: changes
+    if: ${{ needs.changes.outputs.backend != '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -81,6 +110,8 @@ jobs:
 
   Snyk-Test:
     name: snyk test
+    needs: changes
+    if: ${{ needs.changes.outputs.backend != '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -5,10 +5,16 @@ on:
 
 jobs:
   # Detect whether this change touches Go/backend files so the Go-specific
-  # Analysis jobs (lint go, snyk test) can be skipped on infra-only PRs. Mirrors
-  # the backend diff signal the orchestration workflows use to gate the Backend
-  # deploy. Outside the PR-open context (a merge to main/prod, or any push) the
-  # signal is forced non-empty so the Go scans always run there.
+  # Analysis jobs (lint go, snyk test) can be skipped on infra-only PRs. Outside
+  # the PR-open context (a merge to main/prod, or any push) the signal is forced
+  # non-empty so the Go scans always run there.
+  #
+  # SYNC: orchestration-dev.yml's `diff` job runs the same kind of diff to gate
+  # the backend DEPLOY. This signal is an intentional SUPERSET of it - it also
+  # matches go.mod and the backend/analysis workflow files so CI/dep edits re-run
+  # the scans - which guarantees anything that can deploy has also been scanned.
+  # Keep the shared core (the `backend/` pathspec + the `.go`/`.sum`/`Dockerfile`
+  # grep) in sync across both files.
   changes:
     name: detect backend changes
     runs-on: ubuntu-latest

--- a/.github/workflows/orchestration-dev.yml
+++ b/.github/workflows/orchestration-dev.yml
@@ -31,6 +31,13 @@ jobs:
       # Run the backend job when backend code OR the backend workflow itself
       # changes, so edits to backend.yml (e.g. action version bumps) are
       # validated by the smoke test rather than shipping unexercised.
+      #
+      # SYNC: analysis.yml's `changes` job runs the same kind of diff to gate the
+      # Go scans. That one is an intentional SUPERSET (it also matches go.mod and
+      # analysis.yml so CI/dep edits re-run the scans); this one gates the DEPLOY
+      # and is deliberately narrower. Keep the shared core (the `backend/`
+      # pathspec + the `.go`/`.sum`/`Dockerfile` grep) in sync across both, or a
+      # change could deploy without being scanned.
       - name: Check for changes in backend/ or its workflow
         id: backend
         run: echo "backend=$(git --no-pager diff --name-only origin/main -- backend/ .github/workflows/backend.yml | grep -E '\.go$|\.sum$|Dockerfile|workflows/backend.yml' | head -n 1)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Closes #301. The Analysis stage ran `lint go` and `snyk test` (the Go module Snyk scan) on every PR push, even when no Go files changed - so pure infra/Terraform PRs paid for the full Go pipeline for nothing.

This adds a `changes` job to `analysis.yml` that computes the same backend diff signal the orchestration workflows already use to gate the Backend deploy, and gates the two Go-specific jobs on it. The Terraform, IaC, code, and OpenAPI scans are unchanged and still run on every PR.

## Behavior

- Infra-only PR push -> `lint go` and `snyk test` show as skipped; `lint terraform`, `snyk iac test`, `snyk code test`, and the OpenAPI check still run.
- PR touching Go (`.go`, `go.mod`, `go.sum`, `Dockerfile`) or the backend/analysis workflows -> all Analysis jobs run.
- Outside the PR-open context (a merge to main/prod, or any push) the signal is forced non-empty, so the Go scans always run there - prod and impl behavior is unchanged.
- Draft PRs are unaffected (the Analysis workflow still runs; only the Go jobs are conditional).

## Trade-off

`snyk test` is a point-in-time SCA scan. Gating it means an infra-only PR no longer re-surfaces a newly-disclosed CVE in an otherwise-unchanged Go dependency. Acceptable because the merge-to-main/prod and impl paths always re-run it, and `snyk code test` (Go SAST) stays always-on.

## Why it helps

- Cuts ~1-2 minutes of compute per infra-only PR push.
- Cleaner check status for infra reviewers.
- Partial rehome relief: the Go Snyk scan needs the org `SNYK_TOKEN` that fork PRs can't access, so skipping it on infra-only changes removes one of the token-gated jobs a fork would otherwise fail on. Note `snyk code test` and `snyk iac test` also need the token and are not gated, so this reduces but does not eliminate the rehoming need for infra-only fork PRs.

## Testing

`analysis.yml` validated (parses; only `lint go` and `snyk test` carry the `needs: changes` gate). Reviewed by Codex - no critical issues; the deploy-implies-scan invariant holds across dev/impl/prod/push paths. `go.mod` added to the signal per that review.