### PR TITLE
fix(#393): order a system's completed data calls by deadline

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -164,8 +164,9 @@ INSERT INTO public.pillars VALUES (5, 'CrossCutting', 0) ON CONFLICT DO NOTHING;
 INSERT INTO public.pillars VALUES (6, 'Identity', 0) ON CONFLICT DO NOTHING;
 
 -- Test DataCalls (Imperial Audits)
--- IDs are intentionally ordered chronologically so FindLatestDataCall
--- (ORDER BY datacallid DESC) returns the open Audit cycle as current.
+-- Current/latest resolves by deadline (ORDER BY deadline DESC, datacallid DESC
+-- as tiebreak; #393), so the open Audit cycle below wins via its far-future
+-- deadline. IDs stay chronological for readability only.
 INSERT INTO public.datacalls VALUES (1, 'FY2022 Imperial Security Review', '2022-01-01T00:00:00Z', '2022-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
 INSERT INTO public.datacalls VALUES (2, 'FY2023 Imperial Security Review', '2023-01-01T00:00:00Z', '2023-12-31T23:59:59Z') ON CONFLICT DO NOTHING;
 INSERT INTO public.datacalls VALUES (3, 'FY2024 Imperial Security Review', '2024-01-01T00:00:00Z', '2024-12-31T23:59:59Z') ON CONFLICT DO NOTHING;

--- a/backend/internal/model/datacallsfismasystems.go
+++ b/backend/internal/model/datacallsfismasystems.go
@@ -54,7 +54,11 @@ func FindFismaSystemDataCalls(ctx context.Context, fismasystemID int32) ([]*Data
 		From("datacalls dc").
 		InnerJoin("datacalls_fismasystems dcfs ON dc.datacallid = dcfs.datacallid").
 		Where("dcfs.fismasystemid = ?", fismasystemID).
-		OrderBy("dc.datecreated DESC")
+		// Deadline ordering (datacallid as tiebreak) to match FindDataCalls /
+		// FindLatestDataCall (#393): a backfilled historical call carries a
+		// recent datecreated, so datecreated ordering would sort it above the
+		// real current cycle.
+		OrderBy("dc.deadline DESC", "dc.datacallid DESC")
 
 	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[DataCall])
 }

--- a/backend/internal/model/datacallsfismasystems_integration_test.go
+++ b/backend/internal/model/datacallsfismasystems_integration_test.go
@@ -1,0 +1,83 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindFismaSystemDataCallsOrderIntegration pins the #393 sibling cleanup
+// flagged in the #397 review: a system's completed-datacalls list must order by
+// deadline, not datecreated. A backfilled historical call is INSERTed at import
+// time, so its datecreated is recent even though its deadline is long past -
+// under datecreated ordering it would sort above the real current cycle.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindFismaSystemDataCallsOrderIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	suffix := time.Now().UnixNano()
+	const systemID = int32(1001) // Death Star: stable empire-seed system with existing junction rows
+
+	// The "current" cycle: created a while ago, deadline far out (beats the
+	// empire seed's furthest-out 2099 cycle so it must sort first overall).
+	var currentID int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW() - INTERVAL '30 days', '2102-01-01T00:00:00Z'::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%scurrent_%d", integrationTestPrefix, suffix)).Scan(&currentID)
+	require.NoError(t, err)
+
+	// The backfilled historical cycle: created just now (as an import would
+	// be), deadline long past. Under the old datecreated ordering this row
+	// wrongly sorts to the top of the system's list.
+	var backfilledID int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW(), '2019-12-31T23:59:59Z'::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%sbackfilled_%d", integrationTestPrefix, suffix)).Scan(&backfilledID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO datacalls_fismasystems (datacallid, fismasystemid)
+		VALUES ($1, $3), ($2, $3) ON CONFLICT DO NOTHING
+	`, currentID, backfilledID, systemID)
+	require.NoError(t, err)
+
+	dataCalls, err := FindFismaSystemDataCalls(ctx, systemID)
+	require.NoError(t, err)
+	require.NotEmpty(t, dataCalls)
+
+	// The far-future current cycle leads the list; the freshly-created
+	// backfilled cycle must NOT ride its datecreated to the top.
+	assert.Equal(t, currentID, dataCalls[0].DataCallID,
+		"the furthest-out deadline must sort first, regardless of datecreated")
+
+	// And the whole list is non-increasing by deadline, so the backfilled
+	// row sits in its chronological place at the bottom, not merely "not first".
+	for i := 1; i < len(dataCalls); i++ {
+		assert.False(t, dataCalls[i].Deadline.After(dataCalls[i-1].Deadline),
+			"deadlines must be non-increasing: position %d (%s) sorts after position %d (%s)",
+			i, dataCalls[i].DataCall, i-1, dataCalls[i-1].DataCall)
+	}
+	assert.Equal(t, backfilledID, dataCalls[len(dataCalls)-1].DataCallID,
+		"the 2019-deadline backfill must sort last despite the newest datecreated")
+}


### PR DESCRIPTION
## Summary

Follow-up cleanup from the #397 review (note 2 in the review comment on #393): `FindFismaSystemDataCalls`, behind `GET /fismasystems/{id}/datacalls`, still ordered by `datecreated DESC`, the pre-#393 pattern. A backfilled historical call is inserted at import time, so its `datecreated` is recent even though its deadline is long past, and it would sort to the top of a system's completed-calls list once historical loads land. Now ordered by `deadline DESC, datacallid DESC`, matching the three finders #397 already converted (and `findPreviousDataCall` semantics from #450).

Also fixes the stale seed comment in `_test_data_empire.sql` that still described the old `ORDER BY datacallid DESC` behavior (note 3 from the same review).

Display-only ordering change, no API shape change, no frontend change needed.

## Testing

- New `TestFindFismaSystemDataCallsOrderIntegration`: plants a current cycle (created 30 days ago, deadline 2102) and a backfilled cycle (created now, deadline 2019) on a seed system, asserts the current cycle sorts first, the list is non-increasing by deadline, and the backfill sorts last. Mutation-checked: the test fails under the old `datecreated` ordering.
- `make test-unit`, `make test-integration`, and `make test-e2e` (155/155) all green locally.

Snyk and other secret-dependent checks will show red as usual for fork PRs (no repo secrets).