### PR TITLE
Resolve previous data call by deadline-before, not globally-latest

### DIFF
--- a/backend/internal/model/datacalls.go
+++ b/backend/internal/model/datacalls.go
@@ -80,18 +80,26 @@ func FindDataCallByID(ctx context.Context, dataCallID int32) (*DataCall, error) 
 }
 
 func findPreviousDataCall(ctx context.Context, dataCallID int32) (*DataCall, error) {
-	// find the *previous* datacall by deadline (not datacallid): once historical
-	// calls are loaded, a backfilled year can out-id the real prior call, so
-	// ordering by datacallid would pick the wrong "previous" for score rollover.
+	// find the *previous* datacall: the most recent cycle whose deadline is
+	// strictly earlier than this call's deadline. Ordering is deadline-driven
+	// (not datacallid) because historical loads can carry a higher datacallid
+	// than the real prior call.
 	//
-	// Known limitation (ztmf#448): this picks the globally-latest OTHER call, not
-	// the latest call with a deadline earlier than this one. Creating a backfill
-	// data call with a deadline before existing cycles resolves "previous" to a
-	// future cycle. Out of scope here; tracked separately.
+	// The "strictly earlier than this call's deadline" restriction (not merely
+	// "the globally latest other call") is what fixes ztmf#448: a backfill data
+	// call can be created with a deadline BEFORE existing cycles, and picking the
+	// globally-latest other call would then resolve a future cycle as its
+	// "previous" and roll that future cycle's answers backward. Anchoring to
+	// deadlines before this call's makes a normal new cycle pick the real prior
+	// cycle, and a backfill pick the correct earlier cycle - or none, which is
+	// benign (nothing to roll forward). This also excludes the call itself, since
+	// its own deadline is not strictly before itself. Among the strictly-earlier
+	// candidates, datacallid DESC breaks deadline ties; a cycle sharing this
+	// call's exact deadline is not a candidate at all.
 	prevDcSqlb := stmntBuilder.
 		Select(dataCallColumns...).
 		From("datacalls").
-		Where("datacallid!=?", dataCallID).
+		Where("deadline < (SELECT deadline FROM datacalls WHERE datacallid=?)", dataCallID).
 		OrderBy("deadline DESC", "datacallid DESC").
 		Limit(1)
 

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -1229,3 +1229,63 @@ func TestScoringResolvesEnvironmentAliasIntegration(t *testing.T) {
 	assert.InDelta(t, base[0].SystemScore, aliased[0].SystemScore, 1e-9,
 		"an alias pointing at the same scoring_key must not change the score")
 }
+
+// TestFindPreviousDataCallByDeadlineIntegration pins the ztmf#448 fix:
+// findPreviousDataCall must resolve the most recent cycle whose deadline is
+// strictly earlier than the target call's deadline - never the globally-latest
+// other call. The bug surfaced with backfill data calls whose deadline sits
+// before existing cycles: the old query would resolve a FUTURE cycle as the
+// "previous" one and roll its answers backward.
+func TestFindPreviousDataCallByDeadlineIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	suffix := time.Now().UnixNano()
+	mk := func(name, deadline string) int32 {
+		var id int32
+		err := conn.QueryRow(ctx, `
+			INSERT INTO datacalls (datacall, datecreated, deadline)
+			VALUES ($1, NOW(), $2::timestamptz)
+			RETURNING datacallid
+		`, fmt.Sprintf("%s%s_%d", integrationTestPrefix, name, suffix), deadline).Scan(&id)
+		require.NoError(t, err)
+		return id
+	}
+
+	// Two cycles far beyond every seed deadline, plus a backfill whose deadline
+	// sits BETWEEN them. "Previous" of the backfill must be the earlier cycle,
+	// never the later (future) one.
+	before := mk("prevdc_before", "2100-01-01T00:00:00Z")
+	after := mk("prevdc_after", "2102-01-01T00:00:00Z")
+	backfill := mk("prevdc_backfill", "2101-01-01T00:00:00Z")
+
+	prev, err := findPreviousDataCall(ctx, backfill)
+	require.NoError(t, err)
+	assert.Equal(t, before, prev.DataCallID,
+		"previous of a backfill must be the earlier cycle")
+	assert.NotEqual(t, after, prev.DataCallID,
+		"previous must never resolve to a cycle with a later deadline (ztmf#448)")
+
+	// Sanity: the normal forward case still resolves the real prior cycle - the
+	// latest-deadline call before `after` is `backfill` (2101), then `before`.
+	prevOfAfter, err := findPreviousDataCall(ctx, after)
+	require.NoError(t, err)
+	assert.Equal(t, backfill, prevOfAfter.DataCallID,
+		"previous of the latest cycle is the next-earlier deadline")
+
+	// A call earlier than every existing cycle has no previous: ErrNoData, which
+	// copyPreviousScores treats as benign (nothing to roll forward).
+	earliest := mk("prevdc_earliest", "1901-01-01T00:00:00Z")
+	_, err = findPreviousDataCall(ctx, earliest)
+	assert.ErrorIs(t, err, ErrNoData,
+		"a call before all cycles has no previous, not a future one")
+}


### PR DESCRIPTION
## Summary

`findPreviousDataCall` resolves the "previous" data call whose answers get rolled forward into a newly created cycle (via `copyPreviousScores`). It ordered all other data calls by deadline and took the top row - i.e. the globally-latest cycle other than the target.

That is correct for a normal new cycle (the one with the furthest-future deadline), but wrong for a **backfill**: creating a data call with a deadline earlier than existing cycles resolved a *future* cycle as its "previous" one and rolled that future cycle's answers backward into the backfill.

Fixes #448.

## Change

Restrict the lookup to cycles whose deadline is strictly earlier than the target call's own deadline:

```
WHERE deadline < (SELECT deadline FROM datacalls WHERE datacallid = ?)
ORDER BY deadline DESC, datacallid DESC
LIMIT 1
```

- A normal forward cycle still resolves the true prior cycle (same result as before for the non-backfill case).
- A backfill resolves the correct earlier cycle, or none - and "none" is already benign in `copyPreviousScores` (`ErrNoData` returns `(0, nil)`, nothing to roll forward).
- The strictly-less comparison also excludes the call itself, so no separate self-exclusion is needed.

## Testing

- `make test-integration` - added `TestFindPreviousDataCallByDeadlineIntegration`, which pins the fix: a backfill whose deadline sits between two cycles resolves to the earlier one (and explicitly not the later/future one - this assertion fails on `main`), the normal forward case still resolves the real prior cycle, and a call earlier than every cycle resolves to `ErrNoData`. All existing rollover and latest-cycle tests stay green.

## Notes

Surfaced during review of #447 (which made the rollover synchronous and alarmed, so a mis-resolved "previous" became more visible). This is the tracked follow-up.
