### PR TITLE
Persist per-answer status on scores instead of deriving progress from events

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -906,6 +906,22 @@ SELECT DISTINCT ON (s.scoreid)
  WHERE s.scoreid >= 9100
  ORDER BY s.scoreid, uf.userid;
 
+-- Seed scores.status to match the just-seeded audit trail (ztmf#435). This
+-- runs after migrations, so the migration's one-time backfill has already
+-- executed against an empty table and does NOT see these seed rows; mirror
+-- its exact logic here so the seed DB's progress numbers agree with what the
+-- events above imply. A score with a seeded 'updated' event is 'done'; the
+-- rest keep the not_started default. Keeps this consistent automatically as
+-- the events seed above changes (it currently events only scoreid >= 9100).
+UPDATE public.scores s
+SET status = 'done'
+WHERE EXISTS (
+    SELECT 1
+    FROM public.events e
+    WHERE e.resource = 'public.scores'
+      AND (e.payload->>'scoreid')::int = s.scoreid
+);
+
 -- Reset every SERIAL sequence to its current table max. Use
 -- pg_get_serial_sequence() so the right name is resolved at runtime: some
 -- environments have historically renamed tables (e.g. functionscores -> scores)

--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -177,6 +177,13 @@ INSERT INTO public.datacalls VALUES (4, 'FY2025 Death Star Assessment', '2025-01
 -- "datacallid: 5" references and the "?datacallid=5" query string
 -- in that file in lockstep.
 INSERT INTO public.datacalls VALUES (5, 'Audit Fields Smoke Cycle', '2026-01-01T00:00:00Z', '2099-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
+-- Closed, IMPORTED cycle (ztmf#435): mirrors production history loaded from
+-- outside the app - its scores are seeded below with NO events rows, so every
+-- answer keeps status 'not_started' and carries no editor/timestamp. This is
+-- the shape that makes a closed call read 0/N under the "updated" lens while
+-- QuestionsAnswered still reports it complete; keep it event-free on purpose
+-- so that behavior stays reproducible locally.
+INSERT INTO public.datacalls VALUES (6, 'FY2020 Imperial Archives Import', '2020-01-01T00:00:00Z', '2020-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
 
 -- Test FISMA Systems (Imperial Systems)
 -- Use explicit column names to work with initial schema
@@ -879,6 +886,22 @@ BEGIN
         END LOOP;
     END LOOP;
 END $$;
+
+-- Imported-history scores for the FY2020 archives cycle (datacallid 6). Clone
+-- the FY2024 (datacallid 3) answer set so every (system, functionoption) pair
+-- is known-applicable to its system's environment, offset scoreids by +49 to
+-- stay below 9100 - the events seed below only covers scoreid >= 9100, so
+-- these rows get NO events and keep the 'not_started' status default. That is
+-- the point: an imported closed call has answers (QuestionsAnswered > 0) but
+-- no edit provenance (QuestionsUpdated = 0, LastUpdatedAt null), reproducing
+-- the production imported-history shape locally without any real data.
+INSERT INTO public.scores (scoreid, fismasystemid, datecalculated, notes, functionoptionid, datacallid)
+SELECT s.scoreid + 49, s.fismasystemid, '2020-06-01 00:00:00+00',
+       'Recovered from the Imperial Archives - assessor records lost',
+       s.functionoptionid, 6
+  FROM public.scores s
+ WHERE s.datacallid = 3 AND s.scoreid < 9100
+ON CONFLICT DO NOTHING;
 
 -- Audit trail for the seeded scores. last_edited_at / last_edited_by are NOT
 -- stored on scores; FindScores derives them from the events table (the most

--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -929,19 +929,44 @@ SELECT DISTINCT ON (s.scoreid)
  WHERE s.scoreid >= 9100
  ORDER BY s.scoreid, uf.userid;
 
+-- Import provenance for the FY2020 archives cycle (datacallid 6): a service
+-- account plus one 'imported' event per archived score, mirroring how
+-- externally-loaded history is attributed in real environments (ztmf#435). These
+-- give the archived rows a who/when (last-updated shows the import instead of
+-- blank) but use action 'imported', which the status-sync below deliberately
+-- excludes - so the archived answers keep status 'not_started' despite carrying
+-- events. This is the shape that proves imported != updated: answers present,
+-- provenance present, never 'done'.
+INSERT INTO public.users (userid, email, fullname, role, deleted, identity_provider)
+VALUES ('00000000-0000-4000-8000-000000000001', 'svc-importer@empire.test',
+        'Imperial Archives Import Service', 'HHS_READONLY_ADMIN', false, 'okta')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.events (userid, action, resource, createdat, payload)
+SELECT '00000000-0000-4000-8000-000000000001', 'imported', 'public.scores',
+       '2020-06-01 00:00:00+00',
+       jsonb_build_object('scoreid', s.scoreid, 'fismasystemid', s.fismasystemid,
+                          'functionoptionid', s.functionoptionid,
+                          'datacallid', s.datacallid, 'notes', s.notes)
+  FROM public.scores s
+ WHERE s.datacallid = 6;
+
 -- Seed scores.status to match the just-seeded audit trail (ztmf#435). This
 -- runs after migrations, so the migration's one-time backfill has already
 -- executed against an empty table and does NOT see these seed rows; mirror
 -- its exact logic here so the seed DB's progress numbers agree with what the
--- events above imply. A score with a seeded 'updated' event is 'done'; the
--- rest keep the not_started default. Keeps this consistent automatically as
--- the events seed above changes (it currently events only scoreid >= 9100).
+-- events above imply. A score with a seeded 'created'/'updated' event is 'done';
+-- the rest keep the not_started default. Imported-provenance events (see the
+-- FY2020 archives block) are excluded via the same action filter the migration
+-- uses, so imported history stays not_started. Keeps this consistent
+-- automatically as the events seed above changes.
 UPDATE public.scores s
 SET status = 'done'
 WHERE EXISTS (
     SELECT 1
     FROM public.events e
     WHERE e.resource = 'public.scores'
+      AND e.action IN ('created', 'updated')
       AND (e.payload->>'scoreid')::int = s.scoreid
 );
 

--- a/backend/cmd/api/internal/migrations/0048scoresstatus.go
+++ b/backend/cmd/api/internal/migrations/0048scoresstatus.go
@@ -1,0 +1,52 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add per-answer status to scores (state machine replacing events-derived progress)",
+		`
+-- Persist each answer's review state for its data call as a first-class column
+-- (ztmf#435). "Data Call Progress" used to infer "updated this cycle" by
+-- lateral-joining the events audit table, which is fire-and-forget,
+-- non-transactional, and context-gated - a dropped event silently under-counted
+-- progress. status makes the fact explicit and is written in the SAME statement
+-- as the answer, so it can never disagree with the row it describes.
+--
+-- Two states (the third, per-answer "complete", has no trigger in the app today
+-- - completion is tracked at the system level via datacalls_fismasystems - so it
+-- is intentionally out of scope; see ztmf#435 open questions):
+--   not_started - carried forward by copyPreviousScores, untouched this cycle
+--                 (the state that used to be inferred from "no event exists")
+--   done        - genuinely saved this cycle (what an edit event used to proxy)
+--
+-- varchar + CHECK rather than a native ENUM, matching the fismasystems
+-- target_maturity_tier convention (0046): easier to widen later without an
+-- ALTER TYPE dance if the third state is ever introduced.
+--
+-- DEFAULT 'not_started' is a backstop only; all three score-mutating paths set
+-- status explicitly (scores.Save INSERT/UPDATE -> 'done', copyPreviousScores ->
+-- 'not_started').
+ALTER TABLE public.scores
+  ADD COLUMN IF NOT EXISTS status varchar(20) NOT NULL DEFAULT 'not_started'
+    CONSTRAINT scores_status_check CHECK (status IN ('not_started', 'done'));
+
+-- Backfill mirrors the exact derivation the events lateral performed at read
+-- time, so dashboards do not move at cutover: a score row with >= 1 recorded
+-- edit event was "updated" (-> done); a carried-over row with none stays
+-- not_started. Uses the same resource + payload->>'scoreid' predicate the
+-- progress query used, which the events_score_audit_idx partial index (0037)
+-- serves directly, so the backfill is index-assisted rather than a seq scan
+-- per row.
+UPDATE public.scores s
+SET status = 'done'
+WHERE EXISTS (
+    SELECT 1
+    FROM public.events e
+    WHERE e.resource = 'public.scores'
+      AND (e.payload->>'scoreid')::int = s.scoreid
+);
+		`,
+		`
+ALTER TABLE public.scores
+  DROP COLUMN IF EXISTS status;
+		`)
+}

--- a/backend/cmd/api/internal/migrations/0048scoresstatus.go
+++ b/backend/cmd/api/internal/migrations/0048scoresstatus.go
@@ -36,12 +36,18 @@ ALTER TABLE public.scores
 -- progress query used, which the events_score_audit_idx partial index (0037)
 -- serves directly, so the backfill is index-assisted rather than a seq scan
 -- per row.
+--
+-- Only genuine in-app edits (action 'created'/'updated') count as done. Data
+-- loaded outside the app is attributed with 'imported' provenance events so it
+-- carries a who/when, but an import is not a human answering this cycle - those
+-- events must NOT flip the row to done, so they are excluded here.
 UPDATE public.scores s
 SET status = 'done'
 WHERE EXISTS (
     SELECT 1
     FROM public.events e
     WHERE e.resource = 'public.scores'
+      AND e.action IN ('created', 'updated')
       AND (e.payload->>'scoreid')::int = s.scoreid
 );
 		`,

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -20,9 +20,12 @@ import (
 //   - QuestionsUpdated ("touched THIS cycle") drives the active-call progress
 //     chip. A carried-forward answer does not count until re-saved (ztmf#299).
 //   - QuestionsAnswered ("has an answer at all") is the completion signal a
-//     PAST call needs: once a cycle closes, nobody touches it again, so
-//     QuestionsUpdated is 0 for every system and only QuestionsAnswered
-//     reflects that the call was in fact complete (ztmf-ui#537).
+//     PAST call needs. A closed cycle stops accumulating updates, and history
+//     imported from outside the app never had any (no events to backfill), so
+//     QuestionsUpdated says nothing about whether a historical call was in
+//     fact complete - QuestionsAnswered does (ztmf-ui#537). Cycles genuinely
+//     worked in-app keep their backfilled updated counts; accurate history,
+//     just not a completion signal.
 //
 // Both are now read from persisted state (scores.status and score-row
 // presence) rather than reconstructed from the events audit log; see

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -13,12 +13,20 @@ import (
 // data call, built for the "which systems have not updated their
 // questionnaires" dashboard view.
 //
-// QuestionsUpdated counts questions genuinely touched this cycle, not
-// questions that merely have an answer row: when a data call is created,
-// copyPreviousScores pre-populates the previous cycle's answers WITHOUT
-// recording events, so a carried-forward untouched answer has no event row.
-// Counting rows would therefore read ~100% for every carried-over system;
-// counting rows WITH events is what distinguishes real updates.
+// It carries two distinct numerators over the same applicable-function
+// denominator, because the dashboard asks two different questions depending on
+// whether the data call is active or historical:
+//
+//   - QuestionsUpdated ("touched THIS cycle") drives the active-call progress
+//     chip. A carried-forward answer does not count until re-saved (ztmf#299).
+//   - QuestionsAnswered ("has an answer at all") is the completion signal a
+//     PAST call needs: once a cycle closes, nobody touches it again, so
+//     QuestionsUpdated is 0 for every system and only QuestionsAnswered
+//     reflects that the call was in fact complete (ztmf-ui#537).
+//
+// Both are now read from persisted state (scores.status and score-row
+// presence) rather than reconstructed from the events audit log; see
+// FindScoreProgress.
 type ScoreProgress struct {
 	FismaSystemID int32 `json:"fismasystemid"`
 	// QuestionsExpected is the number of questionnaire functions applicable to
@@ -26,20 +34,29 @@ type ScoreProgress struct {
 	// vocabulary (the same join the questionnaire and the score aggregation
 	// use, so the denominator matches what an ISSO actually sees).
 	QuestionsExpected int32 `json:"questionsexpected"`
+	// QuestionsAnswered is the number of distinct applicable functions that
+	// have an answer row in this data call, regardless of whether it was
+	// touched this cycle. Counted from the same applicable-function set as
+	// QuestionsExpected, so it can never exceed it. This is the answered/total
+	// count a historical (closed) data call reports - carried-forward answers
+	// count here even though they do not count as QuestionsUpdated.
+	QuestionsAnswered int32 `json:"questionsanswered"`
 	// QuestionsUpdated is the number of distinct functions whose answer in
-	// this data call has at least one recorded edit event AND is still
-	// applicable to the system's current environment. Counted from the same
-	// applicable-function set as QuestionsExpected, so it can never exceed it.
+	// this data call reached status = 'done' (genuinely saved this cycle) AND
+	// is still applicable to the system's current environment. Counted from
+	// the same applicable-function set as QuestionsExpected, so it can never
+	// exceed it. Read from the persisted scores.status column, not from the
+	// events audit log.
 	QuestionsUpdated int32 `json:"questionsupdated"`
 	// LastUpdatedAt is the most recent edit event across the system's answers
-	// in this data call; nil when nothing has been touched this cycle.
+	// in this data call; nil when nothing has been touched this cycle. This is
+	// a legitimately observational use of the events table (audit timeline),
+	// kept even though the counts no longer read events.
 	LastUpdatedAt *time.Time `json:"lastupdatedat,omitempty"`
 	// UpdatedSinceStart is derivable (QuestionsUpdated > 0) but kept because
 	// it answers the ticket's literal question - "has this system updated
 	// since the start of the data call" - by name in the response, so a
 	// consumer rendering a boolean chip never touches the numeric fields.
-	// The anchor is real: events can only postdate the data call's creation,
-	// so any counted edit necessarily happened after the cycle started.
 	UpdatedSinceStart bool `json:"updatedsincestart"`
 }
 
@@ -83,8 +100,11 @@ func (i FindScoreProgressInput) validate() error {
 //
 // The query is hand-built parameterized SQL through the read-only rawQuery
 // path (never queryRow, which records events), mirroring FindScoreDiff. The
-// events lateral is the same shape FindScores uses for last_edited_at and is
-// served by the events_score_audit_idx partial index.
+// counts derive from persisted state - score-row presence for answered,
+// scores.status for updated - so a dropped/failed event write no longer moves
+// the numbers. A LEFT lateral onto events remains only for LastUpdatedAt (an
+// audit timeline, not a count) and is served by the events_score_audit_idx
+// partial index.
 func FindScoreProgress(ctx context.Context, input FindScoreProgressInput) ([]*ScoreProgress, error) {
 	if err := input.validate(); err != nil {
 		return nil, err
@@ -136,17 +156,18 @@ func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
 	args = append(args, *input.DataCallID)
 	argN++
 
-	// Both count halves draw from the SAME applicable-function set - the exact
+	// All count halves draw from the SAME applicable-function set - the exact
 	// set FindQuestionsByFismaSystem resolves for the questionnaire an ISSO
 	// fills out: functions with a question (INNER, so orphan functions are
 	// excluded), a valid pillar, matched to the system's environment through
-	// the datacenterenvironments scoring vocabulary. Because updated's set is
-	// that same set further restricted to answered-with-an-event functions, it
-	// is a subset of expected's - so questionsupdated can never exceed
-	// questionsexpected even when a carried-over answer references a function
-	// that is no longer applicable after an environment change (that answer
-	// simply fails the applicability join). COUNT(DISTINCT) on both guards
-	// against fan-out from the environment mapping.
+	// the datacenterenvironments scoring vocabulary. answered's and updated's
+	// sets are that same set further restricted to answered functions (and, for
+	// updated, to status = 'done'), so both are subsets of expected's - neither
+	// questionsanswered nor questionsupdated can exceed questionsexpected even
+	// when a carried-over answer references a function that is no longer
+	// applicable after an environment change (that answer simply fails the
+	// applicability join). COUNT(DISTINCT) on all guards against fan-out from
+	// the environment mapping.
 	sql := fmt.Sprintf(`
 WITH scoped_systems AS (
     SELECT fs.fismasystemid, fs.datacenterenvironment
@@ -164,7 +185,14 @@ expected AS (
 ),
 updated AS (
     SELECT ss.fismasystemid,
-           COUNT(DISTINCT f.functionid) AS questionsupdated,
+           -- every applicable answered function (answered/total for a closed
+           -- call); carried-forward rows count here.
+           COUNT(DISTINCT f.functionid) AS questionsanswered,
+           -- only those genuinely saved THIS cycle. status is a persisted
+           -- fact written in the same statement as the answer, so a
+           -- pre-populated row copied by copyPreviousScores (status =
+           -- 'not_started') is excluded without consulting the events log.
+           COUNT(DISTINCT f.functionid) FILTER (WHERE s.status = 'done') AS questionsupdated,
            MAX(le.createdat) AS lastupdatedat -- newest across the system's rows; the lateral below is per-row
     FROM scoped_systems ss
     INNER JOIN scores s ON s.fismasystemid = ss.fismasystemid AND s.datacallid = $%d
@@ -176,9 +204,11 @@ updated AS (
     INNER JOIN pillars p ON p.pillarid = q.pillarid
     -- One newest event per score row (LIMIT 1 keeps the lateral on the
     -- index fast path); the outer MAX then picks the newest across the
-    -- system's rows. The INNER lateral is also the filter - a pre-populated
-    -- row copied by copyPreviousScores has no event and drops out here.
-    INNER JOIN LATERAL (
+    -- system's rows. LEFT now (not the old filtering INNER): it feeds only
+    -- LastUpdatedAt, an audit timeline - a row with no event still counts
+    -- toward the numerators via status/presence and simply contributes no
+    -- timestamp.
+    LEFT JOIN LATERAL (
         SELECT createdat
         FROM events
         WHERE resource = 'public.scores'
@@ -190,6 +220,7 @@ updated AS (
 )
 SELECT ss.fismasystemid,
        COALESCE(ex.questionsexpected, 0) AS questionsexpected,
+       COALESCE(u.questionsanswered, 0) AS questionsanswered,
        COALESCE(u.questionsupdated, 0) AS questionsupdated,
        u.lastupdatedat
 FROM scoped_systems ss
@@ -204,7 +235,7 @@ ORDER BY ss.fismasystemid
 func scanScoreProgress(row pgx.CollectableRow) (*ScoreProgress, error) {
 	var p ScoreProgress
 
-	if err := row.Scan(&p.FismaSystemID, &p.QuestionsExpected, &p.QuestionsUpdated, &p.LastUpdatedAt); err != nil {
+	if err := row.Scan(&p.FismaSystemID, &p.QuestionsExpected, &p.QuestionsAnswered, &p.QuestionsUpdated, &p.LastUpdatedAt); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -279,3 +279,135 @@ func TestFindScoreProgressExcludesInapplicableAnswers(t *testing.T) {
 	assert.LessOrEqual(t, p.QuestionsUpdated, p.QuestionsExpected,
 		"updated can never exceed the applicable-question denominator")
 }
+
+// TestScoreNoOpReSavePreservesNotStartedIntegration pins the ztmf#299 guard at
+// the status level: a carried-forward answer re-saved WITHOUT a real change
+// (the questionnaire UI PUTs on every Next click) must keep status =
+// 'not_started', so it never counts as updated this cycle. The sibling progress
+// test only proves not_started -> done on a genuine edit; this proves the no-op
+// guard (scoreUpdateIsNoOp) leaves status untouched, which is the exact path a
+// broken guard would regress - silently flipping carried rows to done and
+// over-counting progress, the bug this whole change exists to kill.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestScoreNoOpReSavePreservesNotStartedIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// Two cycles anchored above every existing deadline so findPreviousDataCall
+	// (latest, excluding the target) resolves prevDC as the previous of newDC and
+	// not a seed cycle. Same reasoning as TestFindScoreProgressIntegration.
+	var prevDC, newDC int32
+	var maxDeadline time.Time
+	err = conn.QueryRow(ctx, `SELECT COALESCE(MAX(deadline), NOW()) FROM datacalls`).Scan(&maxDeadline)
+	require.NoError(t, err)
+	suffix := time.Now().UnixNano()
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $3::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%snoop_prev_%d", integrationTestPrefix, suffix), time.Now().Add(-2*time.Hour), maxDeadline.Add(24*time.Hour)).Scan(&prevDC)
+	require.NoError(t, err)
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $3::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%snoop_new_%d", integrationTestPrefix, suffix), time.Now().Add(-1*time.Hour), maxDeadline.Add(48*time.Hour)).Scan(&newDC)
+	require.NoError(t, err)
+
+	// A valid (system, functionoption) pair whose function is applicable to the
+	// system's environment, so the carried answer surfaces in the progress query
+	// (same selection as the sibling progress test).
+	var fismaSystemID, functionOptionID int32
+	err = conn.QueryRow(ctx, `
+		SELECT s.fismasystemid, s.functionoptionid
+		FROM scores s
+		INNER JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+		INNER JOIN functions f ON f.functionid = fo.functionid
+		INNER JOIN datacenterenvironments dce
+			ON dce.datacenterenvironment = fs.datacenterenvironment
+			AND dce.scoring_key = f.datacenterenvironment
+		INNER JOIN questions q ON q.questionid = f.questionid
+		WHERE fs.decommissioned = FALSE
+		LIMIT 1
+	`).Scan(&fismaSystemID, &functionOptionID)
+	require.NoError(t, err, "need one seeded score on an active system whose function is applicable to its environment")
+
+	// Seed the previous-cycle answer, then carry it forward. copyPreviousScores
+	// sets status = 'not_started' on the copied row.
+	notes := "noop preservation marker"
+	_, err = conn.Exec(ctx, `
+		INSERT INTO scores (fismasystemid, functionoptionid, datacallid, notes)
+		VALUES ($1, $2, $3, $4)
+	`, fismaSystemID, functionOptionID, prevDC, notes)
+	require.NoError(t, err)
+
+	copyPreviousScores(newDC)
+
+	var copiedScoreID int32
+	var seededStatus string
+	err = conn.QueryRow(ctx, `
+		SELECT scoreid, status FROM scores
+		WHERE datacallid = $1 AND fismasystemid = $2 AND functionoptionid = $3
+	`, newDC, fismaSystemID, functionOptionID).Scan(&copiedScoreID, &seededStatus)
+	require.NoError(t, err, "the carried-forward row must exist in the new datacall")
+	require.Equal(t, "not_started", seededStatus,
+		"copyPreviousScores must seed the carried row as not_started")
+
+	readStatus := func() string {
+		t.Helper()
+		var s string
+		require.NoError(t, conn.QueryRow(ctx, `SELECT status FROM scores WHERE scoreid = $1`, copiedScoreID).Scan(&s))
+		return s
+	}
+	questionsUpdated := func() int32 {
+		t.Helper()
+		rows, err := FindScoreProgress(ctx, FindScoreProgressInput{DataCallID: &newDC, FismaSystemID: &fismaSystemID})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		return rows[0].QuestionsUpdated
+	}
+
+	require.Equal(t, int32(0), questionsUpdated(),
+		"a carried, untouched answer is not updated")
+
+	// Re-save the carried answer with identical fields - the read-through PUT the
+	// questionnaire UI issues on every Next click. This hits the no-op guard,
+	// which returns before any write, so status must NOT transition to 'done'. A
+	// real seeded editor is used so that IF the guard ever regressed and the
+	// write fired, recordEvent would attribute correctly rather than fail the
+	// test for the wrong reason.
+	var editorID, editorRole string
+	err = conn.QueryRow(ctx, `SELECT userid, role FROM users ORDER BY (role = 'OWNER') DESC LIMIT 1`).Scan(&editorID, &editorRole)
+	require.NoError(t, err, "need at least one seeded user to attribute a potential edit to")
+	editorCtx := UserToContext(ctx, &User{UserID: editorID, Role: editorRole})
+
+	sameNotes := notes
+	noop := &Score{
+		ScoreID:          copiedScoreID,
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       newDC,
+		Notes:            &sameNotes,
+	}
+	_, err = noop.Save(editorCtx)
+	require.NoError(t, err, "a no-op re-save must succeed")
+
+	assert.Equal(t, "not_started", readStatus(),
+		"a no-op re-save must not transition a carried answer to done (ztmf#299)")
+	assert.Equal(t, int32(0), questionsUpdated(),
+		"a no-op re-save must leave QuestionsUpdated at zero")
+}

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -411,3 +411,46 @@ func TestScoreNoOpReSavePreservesNotStartedIntegration(t *testing.T) {
 	assert.Equal(t, int32(0), questionsUpdated(),
 		"a no-op re-save must leave QuestionsUpdated at zero")
 }
+
+// TestImportedScoresKeepProvenanceWithoutDoneStatusIntegration pins the
+// imported-history contract (ztmf#435): externally-loaded rows are attributed
+// with 'imported' provenance events (so last-updated shows who/when instead of
+// blank) but must NOT be marked done - an import is not a human answering this
+// cycle. The status backfill / seed status-sync only count 'created'/'updated'
+// events, so imported rows stay not_started despite carrying events. The empire
+// seed's FY2020 archives cycle (datacallid 6) is exactly this shape.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestImportedScoresKeepProvenanceWithoutDoneStatusIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	const archivesDataCallID = 6
+	var total, notStarted, withImported, withEdit int
+	err = conn.QueryRow(ctx, `
+		SELECT
+		  count(*),
+		  count(*) FILTER (WHERE s.status = 'not_started'),
+		  count(*) FILTER (WHERE EXISTS (SELECT 1 FROM public.events e
+		      WHERE e.resource='public.scores' AND e.action='imported'
+		        AND (e.payload->>'scoreid')::int = s.scoreid)),
+		  count(*) FILTER (WHERE EXISTS (SELECT 1 FROM public.events e
+		      WHERE e.resource='public.scores' AND e.action IN ('created','updated')
+		        AND (e.payload->>'scoreid')::int = s.scoreid))
+		FROM public.scores s
+		WHERE s.datacallid = $1
+	`, archivesDataCallID).Scan(&total, &notStarted, &withImported, &withEdit)
+	require.NoError(t, err)
+
+	require.Greater(t, total, 0, "FY2020 archives fixture must seed imported scores")
+	assert.Equal(t, total, notStarted, "imported archive rows must stay not_started")
+	assert.Equal(t, total, withImported, "every archived row must carry an 'imported' provenance event")
+	assert.Equal(t, 0, withEdit, "archived rows must have no created/updated events (import is not an edit)")
+}

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -13,11 +13,13 @@ import (
 
 // TestFindScoreProgressIntegration pins the central semantic of ztmf#299
 // against the real SQL: an answer pre-populated by copyPreviousScores does
-// NOT count as updated (the copy records no events), and the same answer
-// counts the moment a user actually saves it (the write path records an
-// event). Unit tests over the generated SQL cannot see this - it depends on
-// the interplay between the copy path, the event trigger in queryRow, and
-// the INNER lateral in the progress query.
+// NOT count as updated (the copy sets status = 'not_started'), and the same
+// answer counts the moment a user actually saves it (Save sets status =
+// 'done' in the same statement). It also pins ztmf#435's answered/total: the
+// carried-forward answer counts as QuestionsAnswered throughout, since it has
+// a row regardless of status. Unit tests over the generated SQL cannot see
+// this - it depends on the interplay between the copy path, the status
+// transition in Save, and the status filter in the progress query.
 //
 // Requires DB_* env vars pointing at a seeded ZTMF database (the dev compose
 // stack). Skipped under `go test -short`.
@@ -119,13 +121,16 @@ func TestFindScoreProgressIntegration(t *testing.T) {
 	before := findForSystem()
 	assert.Equal(t, int32(0), before.QuestionsUpdated,
 		"pre-populated answers must not count as updated")
+	assert.Equal(t, int32(1), before.QuestionsAnswered,
+		"the carried-forward answer has a row, so it counts as answered even before it is touched")
 	assert.False(t, before.UpdatedSinceStart)
 	assert.Nil(t, before.LastUpdatedAt)
-	assert.GreaterOrEqual(t, before.QuestionsExpected, int32(0),
-		"expected count resolves through the environment mapping")
+	assert.GreaterOrEqual(t, before.QuestionsExpected, int32(1),
+		"expected count resolves through the environment mapping and includes the applicable answered function")
 
 	// Phase 2: a user saves the copied answer through the normal write path,
-	// which records an edit event. Progress must now count it.
+	// which transitions status to 'done' in the same statement. Progress must
+	// now count it as updated.
 	var copiedScoreID int32
 	err = conn.QueryRow(ctx, `
 		SELECT scoreid FROM scores
@@ -162,6 +167,8 @@ func TestFindScoreProgressIntegration(t *testing.T) {
 	after := findForSystem()
 	assert.Equal(t, int32(1), after.QuestionsUpdated,
 		"a genuinely edited answer must count as updated")
+	assert.Equal(t, int32(1), after.QuestionsAnswered,
+		"the answer still has a row, so answered is unchanged by the edit")
 	assert.True(t, after.UpdatedSinceStart)
 	assert.LessOrEqual(t, after.QuestionsUpdated, after.QuestionsExpected,
 		"updated can never exceed the applicable-question denominator")
@@ -263,6 +270,8 @@ func TestFindScoreProgressExcludesInapplicableAnswers(t *testing.T) {
 
 	assert.Greater(t, p.QuestionsExpected, int32(0),
 		"the system has applicable functions of its own")
+	assert.Equal(t, int32(0), p.QuestionsAnswered,
+		"an answer for a non-applicable function must not count as answered either - the answered numerator uses the same applicability join")
 	assert.Equal(t, int32(0), p.QuestionsUpdated,
 		"an edited answer for a non-applicable function must not count as updated")
 	assert.False(t, p.UpdatedSinceStart,

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -41,8 +41,10 @@ func TestFindScoreProgressInputValidate(t *testing.T) {
 //     both the system env and the function's scoring key), which is what stops
 //     a carried-over answer to a now-inapplicable function from inflating the
 //     numerator past 100%;
-//   - the updated CTE keys on edit events via an INNER lateral, excluding
-//     pre-populated rows (copyPreviousScores records no events);
+//   - the updated count filters on the persisted scores.status column
+//     (status = 'done'), excluding pre-populated rows, rather than requiring
+//     an edit event; the events lateral is now LEFT and feeds only
+//     lastupdatedat;
 //   - both halves LEFT JOIN back onto scoped_systems so a zero-activity or
 //     unmapped-environment system still returns a row (0 of N).
 func TestBuildScoreProgressSQL_Shape(t *testing.T) {
@@ -58,12 +60,14 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	assert.Contains(t, sql, "INNER JOIN pillars p ON p.pillarid = q.pillarid", "applicability mirrors FindQuestionsByFismaSystem")
 	// updated re-checks applicability against the system's CURRENT environment.
 	assert.Contains(t, sql, "dce.scoring_key = f.datacenterenvironment", "an answered function must still be applicable to the system's current environment")
-	assert.Equal(t, 2, strings.Count(sql, "COUNT(DISTINCT f.functionid)"), "both halves count distinct applicable functions from the same set")
-	assert.Contains(t, sql, "INNER JOIN LATERAL", "updated count must require an edit event so pre-populated rows drop out")
-	assert.Contains(t, sql, "resource = 'public.scores'", "the lateral must read score events")
+	assert.Equal(t, 3, strings.Count(sql, "COUNT(DISTINCT f.functionid)"), "expected, answered, and updated all count distinct applicable functions from the same set")
+	assert.Contains(t, sql, "FILTER (WHERE s.status = 'done')", "updated is the answered set filtered to genuinely-saved rows via the persisted status column")
+	assert.Contains(t, sql, "LEFT JOIN LATERAL", "the events lateral is now LEFT (audit timeline only), not the filter for the count")
+	assert.Contains(t, sql, "resource = 'public.scores'", "the lateral must read score events for lastupdatedat")
 	assert.Contains(t, sql, "LEFT JOIN expected", "unmapped-environment systems must still return a row")
 	assert.Contains(t, sql, "LEFT JOIN updated", "zero-activity systems must still return a row")
-	assert.Contains(t, sql, "COALESCE(u.questionsupdated, 0)", "zero-activity systems report 0, not NULL")
+	assert.Contains(t, sql, "COALESCE(u.questionsanswered, 0)", "zero-activity systems report 0 answered, not NULL")
+	assert.Contains(t, sql, "COALESCE(u.questionsupdated, 0)", "zero-activity systems report 0 updated, not NULL")
 	assert.Contains(t, sql, "COALESCE(ex.questionsexpected, 0)", "unmapped-environment systems report 0 expected, not NULL")
 
 	// No scope filters: the single arg is the data call id.

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -93,11 +93,20 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 		}
 	}
 
+	// status is set to 'done' in the same INSERT/UPDATE statement as the
+	// answer (ztmf#435). Because it rides the same write, the state can never
+	// disagree with the row it describes - unlike the old events-derived
+	// progress, which depended on a fire-and-forget, non-transactional,
+	// context-gated event write landing separately. Reaching this point means
+	// a genuine create (scoreid == 0) or a change that cleared the no-op guard
+	// above, which is exactly what "updated this cycle" means. A read-through
+	// PUT short-circuits before here and never touches status, so a carried-over
+	// row stays not_started (ztmf#299 preserved).
 	if s.ScoreID == 0 {
 		sqlb = stmntBuilder.
 			Insert("public.scores").
-			Columns("fismasystemid", "notes", "notes_is_ai_summary", "functionoptionid", "datacallid").
-			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID).
+			Columns("fismasystemid", "notes", "notes_is_ai_summary", "functionoptionid", "datacallid", "status").
+			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, "done").
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid")
 	} else {
 		setCols := squirrel.Eq{
@@ -105,6 +114,7 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			"notes":            s.Notes,
 			"functionoptionid": s.FunctionOptionID,
 			"datacallid":       s.DataCallID,
+			"status":           "done",
 		}
 		if s.NotesIsAISummary != nil {
 			setCols["notes_is_ai_summary"] = *s.NotesIsAISummary
@@ -736,15 +746,21 @@ func copyPreviousScores(dataCallID int32) {
 		return
 	}
 
-	// select the previous scores but set the datacallid to be the latest
+	// select the previous scores but set the datacallid to be the latest.
+	// status is seeded as the 'not_started' literal (ztmf#435): the answer
+	// value carries forward in functionoptionid, but its review state for THIS
+	// cycle is reset, so a carried-over-but-untouched answer reads as not
+	// updated - the semantic the events lateral used to derive from "no event
+	// exists" (ztmf#299). The literal is a selected column so it lands in the
+	// same INSERT...SELECT as the copy, keeping the reset atomic with the row.
 	prevScoresSqlb := squirrel.
-		Select("fismasystemid", "datecalculated", "notes", "notes_is_ai_summary", "functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID)).
+		Select("fismasystemid", "datecalculated", "notes", "notes_is_ai_summary", "functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID), "'not_started' as status").
 		From("scores").
 		Where("datacallid=?", prevDataCall.DataCallID)
 
 	sqlb := squirrel.
 		Insert("scores").
-		Columns("fismasystemid", "datecalculated", "notes", "notes_is_ai_summary", "functionoptionid", "datacallid").
+		Columns("fismasystemid", "datecalculated", "notes", "notes_is_ai_summary", "functionoptionid", "datacallid", "status").
 		Select(prevScoresSqlb).
 		PlaceholderFormat(squirrel.Dollar)
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -594,8 +594,19 @@ components:
         lastupdatedat:
           description: |-
             LastUpdatedAt is the most recent edit event across the system's answers
-            in this data call; nil when nothing has been touched this cycle.
+            in this data call; nil when nothing has been touched this cycle. This is
+            a legitimately observational use of the events table (audit timeline),
+            kept even though the counts no longer read events.
           type: string
+        questionsanswered:
+          description: |-
+            QuestionsAnswered is the number of distinct applicable functions that
+            have an answer row in this data call, regardless of whether it was
+            touched this cycle. Counted from the same applicable-function set as
+            QuestionsExpected, so it can never exceed it. This is the answered/total
+            count a historical (closed) data call reports - carried-forward answers
+            count here even though they do not count as QuestionsUpdated.
+          type: integer
         questionsexpected:
           description: |-
             QuestionsExpected is the number of questionnaire functions applicable to
@@ -606,9 +617,11 @@ components:
         questionsupdated:
           description: |-
             QuestionsUpdated is the number of distinct functions whose answer in
-            this data call has at least one recorded edit event AND is still
-            applicable to the system's current environment. Counted from the same
-            applicable-function set as QuestionsExpected, so it can never exceed it.
+            this data call reached status = 'done' (genuinely saved this cycle) AND
+            is still applicable to the system's current environment. Counted from
+            the same applicable-function set as QuestionsExpected, so it can never
+            exceed it. Read from the persisted scores.status column, not from the
+            events audit log.
           type: integer
         updatedsincestart:
           description: |-
@@ -616,8 +629,6 @@ components:
             it answers the ticket's literal question - "has this system updated
             since the start of the data call" - by name in the response, so a
             consumer rendering a boolean chip never touches the numeric fields.
-            The anchor is real: events can only postdate the data call's creation,
-            so any counted edit necessarily happened after the cycle started.
           type: boolean
       type: object
     model.SystemEnrichment:


### PR DESCRIPTION
## Summary

Implements #435: persist each questionnaire answer's review state as a first-class `scores.status` column, and derive "Data Call Progress" from it instead of lateral-joining the `events` audit log.

The progress metric used to infer "updated this cycle" from the presence of an edit event. That coupling is fragile — event writes are fire-and-forget (`queryRow` ignores `recordEvent`'s result), non-transactional (separate connection), and context-gated (skipped when there's no authenticated user). Any dropped event silently under-counts progress. This moves the truth onto the `scores` row itself, written in the **same statement** as the answer, so it can never disagree with the row it describes.

Opening as a **draft for @voidspooks to review** since they authored the issue and own the design intent.

## What changed

- **`scores.status`** (`not_started` | `done`), `varchar + CHECK` (matches the `target_maturity_tier` convention, migration `0046`).
- **`scores.Save`** sets `status = 'done'` on a genuine create/change, in the same INSERT/UPDATE as the answer — no transaction needed. A read-through PUT hits the existing no-op guard and never touches status, so a carried-forward answer stays `not_started` (preserves the #299 "carry-forward is not updated" rule).
- **`copyPreviousScores`** seeds carried rows as `'not_started'`.
- **`FindScoreProgress`** counts `status = 'done'` and drops the events INNER lateral. The events lateral stays as a LEFT join, feeding **only** `lastupdatedat` (a legitimately observational audit-timeline use).
- **`ScoreProgress.QuestionsAnswered`** (new): distinct applicable functions with an answer row, any status. This is the answered/total a *closed* call needs — it lets **ztmf-ui#537** retire its "score present ⇒ complete" proxy. `QuestionsUpdated` stays the "touched this cycle" numerator.
- **Migration `0048`** backfills existing rows (edit event → `done`, else `not_started`), mirroring the old derivation exactly so dashboards don't move at cutover. Seed data mirrors the same backfill (it loads after migrations).
- **`openapi.yaml`** regenerated.

## Design decision (see #435 open questions)

Shipped the **two-state** machine (`not_started → done`), not three. A per-answer `complete` state has no trigger in the app today — completion is tracked at the *system* level via `datacalls_fismasystems`, and events can't distinguish "finalized" from "touched" for a backfill. Two states solve the whole stated problem and backfill losslessly; a third can layer on later if product wants per-answer finalization. Happy to revisit if you'd prefer three.

## Acceptance criteria (#435)

- [x] Progress counts derive from persisted `scores.status`, not the `events` table
- [x] A dropped/failed event write no longer affects progress numbers
- [x] `copyPreviousScores` resets carried rows to `not_started`; #299 behavior preserved
- [x] Past data calls report a real answered/total (`QuestionsAnswered`)
- [x] Backfill leaves existing dashboards unchanged at cutover
- [x] `events` is no longer read by progress/completion logic (only the audit-timeline `lastupdatedat`)

## Test plan

- [x] `go build`, `go vet`, `gofmt` clean
- [x] Unit tests updated + passing (`scoreprogress_test.go` — status filter, `QuestionsAnswered`, SQL shape)
- [x] Migration DDL + backfill verified against real Postgres (correct done/not_started split)
- [x] Integration tests (`scoreprogress_integration_test.go`) — run in CI against a migrated DB
- [x] Reviewer to confirm the two-state choice matches intended design

Refs #435
