### PR TITLE
fix(mail): skip NULL/blank recipients so one contactless system can't abort the send

### DIFF
--- a/backend/cmd/api/internal/controller/massemails.go
+++ b/backend/cmd/api/internal/controller/massemails.go
@@ -56,6 +56,15 @@ func SaveMassEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// No deliverable recipients: a group where every system/user is contactless
+	// (far more reachable now that imported systems carry NULL emails). Skip the
+	// goroutine so we don't dial/auth/quit the SMTP relay for zero recipients;
+	// return the empty list so the caller sees nobody was targeted.
+	if len(recipients) == 0 {
+		respond(w, r, recipients, nil)
+		return
+	}
+
 	go mail.Send(m.Subject, m.Body, recipients)
 
 	respond(w, r, recipients, nil)

--- a/backend/internal/model/massemails.go
+++ b/backend/internal/model/massemails.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -84,9 +85,43 @@ func (m *MassEmail) Recipients(ctx context.Context) ([]string, error) {
 
 	sqlb := massEmailGroups[m.Group]()
 
-	// log.Println(sqlb.ToSql())
+	// Scan into *string, not string: recipient sources include nullable columns
+	// (fismasystems.issoemail, datacallcontact), and imported systems in
+	// particular carry NULL emails. pgx.RowTo[string] cannot scan a SQL NULL, so
+	// a single contactless system used to abort the entire send with an opaque
+	// error before any mail was dialed (ztmf#440).
+	raw, err := query(ctx, sqlb, pgx.RowTo[*string])
+	if err != nil {
+		return nil, err
+	}
 
-	return query(ctx, sqlb, pgx.RowTo[string])
+	return dedupeRecipients(raw), nil
+}
+
+// dedupeRecipients drops NULL and blank recipient emails and de-duplicates
+// case-insensitively. NULLs come from nullable sources (issoemail,
+// datacallcontact); blanks come from string_to_table splitting a trailing or
+// doubled ';'. De-duping means a person listed via both a user row and a
+// system's issoemail is emailed once, not twice.
+func dedupeRecipients(raw []*string) []string {
+	seen := make(map[string]struct{}, len(raw))
+	emails := make([]string, 0, len(raw))
+	for _, e := range raw {
+		if e == nil {
+			continue
+		}
+		addr := strings.TrimSpace(*e)
+		if addr == "" {
+			continue
+		}
+		key := strings.ToLower(addr)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		emails = append(emails, addr)
+	}
+	return emails
 }
 
 func sqlForISSO() squirrel.SelectBuilder {

--- a/backend/internal/model/massemails_integration_test.go
+++ b/backend/internal/model/massemails_integration_test.go
@@ -1,0 +1,66 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMassEmailRecipientsSkipsNullIntegration pins the ztmf#440 regression at
+// the scan layer the unit test can't reach: a fismasystem with a NULL issoemail
+// (and NULL datacallcontact) - exactly the shape imported systems have - must
+// not crash the recipient query. Before the fix, pgx.RowTo[string] failed with
+// "cannot scan NULL into *string" and aborted the entire send. The system's
+// NULL contributes no recipient, and no blank survives.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestMassEmailRecipientsSkipsNullIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// A contactless system: NULL issoemail feeds the ISSO/ALL queries, NULL
+	// datacallcontact feeds the DCC/ALL string_to_table split. Both are the
+	// NULLs that used to crash the scan.
+	var fsid int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO fismasystems (fismauid, fismaacronym, fismaname, opdiv_id, issoemail, datacallcontact)
+		VALUES ('ztmf440-null-uid', 'ZTMF440', 'ZTMF 440 Null Contact',
+		        (SELECT opdiv_id FROM opdivs LIMIT 1), NULL, NULL)
+		RETURNING fismasystemid
+	`).Scan(&fsid)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Fresh connection: the test body's `defer conn.Release()` runs before
+		// t.Cleanup, so the original conn is already back in the pool here.
+		c, err := db.Conn(context.Background())
+		if err != nil {
+			return
+		}
+		defer c.Release()
+		_, _ = c.Exec(context.Background(), `DELETE FROM fismasystems WHERE fismasystemid = $1`, fsid)
+	})
+
+	// Every group whose recipient query touches a nullable column must now
+	// succeed rather than error on the NULL.
+	for _, group := range []string{"ISSO", "DCC", "ALL"} {
+		t.Run(group, func(t *testing.T) {
+			m := &MassEmail{Group: group, Subject: "regression subject", Body: "regression body"}
+			recipients, err := m.Recipients(ctx)
+			require.NoError(t, err,
+				"a NULL issoemail/datacallcontact must not crash the %q recipient query (ztmf#440)", group)
+			for _, r := range recipients {
+				assert.NotEmpty(t, r, "no blank recipient should survive the filter")
+			}
+		})
+	}
+}

--- a/backend/internal/model/massemails_test.go
+++ b/backend/internal/model/massemails_test.go
@@ -1,0 +1,56 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func strptr(s string) *string { return &s }
+
+// TestDedupeRecipients pins the ztmf#440 fix: the recipient list is built from
+// nullable columns (fismasystems.issoemail, datacallcontact) and string_to_table
+// output, so it can contain NULLs and blank segments. A single NULL used to
+// crash the whole send (pgx.RowTo[string] cannot scan NULL). dedupeRecipients
+// must drop NULL/blank, de-duplicate case-insensitively, and preserve order.
+func TestDedupeRecipients(t *testing.T) {
+	t.Run("drops NULL recipients without erroring", func(t *testing.T) {
+		got := dedupeRecipients([]*string{
+			strptr("isso@agency.gov"),
+			nil, // an imported system with no issoemail - the #440 crash case
+			strptr("dcc@agency.gov"),
+		})
+		assert.Equal(t, []string{"isso@agency.gov", "dcc@agency.gov"}, got)
+	})
+
+	t.Run("drops blank and whitespace-only segments", func(t *testing.T) {
+		// string_to_table on "a@x.gov;" yields a trailing "".
+		got := dedupeRecipients([]*string{
+			strptr("a@x.gov"),
+			strptr(""),
+			strptr("   "),
+		})
+		assert.Equal(t, []string{"a@x.gov"}, got)
+	})
+
+	t.Run("de-duplicates case-insensitively", func(t *testing.T) {
+		// Same person via a users row and a system's issoemail.
+		got := dedupeRecipients([]*string{
+			strptr("Person@Agency.gov"),
+			strptr("person@agency.gov"),
+			strptr("other@agency.gov"),
+		})
+		assert.Equal(t, []string{"Person@Agency.gov", "other@agency.gov"}, got)
+	})
+
+	t.Run("trims surrounding whitespace on kept addresses", func(t *testing.T) {
+		got := dedupeRecipients([]*string{strptr("  spaced@agency.gov  ")})
+		assert.Equal(t, []string{"spaced@agency.gov"}, got)
+	})
+
+	t.Run("returns empty (non-nil) slice when everything is filtered", func(t *testing.T) {
+		got := dedupeRecipients([]*string{nil, strptr(""), strptr("  ")})
+		assert.Empty(t, got)
+		assert.NotNil(t, got)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #440. The "Email Users" feature returned an opaque `An error occurred, please try again later` whenever a recipient group included a system or user with a NULL email. `MassEmail.Recipients()` scanned every recipient with `pgx.RowTo[string]`, which cannot scan a SQL NULL — so a single system with a NULL `issoemail`/`datacallcontact` aborted the entire send **before any mail was dialed**. Surfaced in dev after the HHS import brought in systems without contact emails.

This is not an SMTP or infrastructure change — the failure was entirely in building the recipient list, ahead of the mail code.

## Change

- Scan recipients into `*string` instead of `string`, then filter in a new `dedupeRecipients` helper:
  - drop NULL addresses (nullable sources: `fismasystems.issoemail`, `datacallcontact`)
  - drop blank/whitespace-only addresses (from `string_to_table` splitting a trailing or doubled `;`)
  - de-duplicate case-insensitively, so a person listed via both a `users` row and a system's `issoemail` is emailed once, not twice. (In the CMS/Okta identity context, `A@x` and `a@x` are always the same mailbox.)
- Skip the `mail.Send` goroutine entirely when there are no deliverable recipients (a fully-contactless group, now reachable post-import), rather than dialing the SMTP relay for zero recipients.

## Testing

- Unit: `TestDedupeRecipients` — NULL handling (the crash case), blank/whitespace segments, case-insensitive dedup, trimming, all-filtered.
- Integration: `TestMassEmailRecipientsSkipsNullIntegration` — inserts a system with NULL `issoemail`/`datacallcontact` and asserts the ISSO/DCC/ALL recipient queries no longer crash on the NULL (drives the real scan path, pins the regression end to end).
- `make test-unit` and `make test-integration` green, `go vet` clean.

## Out of scope / follow-ups

- Populating the missing contact emails on imported systems is intentionally left out — the fix skips contactless systems rather than fabricating addresses.
- Worth filing separately: per-recipient send-result capture (pass/fail), and confirming the dev VPC can actually reach the CMS internal SMTP relay (`smtp.cloud.internal.cms.gov`) — this crash previously masked whether it's reachable from dev.
