### PR TITLE
Surface silent score-rollover failures on data call creation

### DIFF
--- a/backend/internal/model/datacalls.go
+++ b/backend/internal/model/datacalls.go
@@ -79,10 +79,15 @@ func FindDataCallByID(ctx context.Context, dataCallID int32) (*DataCall, error) 
 	return queryRow(ctx, sqlb, pgx.RowToStructByName[DataCall])
 }
 
-func findPreviousDataCall(dataCallID int32) (*DataCall, error) {
+func findPreviousDataCall(ctx context.Context, dataCallID int32) (*DataCall, error) {
 	// find the *previous* datacall by deadline (not datacallid): once historical
 	// calls are loaded, a backfilled year can out-id the real prior call, so
 	// ordering by datacallid would pick the wrong "previous" for score rollover.
+	//
+	// Known limitation (ztmf#448): this picks the globally-latest OTHER call, not
+	// the latest call with a deadline earlier than this one. Creating a backfill
+	// data call with a deadline before existing cycles resolves "previous" to a
+	// future cycle. Out of scope here; tracked separately.
 	prevDcSqlb := stmntBuilder.
 		Select(dataCallColumns...).
 		From("datacalls").
@@ -90,7 +95,7 @@ func findPreviousDataCall(dataCallID int32) (*DataCall, error) {
 		OrderBy("deadline DESC", "datacallid DESC").
 		Limit(1)
 
-	return queryRow(context.TODO(), prevDcSqlb, pgx.RowToStructByName[DataCall])
+	return queryRow(ctx, prevDcSqlb, pgx.RowToStructByName[DataCall])
 }
 
 func FindLatestDataCall(ctx context.Context) (*DataCall, error) {

--- a/backend/internal/model/datacalls.go
+++ b/backend/internal/model/datacalls.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"log"
 	"strings"
 	"time"
 
@@ -45,7 +46,18 @@ func (d *DataCall) Save(ctx context.Context) (*DataCall, error) {
 		return nil, err
 	}
 
-	go copyPreviousScores(dataCall.DataCallID)
+	// Roll the previous cycle's answers into a *newly created* data call only.
+	// Never on update: re-running the copy on an edit would duplicate every
+	// carried-over score (ztmf#411). Run it synchronously so the outcome is
+	// observable, but do not fail the create on a copy error - the datacall row
+	// is already committed and is valid without a rollover (the first-ever cycle
+	// legitimately copies zero rows). copyPreviousScores emits the loud
+	// ROLLOVER_ANOMALY signal on any zero/partial/errored copy.
+	if d.DataCallID == 0 {
+		if _, err := copyPreviousScores(ctx, dataCall.DataCallID); err != nil {
+			log.Println(err)
+		}
+	}
 
 	return dataCall, nil
 }

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -99,7 +99,9 @@ func TestFindScoreProgressIntegration(t *testing.T) {
 	`, fismaSystemID, functionOptionID, prevDC, notes)
 	require.NoError(t, err)
 
-	copyPreviousScores(newDC)
+	if _, err := copyPreviousScores(ctx, newDC); err != nil {
+		t.Fatalf("copyPreviousScores: %v", err)
+	}
 
 	findForSystem := func() *ScoreProgress {
 		t.Helper()

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -727,20 +728,61 @@ ORDER BY ps.datacallid, ps.fismasystemid, ps.pillarid
 	return sql, args
 }
 
-// dataCallID is meant to be passed the *latest* datacall most recently created so the previous can be selected
-func copyPreviousScores(dataCallID int32) {
+// copyPreviousScores rolls the previous cycle's answers forward into the
+// newly created data call identified by dataCallID (the *latest* datacall; the
+// previous one is discovered via findPreviousDataCall). It returns the number
+// of score rows copied.
+//
+// The rollover is best-effort enrichment - it never invalidates the new data
+// call - but a zero, partial, or errored copy is surfaced loudly via the
+// ROLLOVER_ANOMALY log token (wired to a CloudWatch metric alarm) so an empty
+// cycle is detected rather than shipped silently. See ztmf#411.
+func copyPreviousScores(ctx context.Context, dataCallID int32) (int64, error) {
 	prevDataCall, err := findPreviousDataCall(dataCallID)
-
 	if err != nil {
-		log.Println(err)
-		return
+		// No previous cycle (the first-ever data call) is the expected, benign
+		// case: nothing to roll forward, and not an anomaly.
+		if errors.Is(err, ErrNoData) {
+			return 0, nil
+		}
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=? copied=0 err=%v", dataCallID, err)
+		return 0, err
 	}
 
-	// select the previous scores but set the datacallid to be the latest
-	prevScoresSqlb := squirrel.
-		Select("fismasystemid", "datecalculated", "notes", "notes_is_ai_summary", "functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID)).
+	// skip convenience methods to avoid recording events for this operation
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=? copied=0 err=%v", dataCallID, err)
+		return 0, err
+	}
+	defer conn.Release()
+
+	// Total candidate rows in the previous cycle, including any that are no
+	// longer referentially valid. Compared against the count actually copied to
+	// detect a partial (or empty) rollover.
+	var expected int64
+	countSql, countArgs, _ := squirrel.
+		Select("COUNT(*)").
 		From("scores").
-		Where("datacallid=?", prevDataCall.DataCallID)
+		Where("datacallid=?", prevDataCall.DataCallID).
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	if err = conn.QueryRow(ctx, countSql, countArgs...).Scan(&expected); err != nil {
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=? copied=0 err=%v", dataCallID, err)
+		return 0, err
+	}
+
+	// Copy the previous scores into the new cycle, rewriting datacallid to the
+	// latest. INNER JOIN the FK parents so a score whose fismasystem or
+	// functionoption no longer resolves is silently dropped instead of aborting
+	// the entire batch - the all-or-nothing INSERT...SELECT was the ztmf#411
+	// foot-gun where a single bad row emptied the whole rollover.
+	prevScoresSqlb := squirrel.
+		Select("s.fismasystemid", "s.datecalculated", "s.notes", "s.notes_is_ai_summary", "s.functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID)).
+		From("scores s").
+		Join("fismasystems fs ON fs.fismasystemid = s.fismasystemid").
+		Join("functionoptions fo ON fo.functionoptionid = s.functionoptionid").
+		Where("s.datacallid=?", prevDataCall.DataCallID)
 
 	sqlb := squirrel.
 		Insert("scores").
@@ -748,18 +790,20 @@ func copyPreviousScores(dataCallID int32) {
 		Select(prevScoresSqlb).
 		PlaceholderFormat(squirrel.Dollar)
 
-	// skip convenience methods to avoid recording events for this operation
-	conn, err := db.Conn(context.TODO())
-	if err != nil {
-		return
-	}
-	defer conn.Release()
-
 	sql, args, _ := sqlb.ToSql()
 
-	_, err = conn.Exec(context.TODO(), sql, args...)
-
+	tag, err := conn.Exec(ctx, sql, args...)
 	if err != nil {
-		log.Println(err)
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=%d copied=0 err=%v", dataCallID, expected, err)
+		return 0, err
 	}
+
+	copied := tag.RowsAffected()
+	if copied < expected {
+		// Either zero-when-expected, or a partial copy where dead-FK rows were
+		// dropped by the JOIN. Both warrant an operator signal.
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=%d copied=%d err=<none>", dataCallID, expected, copied)
+	}
+
+	return copied, nil
 }

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -748,7 +748,7 @@ ORDER BY ps.datacallid, ps.fismasystemid, ps.pillarid
 // ROLLOVER_ANOMALY log token (wired to a CloudWatch metric alarm) so an empty
 // cycle is detected rather than shipped silently. See ztmf#411.
 func copyPreviousScores(ctx context.Context, dataCallID int32) (int64, error) {
-	prevDataCall, err := findPreviousDataCall(dataCallID)
+	prevDataCall, err := findPreviousDataCall(ctx, dataCallID)
 	if err != nil {
 		// No previous cycle (the first-ever data call) is the expected, benign
 		// case: nothing to roll forward, and not an anomaly.

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -337,7 +337,9 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 	// Run the rollover. copyPreviousScores is unexported and accepts
 	// the *latest* datacallid — it discovers the previous one via
 	// findPreviousDataCall.
-	copyPreviousScores(newDC)
+	copied, err := copyPreviousScores(ctx, newDC)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, copied, "copyPreviousScores must report the one row it carried forward")
 
 	// After copy: the new datacall has at least the marker score.
 	var afterCount int
@@ -350,6 +352,66 @@ func TestCopyPreviousScoresIntegration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, afterCount,
 		"copyPreviousScores must carry the marker (system, functionoption) into the new datacall")
+}
+
+// TestCopyPreviousScoresEmptyPreviousIntegration covers the benign zero-row
+// rollover: a previous cycle that exists but holds no scores. This must be
+// handled cleanly - copied == 0, no error, and NO ROLLOVER_ANOMALY - so it is
+// distinguishable from the failure case where a non-empty previous cycle copies
+// zero rows. See ztmf#411.
+//
+// Note on the resilient INNER JOIN in copyPreviousScores: it drops previous-cycle
+// score rows whose fismasystem/functionoption FK parents no longer resolve, so a
+// single bad row can no longer abort the whole batch. That dead-FK state cannot
+// be manufactured here - scores.fismasystemid/functionoptionid are NOT NULL FKs
+// and their parents are ON DELETE RESTRICT, so the DB refuses to create or orphan
+// such a row. The JOIN is therefore defense-in-depth against a state the schema
+// currently prevents; the happy-path test above proves it does not drop VALID
+// rows (copied == 1), and this test proves the expected-vs-copied accounting does
+// not false-alarm on a legitimately empty previous cycle.
+func TestCopyPreviousScoresEmptyPreviousIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	// Same two-datacall setup as the happy path (deadlines beat every seed row so
+	// prevDC is the unambiguous previous of newDC), but seed NO scores under
+	// prevDC.
+	var prevDC, newDC int32
+	suffix := time.Now().UnixNano()
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), '2100-01-01T00:00:00Z'::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%sprev_empty_%d", integrationTestPrefix, suffix)).Scan(&prevDC)
+	require.NoError(t, err)
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), '2101-01-01T00:00:00Z'::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%snew_empty_%d", integrationTestPrefix, suffix)).Scan(&newDC)
+	require.NoError(t, err)
+
+	copied, err := copyPreviousScores(ctx, newDC)
+	require.NoError(t, err, "an empty previous cycle is benign, not an error")
+	assert.EqualValues(t, 0, copied, "an empty previous cycle copies zero rows")
+
+	var afterCount int
+	err = conn.QueryRow(ctx,
+		`SELECT COUNT(*) FROM scores WHERE datacallid = $1`, newDC,
+	).Scan(&afterCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, afterCount, "newDC must remain empty when the previous cycle had no scores")
 }
 
 // TestFindLatestDataCallByDeadlineIntegration verifies "latest" resolves by

--- a/infrastructure/monitoring-rollover.tf
+++ b/infrastructure/monitoring-rollover.tf
@@ -1,0 +1,46 @@
+# CloudWatch alerting for the score-rollover copy that runs when a new data
+# call is created (backend copyPreviousScores). The copy is best-effort and
+# never fails the create, so its only runtime signal is a distinctive log token,
+# ROLLOVER_ANOMALY, emitted on any zero, partial, or errored rollover. This turns
+# that token into a metric and alarm so an empty new cycle is detected rather
+# than shipped silently. See ztmf#411.
+
+# Count of ROLLOVER_ANOMALY lines in the API log group.
+resource "aws_cloudwatch_log_metric_filter" "ztmf_api_rollover_anomaly" {
+  name           = "ztmf-api-rollover-anomaly-${var.environment}"
+  log_group_name = aws_cloudwatch_log_group.ztmf_api.name
+  pattern        = "ROLLOVER_ANOMALY"
+
+  metric_transformation {
+    name          = "RolloverAnomaly"
+    namespace     = "ZTMF/API"
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+# Alarm on any anomaly. The score-rollover copy is plain Go that only
+# log.Printf's - it has no self-emitter - so, like the login/OIDC alarms, it
+# routes to the shared ztmf_alarms SNS topic (defined in monitoring-login-auth.tf)
+# rather than leaving alarm_actions empty (that convention is only for the kion /
+# cert-rotation Lambdas, which emit Slack themselves).
+resource "aws_cloudwatch_metric_alarm" "ztmf_api_rollover_anomaly" {
+  alarm_name          = "ztmf-api-rollover-anomaly-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "RolloverAnomaly"
+  namespace           = "ZTMF/API"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "ZTMF data-call score rollover copied zero/partial rows or errored (ROLLOVER_ANOMALY)"
+  alarm_actions       = [aws_sns_topic.ztmf_alarms.arn]
+  ok_actions          = [aws_sns_topic.ztmf_alarms.arn]
+
+  tags = {
+    Name        = "ZTMF API Rollover Anomaly Alarm"
+    Environment = var.environment
+  }
+}


### PR DESCRIPTION
## Summary

`copyPreviousScores` rolls the previous cycle's answers forward into a newly created data call. It was a fire-and-forget goroutine that swallowed every error and never checked how many rows it copied, so a single FK-inconsistent row in the previous cycle could abort the whole `INSERT ... SELECT`, get logged anonymously, and open the new cycle with **zero carried-over answers** - indistinguishable from success to the API caller and to operators. Every system in the new cycle would appear to have made no progress.

Fixes #411.

## Changes

- **Surface failures.** `copyPreviousScores` now returns `(int64, error)` and runs synchronously. The "no previous cycle" case (first-ever data call) is treated as benign; any real error, a zero copy against a non-empty previous cycle, or a partial copy now emits a distinctive `ROLLOVER_ANOMALY` log line with the expected/copied counts.
- **Resilient copy.** The source `SELECT` now `INNER JOIN`s the `fismasystems` and `functionoptions` FK parents, so a score whose parent no longer resolves is dropped from the batch instead of aborting the entire rollover. The row count actually copied is compared against the count of candidate rows to detect a partial or empty result.
- **Insert-only gate.** The copy now runs only on the insert path (`d.DataCallID == 0`). Previously it fired after both the INSERT and UPDATE branches of `DataCall.Save`, so editing an existing data call re-ran the full copy and duplicated every carried-over score. The create is not failed on a copy error - the data call row is already committed and is valid without a rollover - but the outcome is now observable.
- **Request context.** The copy now runs on the caller's `context.Context` rather than `context.TODO()`, so a cancelled create request cancels the copy and releases its pooled connection.
- **Alerting.** A CloudWatch log metric filter + alarm on the `ROLLOVER_ANOMALY` token, routed to the existing `ztmf_alarms` SNS topic (same pattern as the login/OIDC alarms, which are also Go paths with no self-emitter).

## Testing

### Automated

- `make test-integration` - updated the existing happy-path assertion to check the returned copied-count, and added `TestCopyPreviousScoresEmptyPreviousIntegration` covering the benign empty-previous-cycle path (zero rows, no error, no false anomaly). Green on the merged tree (includes #437's per-answer status changes).
- `terraform fmt -check` and `tflint` pass on the new monitoring file.

### Manual end-to-end against a production-shape database

Exercised through the real `POST /api/v1/datacalls` endpoint against a local database loaded with production-shape data (192,782 scores across 6 existing data calls), with an OWNER-role token. Created a new data call whose deadline falls after the latest existing cycle, so the previous cycle (38,400 scores) was the rollover source.

| Check | Result |
| --- | --- |
| Rollover copied from the previous cycle | 38,400 copied, exactly matching the 38,400 expected - a full clean copy, no rows dropped by the FK join |
| Per-answer `status` reset on carried rows | all 38,400 rows landed as `not_started`, set atomically within the copy |
| Answer values preserved | non-null notes carried forward on all 38,400 rows |
| `ROLLOVER_ANOMALY` emitted on a clean copy | none - the expected-vs-copied check does not false-alarm |
| Insert-only gate | editing the new data call via `PUT` did not re-fire the copy (count stayed 38,400; the previous unconditional behavior would have doubled it to 76,800) |

The test data call was removed afterward and the database returned to its exact baseline. The error and partial-copy branches cannot be reproduced against a real schema (the `NOT NULL` FKs forbid the orphaned-row state), so they remain covered by the integration tests and the reasoning above rather than a live run.

## Notes

- The dropped-dead-FK path in the resilient copy is defense-in-depth against a state the schema currently prevents (`scores.fismasystemid` / `functionoptionid` are `NOT NULL` FKs with no `ON DELETE` cascade, so the DB refuses to orphan a score). It cannot be reproduced in a test without tearing down the constraints; the happy-path test proves the JOIN does not drop valid rows, and the empty-previous test proves the expected-vs-copied accounting does not false-alarm.
- Wrapping the data-call insert and the rollover copy in a single transaction (so they are truly atomic) is deliberately out of scope - it would require reworking the shared `queryRow`/`recordEvent` connection pattern, and a data call is semantically valid without a rollover.
