### PR TITLE
fix(fismasystems): clear blank optional fields to NULL, stop blank-email 400 (#442)

### DIFF
--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -612,6 +612,39 @@ tests:
           data:
             <<: *hhsExpected
 
+  # Test A2 — clearing values (ztmf#442). On the same system (still holding the
+  # HHS values Test A preserved), an OWNER PUT that sends hva as "" clears it to
+  # NULL, and a blanked issoemail no longer 400s the whole save. HHS fields still
+  # omitted from the body stay untouched (partial-PUT contract from Test A).
+  - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystemWithHHS.Response.data.fismasystemid}}"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        <<: *updatedFismaSystemData
+        issoemail: "" # blanked email must not 400 (it clears to NULL)
+        hva: "" # cleared metadata field -> NULL
+    expect:
+      status: 204
+
+  - url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystemWithHHS.Response.data.fismasystemid}}"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            hva: null # "" cleared the column to NULL, not "" or unchanged
+            issoemail: null # blanked email cleared to NULL, no 400
+            system_owner: "Grand Moff Tarkin" # omitted HHS field preserved
+            cloud_system: "Yes" # omitted HHS field preserved
+
   # Test B — Scoped admin RBAC gate.
   #
   # Part 1: opDivAdmin POSTs a system with HHS fields → clearHHSMetadata

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -182,6 +182,15 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 
 	var sqlb SqlBuilder
 
+	// A blanked contact email arrives as "" from the edit form (a cleared input
+	// is "", not null). These are always written, so collapse "" to nil now:
+	// otherwise validate() below runs isValidEmail("") and 400s the whole save,
+	// and the column would store "" instead of NULL (ztmf#442). The metadata
+	// fields are handled per-path below, where "" (clear) must stay
+	// distinguishable from nil (omitted → leave unchanged).
+	f.DataCallContact = blankToNil(f.DataCallContact)
+	f.ISSOEmail = blankToNil(f.ISSOEmail)
+
 	if err := f.validate(); err != nil {
 		return nil, err
 	}
@@ -227,15 +236,17 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 				f.FismaUID, f.FismaAcronym, f.FismaName, f.FismaSubsystem, f.Component,
 				f.Groupacronym, f.GroupName, f.DivisionName, f.DataCenterEnvironment,
 				f.DataCallContact, f.ISSOEmail, f.SDLSyncEnabled, opdivVal,
-				f.HVA, f.FIPS, f.SystemType, f.CloudSystem, f.CloudServiceModel,
-				f.CloudVendor, f.SystemOperator, f.GocoCocGoGo, f.SystemOwner,
-				f.SystemOwnerEmail, f.Legacy, f.ISSOName,
+				// A blank optional field on create is NULL, not "" (ztmf#442).
+				blankToNil(f.HVA), blankToNil(f.FIPS), blankToNil(f.SystemType),
+				blankToNil(f.CloudSystem), blankToNil(f.CloudServiceModel),
+				blankToNil(f.CloudVendor), blankToNil(f.SystemOperator),
+				blankToNil(f.GocoCocGoGo), blankToNil(f.SystemOwner),
+				blankToNil(f.SystemOwnerEmail), blankToNil(f.Legacy),
+				blankToNil(f.ISSOName),
 			).
 			Suffix("RETURNING " + strings.Join(fismaSystemColumns, ", "))
 	} else {
-		// UPDATE - exclude decommissioned fields.
-		// Core fields are always written; HHS fields are conditional on non-nil
-		// so a partial PUT (form that omits a field) does not wipe importer data.
+		// UPDATE - exclude decommissioned fields. Core fields are always written.
 		setCols := squirrel.Eq{
 			"fismauid":              f.FismaUID,
 			"fismaacronym":          f.FismaAcronym,
@@ -250,6 +261,16 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 			"issoemail":             f.ISSOEmail,
 			"sdl_sync_enabled":      f.SDLSyncEnabled,
 		}
+		// Metadata fields distinguish three request states (ztmf#442):
+		//   - omitted / null (nil pointer) -> leave the stored value untouched,
+		//     so a partial PUT never wipes importer data (and a scoped-admin edit,
+		//     whose HHS fields copyHHSMetadata has set to the stored values, is a
+		//     no-op here);
+		//   - "" (a cleared form input) -> write NULL, so a blank actually clears
+		//     the value rather than persisting "" or being silently ignored;
+		//   - a value -> write it.
+		// blankToNil folds the "" case into a nil *string, which pgx encodes as
+		// NULL; nil-guarding the assignment keeps the omitted case untouched.
 		hhsCols := map[string]*string{
 			"hva":                 f.HVA,
 			"fips":                f.FIPS,
@@ -266,7 +287,7 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 		}
 		for col, val := range hhsCols {
 			if val != nil {
-				setCols[col] = *val
+				setCols[col] = blankToNil(val)
 			}
 		}
 		sqlb = stmntBuilder.
@@ -506,6 +527,17 @@ func SaveTargetMaturity(ctx context.Context, input TargetMaturityInput) (*FismaS
 		Suffix("RETURNING " + strings.Join(fismaSystemColumns, ", "))
 
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[FismaSystem])
+}
+
+// blankToNil returns nil for a pointer to an empty string, so a blank input
+// clears the column to NULL instead of persisting "" (ztmf#442). A genuine nil
+// (field absent or null in the request) is returned untouched, which the UPDATE
+// path relies on to tell "clear this" ("") apart from "leave unchanged" (nil).
+func blankToNil(p *string) *string {
+	if p != nil && *p == "" {
+		return nil
+	}
+	return p
 }
 
 func (f *FismaSystem) validate() error {

--- a/backend/internal/model/fismasystems_test.go
+++ b/backend/internal/model/fismasystems_test.go
@@ -231,6 +231,32 @@ func TestFismaSystem_Validate(t *testing.T) {
 	}
 }
 
+// TestBlankToNil pins the ztmf#442 primitive: "" -> nil (clear to NULL), while
+// a genuine nil and a real value pass through untouched. Save uses the nil vs
+// "" distinction on UPDATE to tell "leave unchanged" (nil) from "clear" ("").
+func TestBlankToNil(t *testing.T) {
+	assert.Nil(t, blankToNil(stringPtr("")), `"" collapses to nil so the column clears to NULL`)
+	assert.Nil(t, blankToNil(nil), "nil (omitted/null) stays nil -> leave unchanged")
+	if got := blankToNil(stringPtr("Moderate")); assert.NotNil(t, got) {
+		assert.Equal(t, "Moderate", *got, "a real value passes through")
+	}
+}
+
+// TestFismaSystem_Validate_BlankEmails pins that a blanked contact email is
+// treated as unset, not invalid (ztmf#442). Save collapses "" -> nil for the
+// two email fields before validate(); before the fix, an empty issoemail reached
+// isValidEmail("") and 400'd the whole save.
+func TestFismaSystem_Validate_BlankEmails(t *testing.T) {
+	fs := FismaSystem{
+		FismaUID:        "CDC8767221",
+		FismaAcronym:    "TEST",
+		FismaName:       "Test System",
+		DataCallContact: blankToNil(stringPtr("")),
+		ISSOEmail:       blankToNil(stringPtr("")),
+	}
+	assert.NoError(t, fs.validate(), "a blanked email is unset, not invalid")
+}
+
 // TestDeleteFismaSystem_WithCustomDate tests decommission with custom date
 func TestDeleteFismaSystem_WithCustomDate(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Closes #442.

## Problem

The admin system add/edit save (`POST/PUT /fismasystems`) mishandled empty values on the optional metadata fields. Three symptoms, one root cause:

1. **Blanking an email field 400'd the whole save** — a cleared `datacallcontact`/`issoemail` arrives as `""`, which reached `isValidEmail("")` (false) and failed validation.
2. **A set metadata field couldn't be cleared** — the UPDATE path wrote only non-nil fields, so `null` meant "leave unchanged" and there was no way to un-set a value.
3. **Clearing stored `""`, not NULL** — a cleared input was written verbatim, so a column's "unknown" (NULL) and "blank" (`""`) states diverged.

Root cause: nothing normalized `""`, and the write path couldn't tell "clear this" from "leave unchanged."

## Fix (backend-only)

A three-state write contract via a small `blankToNil` helper:

- **`""` (a cleared form input) → write NULL** (clears the value)
- **`nil` (field omitted or `null`) → leave the stored value unchanged** — so a partial PUT never wipes importer data (preserves the existing emberfall Test A guard), and a scoped-admin edit whose HHS fields `copyHHSMetadata` set to stored values is a no-op
- **a value → write it**

Contact emails collapse `""` → nil before validation (so a blanked email is *unset*, not invalid); INSERT and UPDATE run the metadata fields through `blankToNil`.

No frontend change required — normalizing on the backend makes the existing form behavior correct.

## Why this shape

The obvious "write everything authoritatively" approach would have broken **emberfall Test A**, which deliberately pins that an OWNER partial PUT with HHS fields *omitted* must not wipe stored values. The `nil = leave unchanged` / `"" = clear` split fixes all three bugs while keeping that contract.

## Testing

- New unit tests: `TestBlankToNil`, `TestFismaSystem_Validate_BlankEmails`.
- New emberfall case (Test A2): clear-via-`""` writes NULL, a blanked email saves (204, cleared), and omitted HHS fields stay preserved.
- `make test-integration` green; `make test-e2e` green (155/0). Pre-commit + pre-push hooks green.
- Verified live against the dev API: blank email → 204 + NULL; `hva:""` → NULL; partial PUT (hva omitted) → preserved; `hva:null` → unchanged.

## Context

Surfaced while reviewing the metadata-standardization epic (#431); this blocks that epic's `cloud_system = No ⇒ clear cloud_service_model/cloud_vendor` rule and its "preserve unknown (null) end to end" criterion, so it lands first.

> Snyk / secret-dependent CI will show red on this fork PR (no repo secrets) — expected; maintainers re-run after pulling.
