### PR TITLE
feat(#239): add /datacentermismatches wrong-data-center report

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -562,19 +562,48 @@ ON CONFLICT (idm_name) DO NOTHING;
 -- Shield Gen (1003), which the Emberfall ISSO is assigned to. Gives the
 -- /systemenrichment endpoint E2E coverage via the users_fismasystems join.
 -- The payload is opaque to ztmf core (owned by the enrichment pipeline).
+-- data_center_environment ('CMS-Cloud-AWS', a canonical vocabulary value from
+-- migration 0045) deliberately disagrees with the system's own value
+-- ('Forest-Moon'), making this THE visible /datacentermismatches row (issue
+-- #239) with cfacts_value_known = TRUE.
 INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
     'E1D00198-36D4-4EAB-8C00-501E1D000999',
-    '{"fisma_acronym":"SLD-GEN","cfacts":{"lifecycle_phase":"Operational","fips_impact_level":"Moderate"},"scoring":{"suggested_score":2,"suggested_label":"Initial","evidence_sources":["Kion","Hardenize"]}}',
+    '{"fisma_acronym":"SLD-GEN","data_center_environment":"CMS-Cloud-AWS","cfacts":{"lifecycle_phase":"Operational","fips_impact_level":"Moderate"},"scoring":{"suggested_score":2,"suggested_label":"Initial","evidence_sources":["Kion","Hardenize"]}}',
+    '2026-05-20 00:00:00+00'
+) ON CONFLICT (fisma_uuid) DO NOTHING;
+
+-- Enrichment for the Executor (1002, EMPIRE, active): CFACTS agrees with the
+-- system's own value ('Imperial-Fleet'), so /datacentermismatches must exclude
+-- it. Proves matching systems are filtered out, not merely absent from the data
+-- (pinned by datacentermismatches_integration_test.go against the fresh seed).
+-- Note: mid-way through the emberfall suite a PUT flips the system to 'Other',
+-- after which the row legitimately reports; the e2e assertion covers that
+-- post-edit state.
+INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
+    'E0EC0100-1980-4C3D-9A7B-00F020240000',
+    '{"fisma_acronym":"SSD-EX","data_center_environment":"Imperial-Fleet","cfacts":{"lifecycle_phase":"Operational","fips_impact_level":"High"}}',
+    '2026-05-20 00:00:00+00'
+) ON CONFLICT (fisma_uuid) DO NOTHING;
+
+-- Enrichment for the Death Star (1001, EMPIRE, decommissioned): CFACTS
+-- disagrees ('CMS-Cloud-MAG' vs 'Space-Station'), but the system is
+-- decommissioned, so /datacentermismatches must exclude it (decommissioned
+-- drift is expected, not actionable).
+INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
+    'DEA75100-1977-4A1F-8B2E-A1DE0AA00404',
+    '{"fisma_acronym":"DS-1","data_center_environment":"CMS-Cloud-MAG","cfacts":{"lifecycle_phase":"Retired","fips_impact_level":"High"}}',
     '2026-05-20 00:00:00+00'
 ) ON CONFLICT (fisma_uuid) DO NOTHING;
 
 -- Enrichment row for a REBELLION system (RB-1, 1005). REBELLION has
 -- insights_enabled = FALSE, so the OpDiv gate must hide this row: a read returns
 -- 404 even though the payload exists and the caller is authorized. Proves the
--- gate is the OpDiv flag, not merely a missing row.
+-- gate is the OpDiv flag, not merely a missing row. Its data_center_environment
+-- also disagrees ('Endor-Cloud' vs 'Jungle-Moon'), proving the same gate keeps
+-- non-enabled OpDivs out of /datacentermismatches.
 INSERT INTO public.system_enrichment (fisma_uuid, payload, synced_at) VALUES (
     'A1B2C300-1977-4E5F-9D0A-1234567890AB',
-    '{"fisma_acronym":"RB-1","cfacts":{"lifecycle_phase":"Operational","fips_impact_level":"Low"},"scoring":{"suggested_score":1,"suggested_label":"Traditional","evidence_sources":["Kion"]}}',
+    '{"fisma_acronym":"RB-1","data_center_environment":"Endor-Cloud","cfacts":{"lifecycle_phase":"Operational","fips_impact_level":"Low"},"scoring":{"suggested_score":1,"suggested_label":"Traditional","evidence_sources":["Kion"]}}',
     '2026-05-20 00:00:00+00'
 ) ON CONFLICT (fisma_uuid) DO NOTHING;
 

--- a/backend/cmd/api/internal/controller/datacentermismatches.go
+++ b/backend/cmd/api/internal/controller/datacentermismatches.go
@@ -1,0 +1,44 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+)
+
+// ListDataCenterMismatches returns the wrong-data-center report (ztmf#239):
+// active systems whose CFACTS-reported data center environment (from the
+// system_enrichment payload) disagrees with the value recorded in ZTMF. This is
+// an admin-tier report: unscoped admins see every insights-enabled OpDiv,
+// OpDiv-scoped admins see their granted OpDivs (fail-closed), and ISSO/ISSM get
+// 403 - an ISSO-facing "report a difference" flow is tracked separately and is
+// deliberately not this endpoint.
+//
+//	@Summary	List systems whose CFACTS data center environment disagrees with ZTMF's
+//	@Tags		datacentermismatches
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Success	200	{object}	apiResponse[[]model.DataCenterMismatch]
+//	@Failure	403	{object}	apiResponse[any]
+//	@Failure	500	{object}	apiResponse[any]
+//	@Router		/datacentermismatches [get]
+func ListDataCenterMismatches(w http.ResponseWriter, r *http.Request) {
+	user := model.UserFromContext(r.Context())
+	in := model.FindDataCenterMismatchesInput{}
+
+	// Scope by tier: unscoped admins see all; OpDiv tiers fail-closed to their
+	// granted OpDivs' systems; ISSO/ISSM are not the report's audience -> 403.
+	switch {
+	case user.HasUnscopedRead():
+		// no scope filter
+	case user.IsOpDivTier():
+		in.RestrictToOpDivIDs = true
+		_, in.OpDivIDs = user.EffectiveOpDivScope()
+	default:
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	mismatches, err := model.FindDataCenterMismatches(r.Context(), in)
+	respond(w, r, mismatches, err)
+}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -108,6 +108,8 @@ func Handler() http.Handler {
 
 	router.HandleFunc("/api/v1/datacenterenvironments", controller.ListDataCenterEnvironments).Methods("GET")
 
+	router.HandleFunc("/api/v1/datacentermismatches", controller.ListDataCenterMismatches).Methods("GET")
+
 	router.HandleFunc("/api/v1/events", controller.GetEvents).Methods("GET")
 
 	router.HandleFunc("/api/v1/systemenrichment/{fisma_uuid:[a-zA-Z0-9-]+}", controller.GetSystemEnrichment).Methods("GET")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1686,6 +1686,62 @@ tests:
     expect:
       status: 404
 
+  # Wrong-data-center report (issue #239). Two rows at this point in the run:
+  #   - Shield Gen (1003, EMPIRE, active): the seeded mismatch (CFACTS
+  #     CMS-Cloud-AWS vs ZTMF Forest-Moon), cfacts_value_known TRUE.
+  #   - Executor (1002): seeded as MATCHING (Imperial-Fleet on both sides), but
+  #     the "preserve HHS data" PUT above (*system1002WithHHSData) flips the
+  #     system to "Other" mid-suite, so by now it reports - proving the report
+  #     tracks live system edits. The fresh-seed "matching row is excluded"
+  #     behavior is pinned by internal/model/datacentermismatches_integration_test.go.
+  # Still excluded here: the Death Star (1001) mismatches but is decommissioned,
+  # and RB-1 (1005) mismatches but REBELLION is not insights_enabled (gated).
+  - url: http://localhost:8080/api/v1/datacentermismatches
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - fismasystemid: 1003
+              fismaacronym: "SLD-GEN"
+              datacenterenvironment: "Forest-Moon"
+              cfacts_datacenterenvironment: "CMS-Cloud-AWS"
+              cfacts_value_known: true
+            - fismasystemid: 1002
+              fismaacronym: "SSD-EX"
+              datacenterenvironment: "Other"
+              cfacts_datacenterenvironment: "Imperial-Fleet"
+              cfacts_value_known: true
+
+  # The report is admin-tier only: ISSO/ISSM get 403 (the ISSO-facing
+  # "report a difference" flow is a separate ticket, not this endpoint).
+  - url: http://localhost:8080/api/v1/datacentermismatches
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 403
+
+  # HHS_READONLY_ADMIN has unscoped read, so the report returns for it too.
+  - url: http://localhost:8080/api/v1/datacentermismatches
+    method: GET
+    headers:
+      <<: *readonlyAdminHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - fismasystemid: 1003
+            - fismasystemid: 1002
+
   # ZTMF Insights (issue #416). /insights is a LIST endpoint: scope and the
   # OpDiv gate yield an empty array (200), never 403/404. Array bodies assert
   # since aquia-inc/emberfall#36 closed, but only the scalar key columns are

--- a/backend/internal/model/datacentermismatches.go
+++ b/backend/internal/model/datacentermismatches.go
@@ -76,7 +76,7 @@ func FindDataCenterMismatches(ctx context.Context, in FindDataCenterMismatchesIn
 		// fismasystems.fismauid isn't unique, so a plain JOIN to the PK-keyed
 		// enrichment row fans out to every sibling system, attributing one OpDiv's
 		// payload to another (cross-OpDiv leak). LATERAL ... LIMIT 1 collapses to
-		// one system per uuid (lowest id, like FindFismaSystemByUUID).
+		// one active system per uuid, picking the lowest fismasystemid.
 		JoinClause(`INNER JOIN LATERAL (
 			SELECT fs.fismasystemid, fs.fismaacronym, fs.fismaname,
 			       fs.datacenterenvironment, fs.opdiv_id

--- a/backend/internal/model/datacentermismatches.go
+++ b/backend/internal/model/datacentermismatches.go
@@ -33,9 +33,9 @@ type DataCenterMismatch struct {
 	// datacenterenvironments reference table. FALSE flags vocabulary drift:
 	// fixing the system would first require a new mapping row (ztmf#392), so
 	// those rows need different handling than a simple wrong value.
-	CFACTSValueKnown bool       `json:"cfacts_value_known" db:"cfacts_value_known"`
-	OpDivID          *int32     `json:"opdiv_id" db:"opdiv_id"`
-	SyncedAt         time.Time  `json:"synced_at" db:"synced_at"`
+	CFACTSValueKnown bool      `json:"cfacts_value_known" db:"cfacts_value_known"`
+	OpDivID          *int32    `json:"opdiv_id" db:"opdiv_id"`
+	SyncedAt         time.Time `json:"synced_at" db:"synced_at"`
 }
 
 // FindDataCenterMismatchesInput scopes the report. OpDivIDs /
@@ -73,13 +73,24 @@ func FindDataCenterMismatches(ctx context.Context, in FindDataCenterMismatchesIn
 			"se.synced_at",
 		).
 		From("system_enrichment se").
-		InnerJoin("fismasystems fs ON LOWER(fs.fismauid) = LOWER(se.fisma_uuid)").
+		// fismasystems.fismauid isn't unique, so a plain JOIN to the PK-keyed
+		// enrichment row fans out to every sibling system, attributing one OpDiv's
+		// payload to another (cross-OpDiv leak). LATERAL ... LIMIT 1 collapses to
+		// one system per uuid (lowest id, like FindFismaSystemByUUID).
+		JoinClause(`INNER JOIN LATERAL (
+			SELECT fs.fismasystemid, fs.fismaacronym, fs.fismaname,
+			       fs.datacenterenvironment, fs.opdiv_id
+			FROM fismasystems fs
+			WHERE LOWER(fs.fismauid) = LOWER(se.fisma_uuid)
+			  AND fs.decommissioned = FALSE
+			ORDER BY fs.fismasystemid
+			LIMIT 1
+		) fs ON TRUE`).
 		InnerJoin("opdivs o ON o.opdiv_id = fs.opdiv_id AND o.insights_enabled = TRUE").
-		Where("fs.decommissioned = FALSE").
-		Where("NULLIF(" + cfactsDC + ", '') IS NOT NULL").
+		Where("NULLIF("+cfactsDC+", '') IS NOT NULL").
 		// IS DISTINCT FROM (not <>) so a NULL ZTMF value still reports: CFACTS
 		// holding a value ZTMF lacks is a mismatch, not a non-comparison.
-		Where("LOWER(" + cfactsDC + ") IS DISTINCT FROM LOWER(TRIM(fs.datacenterenvironment))").
+		Where("LOWER("+cfactsDC+") IS DISTINCT FROM LOWER(TRIM(fs.datacenterenvironment))").
 		OrderBy("fs.fismaacronym", "fs.fismasystemid")
 
 	// OpDiv-scoped admin tiers (fail-closed): restrict to systems in the admin's

--- a/backend/internal/model/datacentermismatches.go
+++ b/backend/internal/model/datacentermismatches.go
@@ -1,0 +1,95 @@
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// enrichmentDataCenterKey is the system_enrichment payload key under which the
+// ztmf-insights pipeline reports the CFACTS data center environment. The
+// payload is otherwise opaque to ztmf core; this key is the single point of
+// coupling for the wrong-data-center report (ztmf#239). Provisional until the
+// pipeline ships the field, so a rename is a one-constant change.
+const enrichmentDataCenterKey = "data_center_environment"
+
+// DataCenterMismatch is one row of the wrong-data-center report (ztmf#239): an
+// active FISMA system in an insights-enabled OpDiv whose CFACTS-reported data
+// center environment disagrees (case-insensitively, ignoring surrounding
+// whitespace) with the value recorded on the system.
+type DataCenterMismatch struct {
+	FismaSystemID int32  `json:"fismasystemid" db:"fismasystemid"`
+	FismaAcronym  string `json:"fismaacronym" db:"fismaacronym"`
+	FismaName     string `json:"fismaname" db:"fismaname"`
+	// DataCenterEnvironment is ZTMF's own (self-reported) value. NULL when the
+	// system has none recorded; that still counts as a mismatch, since CFACTS
+	// reporting a value ZTMF lacks is drift worth surfacing.
+	DataCenterEnvironment *string `json:"datacenterenvironment" db:"datacenterenvironment"`
+	// CFACTSDataCenterEnvironment is the pipeline-reported value, trimmed but
+	// otherwise verbatim so the report shows exactly what CFACTS holds.
+	CFACTSDataCenterEnvironment string `json:"cfacts_datacenterenvironment" db:"cfacts_datacenterenvironment"`
+	// CFACTSValueKnown reports whether the CFACTS value appears in the
+	// datacenterenvironments reference table. FALSE flags vocabulary drift:
+	// fixing the system would first require a new mapping row (ztmf#392), so
+	// those rows need different handling than a simple wrong value.
+	CFACTSValueKnown bool       `json:"cfacts_value_known" db:"cfacts_value_known"`
+	OpDivID          *int32     `json:"opdiv_id" db:"opdiv_id"`
+	SyncedAt         time.Time  `json:"synced_at" db:"synced_at"`
+}
+
+// FindDataCenterMismatchesInput scopes the report. OpDivIDs /
+// RestrictToOpDivIDs carry the auth'd user's access scope and are set by the
+// controller, never by the client, mirroring FindSystemInsightsInput.
+type FindDataCenterMismatchesInput struct {
+	// OpDiv scope for the per-OpDiv admin tiers. RestrictToOpDivIDs with an
+	// empty slice fails closed (no rows).
+	OpDivIDs           []int32
+	RestrictToOpDivIDs bool
+}
+
+// FindDataCenterMismatches returns active systems whose CFACTS-reported data
+// center environment disagrees with fismasystems.datacenterenvironment.
+// Decommissioned systems are excluded (their drift is expected), as are
+// enrichment rows without the data-center key (the pipeline has not shipped the
+// field for them yet), so the report is empty rather than wrong until the
+// upstream data lands. Visibility is gated on the owning OpDiv's
+// insights_enabled flag, same as the enrichment read itself.
+func FindDataCenterMismatches(ctx context.Context, in FindDataCenterMismatchesInput) ([]*DataCenterMismatch, error) {
+	// cfactsDC extracts and trims the pipeline-reported value. The key is a
+	// trusted compile-time constant (never user input), so inlining it is safe,
+	// mirroring existsIn's trusted-column approach.
+	cfactsDC := "TRIM(se.payload->>'" + enrichmentDataCenterKey + "')"
+
+	sqlb := stmntBuilder.
+		Select(
+			"fs.fismasystemid",
+			"fs.fismaacronym",
+			"fs.fismaname",
+			"fs.datacenterenvironment",
+			cfactsDC+" AS cfacts_datacenterenvironment",
+			"EXISTS(SELECT 1 FROM public.datacenterenvironments d WHERE LOWER(d.datacenterenvironment) = LOWER("+cfactsDC+")) AS cfacts_value_known",
+			"fs.opdiv_id",
+			"se.synced_at",
+		).
+		From("system_enrichment se").
+		InnerJoin("fismasystems fs ON LOWER(fs.fismauid) = LOWER(se.fisma_uuid)").
+		InnerJoin("opdivs o ON o.opdiv_id = fs.opdiv_id AND o.insights_enabled = TRUE").
+		Where("fs.decommissioned = FALSE").
+		Where("NULLIF(" + cfactsDC + ", '') IS NOT NULL").
+		// IS DISTINCT FROM (not <>) so a NULL ZTMF value still reports: CFACTS
+		// holding a value ZTMF lacks is a mismatch, not a non-comparison.
+		Where("LOWER(" + cfactsDC + ") IS DISTINCT FROM LOWER(TRIM(fs.datacenterenvironment))").
+		OrderBy("fs.fismaacronym", "fs.fismasystemid")
+
+	// OpDiv-scoped admin tiers (fail-closed): restrict to systems in the admin's
+	// granted OpDivs. Empty grants under RestrictToOpDivIDs -> no rows.
+	switch {
+	case in.RestrictToOpDivIDs && len(in.OpDivIDs) == 0:
+		sqlb = sqlb.Where("FALSE")
+	case len(in.OpDivIDs) > 0:
+		sqlb = sqlb.Where("fs.opdiv_id = ANY(?)", in.OpDivIDs)
+	}
+
+	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[DataCenterMismatch])
+}

--- a/backend/internal/model/datacentermismatches_integration_test.go
+++ b/backend/internal/model/datacentermismatches_integration_test.go
@@ -110,6 +110,27 @@ func TestFindDataCenterMismatchesIntegration(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, rows)
 	})
+
+	t.Run("DuplicateFismauidDoesNotFanOut", func(t *testing.T) {
+		// Two active systems sharing a fismauid + one (PK-keyed) enrichment row
+		// must yield ONE report row (lowest id), not one per system -- the fan-out
+		// that leaks one OpDiv's payload to another.
+		lowerID, higherID := insertDuplicateUUIDFixture(t, ctx, "ztmf239-dup-uid", "CMSDC")
+
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{})
+		require.NoError(t, err)
+
+		assert.NotNil(t, findMismatchBySystemID(rows, lowerID), "the lowest-fismasystemid sibling should be the single reported row")
+		assert.Nil(t, findMismatchBySystemID(rows, higherID), "the duplicate-fismauid sibling must not produce a second (phantom) row")
+
+		count := 0
+		for _, r := range rows {
+			if r.FismaSystemID == lowerID || r.FismaSystemID == higherID {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "a single enrichment row must not fan out across systems sharing a fismauid")
+	})
 }
 
 // insertTempMismatchFixture creates an active EMPIRE system (ztmfDCE may be ""
@@ -163,4 +184,50 @@ func findMismatchBySystemID(rows []*DataCenterMismatch, fsid int32) *DataCenterM
 		}
 	}
 	return nil
+}
+
+// insertDuplicateUUIDFixture stages the fan-out hazard: two active EMPIRE
+// systems sharing one fismauid + a single enrichment row whose CFACTS value
+// mismatches both. Returns the two fismasystemids ascending (lower = the one
+// the LATERAL's ORDER BY fismasystemid must pick). Self-cleaning.
+func insertDuplicateUUIDFixture(t *testing.T, ctx context.Context, uid, cfactsDCE string) (lowerID, higherID int32) {
+	t.Helper()
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	insertSystem := func(acronym, ztmfDCE string) int32 {
+		var fsid int32
+		err := conn.QueryRow(ctx, `
+			INSERT INTO fismasystems (fismauid, fismaacronym, fismaname, datacenterenvironment, opdiv_id)
+			VALUES ($1, $2, $3, $4, (SELECT opdiv_id FROM opdivs WHERE code = 'EMPIRE'))
+			RETURNING fismasystemid
+		`, uid, acronym, acronym+" dup-uuid fixture (ztmf#239)", ztmfDCE).Scan(&fsid)
+		require.NoError(t, err)
+		return fsid
+	}
+
+	// Inserted in order so the first gets the lower fismasystemid (SERIAL); both
+	// values mismatch cfactsDCE so both would report under a fan-out.
+	lowerID = insertSystem("ZTMF239-DUP-A", "Forest-Moon")
+	higherID = insertSystem("ZTMF239-DUP-B", "Endor-Orbit")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO system_enrichment (fisma_uuid, payload)
+		VALUES ($1, jsonb_build_object('data_center_environment', $2::text))
+	`, uid, cfactsDCE)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		c, err := db.Conn(context.Background())
+		if err != nil {
+			return
+		}
+		defer c.Release()
+		_, _ = c.Exec(context.Background(), `DELETE FROM system_enrichment WHERE fisma_uuid = $1`, uid)
+		_, _ = c.Exec(context.Background(), `DELETE FROM fismasystems WHERE fismasystemid = ANY($1)`, []int32{lowerID, higherID})
+	})
+
+	return lowerID, higherID
 }

--- a/backend/internal/model/datacentermismatches_integration_test.go
+++ b/backend/internal/model/datacentermismatches_integration_test.go
@@ -1,0 +1,166 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindDataCenterMismatchesIntegration exercises the wrong-data-center
+// report (ztmf#239) against the empire seed, which stages every filter:
+//   - Shield Gen (1003, EMPIRE, active): CFACTS 'CMS-Cloud-AWS' vs ZTMF
+//     'Forest-Moon' -> THE visible mismatch, cfacts_value_known = TRUE.
+//   - Executor (1002, EMPIRE, active): CFACTS agrees -> excluded.
+//   - Death Star (1001, EMPIRE): mismatch but decommissioned -> excluded.
+//   - RB-1 (1005, REBELLION): mismatch but REBELLION is not insights_enabled
+//     -> gated.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindDataCenterMismatchesIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+
+	t.Run("UnscopedSeesSeededMismatchOnly", func(t *testing.T) {
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{})
+		require.NoError(t, err)
+		require.Len(t, rows, 1, "expected exactly the Shield Gen row: Executor matches, Death Star is decommissioned, RB-1 is OpDiv-gated")
+
+		got := rows[0]
+		assert.Equal(t, int32(1003), got.FismaSystemID)
+		assert.Equal(t, "SLD-GEN", got.FismaAcronym)
+		if assert.NotNil(t, got.DataCenterEnvironment) {
+			assert.Equal(t, "Forest-Moon", *got.DataCenterEnvironment)
+		}
+		assert.Equal(t, "CMS-Cloud-AWS", got.CFACTSDataCenterEnvironment)
+		assert.True(t, got.CFACTSValueKnown, "CMS-Cloud-AWS is canonical vocabulary (migration 0045)")
+		assert.False(t, got.SyncedAt.IsZero())
+	})
+
+	t.Run("UnknownCFACTSValueIsFlagged", func(t *testing.T) {
+		// A CFACTS value outside the datacenterenvironments vocabulary must
+		// still report, with cfacts_value_known = FALSE (vocabulary drift needs
+		// a mapping row before the system value can even be corrected).
+		fsid := insertTempMismatchFixture(t, ctx, "ztmf239-unknown-uid", "ZTMF239-UNK", "Forest-Moon", "Endor-Orbit")
+
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{})
+		require.NoError(t, err)
+
+		got := findMismatchBySystemID(rows, fsid)
+		require.NotNil(t, got, "temp system with unknown CFACTS value should appear in the report")
+		assert.Equal(t, "Endor-Orbit", got.CFACTSDataCenterEnvironment)
+		assert.False(t, got.CFACTSValueKnown)
+	})
+
+	t.Run("CaseAndWhitespaceDifferencesAreNotMismatches", func(t *testing.T) {
+		// 'cms-cloud-aws' vs ' CMS-Cloud-AWS ' differs only in case and padding;
+		// the report must not flag it.
+		fsid := insertTempMismatchFixture(t, ctx, "ztmf239-case-uid", "ZTMF239-CASE", "cms-cloud-aws", " CMS-Cloud-AWS ")
+
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{})
+		require.NoError(t, err)
+		assert.Nil(t, findMismatchBySystemID(rows, fsid), "case/whitespace-only difference must not report as a mismatch")
+	})
+
+	t.Run("NullZTMFValueIsAMismatch", func(t *testing.T) {
+		// CFACTS holds a value but ZTMF has none recorded: drift worth surfacing.
+		fsid := insertTempMismatchFixture(t, ctx, "ztmf239-null-uid", "ZTMF239-NULL", "", "CMSDC")
+
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{})
+		require.NoError(t, err)
+
+		got := findMismatchBySystemID(rows, fsid)
+		require.NotNil(t, got, "NULL ZTMF value with a CFACTS value should appear in the report")
+		assert.Nil(t, got.DataCenterEnvironment)
+		assert.Equal(t, "CMSDC", got.CFACTSDataCenterEnvironment)
+	})
+
+	t.Run("OpDivScopeFailsClosed", func(t *testing.T) {
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{RestrictToOpDivIDs: true})
+		require.NoError(t, err)
+		assert.Empty(t, rows, "RestrictToOpDivIDs with zero grants must return no rows")
+	})
+
+	t.Run("OpDivScopeFilters", func(t *testing.T) {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Release()
+
+		var empireID, rebellionID int32
+		require.NoError(t, conn.QueryRow(ctx, `SELECT opdiv_id FROM opdivs WHERE code = 'EMPIRE'`).Scan(&empireID))
+		require.NoError(t, conn.QueryRow(ctx, `SELECT opdiv_id FROM opdivs WHERE code = 'REBELLION'`).Scan(&rebellionID))
+
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{RestrictToOpDivIDs: true, OpDivIDs: []int32{empireID}})
+		require.NoError(t, err)
+		require.NotEmpty(t, rows, "EMPIRE-scoped admin should see the Shield Gen mismatch")
+		for _, r := range rows {
+			if assert.NotNil(t, r.OpDivID) {
+				assert.Equal(t, empireID, *r.OpDivID)
+			}
+		}
+
+		// REBELLION grant alone yields nothing: its only mismatch row is behind
+		// the insights_enabled gate, which scope must not bypass.
+		rows, err = FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{RestrictToOpDivIDs: true, OpDivIDs: []int32{rebellionID}})
+		require.NoError(t, err)
+		assert.Empty(t, rows)
+	})
+}
+
+// insertTempMismatchFixture creates an active EMPIRE system (ztmfDCE may be ""
+// for NULL) with an enrichment row whose payload reports cfactsDCE, and
+// registers cleanup for both. Returns the new fismasystemid.
+func insertTempMismatchFixture(t *testing.T, ctx context.Context, uid, acronym, ztmfDCE, cfactsDCE string) int32 {
+	t.Helper()
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	var dce *string
+	if ztmfDCE != "" {
+		dce = &ztmfDCE
+	}
+
+	var fsid int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO fismasystems (fismauid, fismaacronym, fismaname, datacenterenvironment, opdiv_id)
+		VALUES ($1, $2, $3, $4, (SELECT opdiv_id FROM opdivs WHERE code = 'EMPIRE'))
+		RETURNING fismasystemid
+	`, uid, acronym, acronym+" temp fixture (ztmf#239)", dce).Scan(&fsid)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO system_enrichment (fisma_uuid, payload)
+		VALUES ($1, jsonb_build_object('fisma_acronym', $2::text, 'data_center_environment', $3::text))
+	`, uid, acronym, cfactsDCE)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		// Fresh connection: the test body's `defer conn.Release()` runs before
+		// t.Cleanup, so the original conn is already back in the pool here.
+		c, err := db.Conn(context.Background())
+		if err != nil {
+			return
+		}
+		defer c.Release()
+		_, _ = c.Exec(context.Background(), `DELETE FROM system_enrichment WHERE fisma_uuid = $1`, uid)
+		_, _ = c.Exec(context.Background(), `DELETE FROM fismasystems WHERE fismasystemid = $1`, fsid)
+	})
+
+	return fsid
+}
+
+func findMismatchBySystemID(rows []*DataCenterMismatch, fsid int32) *DataCenterMismatch {
+	for _, r := range rows {
+		if r.FismaSystemID == fsid {
+			return r
+		}
+	}
+	return nil
+}

--- a/backend/internal/model/datacentermismatches_test.go
+++ b/backend/internal/model/datacentermismatches_test.go
@@ -1,0 +1,58 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDataCenterMismatch_JSONShape pins the response contract the UI and the
+// emberfall suite assert against: snake_case keys, the CFACTS value under
+// cfacts_datacenterenvironment, and the vocabulary flag under
+// cfacts_value_known.
+func TestDataCenterMismatch_JSONShape(t *testing.T) {
+	dce := "Forest-Moon"
+	opdiv := int32(1)
+	m := DataCenterMismatch{
+		FismaSystemID:               1003,
+		FismaAcronym:                "SLD-GEN",
+		FismaName:                   "Shield Generator Control Network",
+		DataCenterEnvironment:       &dce,
+		CFACTSDataCenterEnvironment: "CMS-Cloud-AWS",
+		CFACTSValueKnown:            true,
+		OpDivID:                     &opdiv,
+		SyncedAt:                    time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC),
+	}
+
+	out, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"fismasystemid": 1003,
+		"fismaacronym": "SLD-GEN",
+		"fismaname": "Shield Generator Control Network",
+		"datacenterenvironment": "Forest-Moon",
+		"cfacts_datacenterenvironment": "CMS-Cloud-AWS",
+		"cfacts_value_known": true,
+		"opdiv_id": 1,
+		"synced_at": "2026-05-20T00:00:00Z"
+	}`, string(out))
+}
+
+// TestDataCenterMismatch_NullZTMFValue pins that a system with no recorded
+// datacenterenvironment serializes it as null rather than "" - the report
+// treats "CFACTS has a value ZTMF lacks" as a mismatch, and the UI needs to
+// distinguish that from an empty string.
+func TestDataCenterMismatch_NullZTMFValue(t *testing.T) {
+	m := DataCenterMismatch{
+		FismaSystemID:               1,
+		FismaAcronym:                "X",
+		FismaName:                   "X",
+		CFACTSDataCenterEnvironment: "CMSDC",
+	}
+
+	out, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), `"datacenterenvironment":null`)
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -55,6 +55,16 @@ components:
         error:
           type: string
       type: object
+    controller.apiResponse-array_model_DataCenterMismatch:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/model.DataCenterMismatch'
+          type: array
+          uniqueItems: false
+        error:
+          type: string
+      type: object
     controller.apiResponse-array_model_Event:
       properties:
         data:
@@ -313,6 +323,37 @@ components:
           type: string
         selectable:
           type: boolean
+      type: object
+    model.DataCenterMismatch:
+      properties:
+        cfacts_datacenterenvironment:
+          description: |-
+            CFACTSDataCenterEnvironment is the pipeline-reported value, trimmed but
+            otherwise verbatim so the report shows exactly what CFACTS holds.
+          type: string
+        cfacts_value_known:
+          description: |-
+            CFACTSValueKnown reports whether the CFACTS value appears in the
+            datacenterenvironments reference table. FALSE flags vocabulary drift:
+            fixing the system would first require a new mapping row (ztmf#392), so
+            those rows need different handling than a simple wrong value.
+          type: boolean
+        datacenterenvironment:
+          description: |-
+            DataCenterEnvironment is ZTMF's own (self-reported) value. NULL when the
+            system has none recorded; that still counts as a mismatch, since CFACTS
+            reporting a value ZTMF lacks is drift worth surfacing.
+          type: string
+        fismaacronym:
+          type: string
+        fismaname:
+          type: string
+        fismasystemid:
+          type: integer
+        opdiv_id:
+          type: integer
+        synced_at:
+          type: string
       type: object
     model.Event:
       properties:
@@ -1057,6 +1098,32 @@ paths:
       summary: List datacenterenvironment mappings
       tags:
       - datacenterenvironments
+  /datacentermismatches:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-array_model_DataCenterMismatch'
+          description: OK
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: List systems whose CFACTS data center environment disagrees with ZTMF's
+      tags:
+      - datacentermismatches
   /events:
     get:
       parameters:


### PR DESCRIPTION
> **Note:** In-repo copy of #452 by @voidspooks, moved from the fork so Snyk and the deploy CI gates can run (those require org secrets unavailable to fork PRs). Commits and authorship are unchanged.
>
> Refs #452

---

## Summary

Adds `GET /api/v1/datacentermismatches` — an admin report of systems whose CFACTS-reported data center environment (the `data_center_environment` enrichment key) disagrees with the system's own recorded `datacenterenvironment`. The comparison is trim + case-insensitive; it excludes decommissioned systems and OpDivs without `insights_enabled`, and RBAC mirrors `/insights` (admin-tier only, fail-closed OpDiv scoping, ISSO/ISSM → 403). Companion to the frontend chip in ztmf-ui#590. Part of #239.
