### PR TITLE
adds guard on what systems a user can be assigned based on their opdivs

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -133,7 +133,12 @@ SELECT u.userid, (SELECT opdiv_id FROM public.opdivs WHERE code = 'EMPIRE')
         'Emperor.Palpatine@coruscant.empire',
         'Captain.Needa@executor.empire',
         'Opdiv.Admin@empire.test',
-        'Opdiv.Readonly@empire.test'
+        'Opdiv.Readonly@empire.test',
+        -- Thrawn is the assignment-test fixture. Since #449 an assignment write
+        -- rejects any system whose OpDiv the target does not hold (fail closed:
+        -- no OpDiv grant -> no assignable systems), so a properly-provisioned
+        -- ISSO must hold an OpDiv before systems can be assigned to them.
+        'Grand.Admiral.Thrawn@chiss.empire'
        )
 ON CONFLICT DO NOTHING;
 

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -450,6 +450,26 @@ func TestListUserFismaSystems_ISSOForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// --- ListAssignableFismaSystems ---
+
+func TestListAssignableFismaSystems_ReadonlyAdminAllowed(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/v1/users/11111111-1111-1111-1111-111111111111/assignablefismasystems", nil)
+	r = withUser(r, readonlyAdmin)
+	w := httptest.NewRecorder()
+
+	ListAssignableFismaSystems(w, r)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}
+
+func TestListAssignableFismaSystems_ISSOForbidden(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/v1/users/11111111-1111-1111-1111-111111111111/assignablefismasystems", nil)
+	r = withUser(r, issoUser)
+	w := httptest.NewRecorder()
+
+	ListAssignableFismaSystems(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 // --- CreateUserFismaSystem ---
 
 func TestCreateUserFismaSystem_ReadonlyAdminForbidden(t *testing.T) {

--- a/backend/cmd/api/internal/controller/usersfismasystems.go
+++ b/backend/cmd/api/internal/controller/usersfismasystems.go
@@ -38,6 +38,73 @@ func ListUserFismaSystems(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, fismasystemids, err)
 }
 
+//	@Summary	List the FISMA systems assignable to a user
+//	@Description	Systems that may be assigned to the target user: those in the target's OpDivs, intersected with the caller's own OpDivs when the caller is OpDiv-scoped.
+//	@Tags		users
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		userid	path	string	true	"User ID"
+//	@Success	200	{object}	apiResponse[[]model.FismaSystem]
+//	@Failure	403	{object}	apiResponse[any]
+//	@Failure	404	{object}	apiResponse[any]
+//	@Failure	500	{object}	apiResponse[any]
+//	@Router		/users/{userid}/assignablefismasystems [get]
+func ListAssignableFismaSystems(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.HasAdminRead() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	vars := mux.Vars(r)
+	userID, ok := vars["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	target, err := model.FindUserByID(r.Context(), userID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+	// An OpDiv-scoped caller may only read a user they share an OpDiv with, same
+	// gate the per-user OpDiv endpoints use (usersopdivs.go). A target with no
+	// grants yet stays readable so provisioning is not blocked; unscoped admins
+	// read anyone.
+	if !authdUser.HasUnscopedRead() && len(target.AssignedOpDivIDs) > 0 && !sharesOpDiv(authdUser, target) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	// Assignable = systems in the target user's OpDivs. RestrictToOpDivIDs is set
+	// unconditionally so a target with no OpDiv grants fails closed (no rows)
+	// rather than falling through to an unscoped read - mirroring the write guard,
+	// which rejects any system whose OpDiv the target does not hold (#449).
+	input := model.FindFismaSystemsInput{RestrictToOpDivIDs: true}
+	for _, id := range target.AssignedOpDivIDs {
+		if id != nil {
+			input.OpDivIDs = append(input.OpDivIDs, *id)
+		}
+	}
+	// An OpDiv-scoped caller can only write systems in their own OpDivs, so narrow
+	// the picker to the intersection - it should never offer a system the caller
+	// could not actually assign.
+	if authdUser.IsOpDivTier() {
+		var scoped []int32
+		for _, id := range input.OpDivIDs {
+			if authdUser.IsAssignedOpDiv(id) {
+				scoped = append(scoped, id)
+			}
+		}
+		input.OpDivIDs = scoped
+	}
+
+	fismasystems, err := model.FindFismaSystems(r.Context(), input)
+
+	respond(w, r, fismasystems, err)
+}
+
 //	@Summary	Assign a FISMA system to a user
 //	@Tags		users
 //	@Accept		json
@@ -75,11 +142,16 @@ func CreateUserFismaSystem(w http.ResponseWriter, r *http.Request) {
 		respond(w, r, nil, ErrMalformed)
 		return
 	}
+	// The path userid is authoritative. Re-pin it after decoding so a body that
+	// carries its own "userid" cannot retarget the write to a user other than
+	// the one the guards below validate (that would reopen the #449 gap).
+	uf.UserID = userID
 
 	// OpDiv write-scope: the acting admin may only assign a system they manage
 	// to a user they manage. OWNER/HHS_ADMIN pass both; an OPDIV_ADMIN must hold
 	// the system's OpDiv and share an OpDiv with the target user.
-	if _, gerr := guardManageFismaSystem(r.Context(), authdUser, uf.FismaSystemID); gerr != nil {
+	sys, gerr := guardManageFismaSystem(r.Context(), authdUser, uf.FismaSystemID)
+	if gerr != nil {
 		respond(w, r, nil, gerr)
 		return
 	}
@@ -89,6 +161,14 @@ func CreateUserFismaSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !authdUser.CanManageUser(target) {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+	// #449: the system's OpDiv must be one the TARGET user belongs to, regardless
+	// of the acting admin's tier. Fail closed on a target with no matching grant -
+	// an unscoped admin (OWNER/HHS_ADMIN) passes the guards above for every OpDiv,
+	// so without this they could assign a system outside the user's OpDiv.
+	if !target.CanBeAssignedFismaSystem(sys.OpDivID) {
 		respond(w, r, nil, ErrForbidden)
 		return
 	}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -80,6 +80,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}", controller.DeleteUser).Methods("DELETE")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/restore", controller.RestoreUser).Methods("PUT")
 
+	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignablefismasystems", controller.ListAssignableFismaSystems).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems", controller.ListUserFismaSystems).Methods("GET")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems", controller.CreateUserFismaSystem).Methods("POST")
 	router.HandleFunc("/api/v1/users/{userid:"+userIdPattern+"}/assignedfismasystems/{fismasystemid:[0-9]+}", controller.DeleteUserFismaSystem).Methods("DELETE")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1424,6 +1424,70 @@ tests:
     expect:
       status: 200
 
+  # ---- #449: the assignment write must not grant a system whose OpDiv the
+  # target user does not hold, regardless of the acting admin's tier, and the
+  # path userid is authoritative over any userid in the request body. ----
+
+  # OWNER (unscoped) assigning a REBELLION system (1005) to Thrawn, who holds
+  # EMPIRE only, is rejected. Before #449 both admin-side guards
+  # (guardManageFismaSystem + CanManageUser) passed for an unscoped admin and
+  # the cross-OpDiv row was written (201); now the target-OpDiv check blocks it.
+  - url: "http://localhost:8080/api/v1/users/aa000088-8888-4888-8888-888888888888/assignedfismasystems"
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1005
+    expect:
+      status: 403
+
+  # Path userid wins over a body userid. Assigning an in-OpDiv system (1003)
+  # with a different "userid" in the body still writes to the path user
+  # (Thrawn) - a body override was the way to reopen the #449 gap by validating
+  # one user and persisting another. The body value here is a DIFFERENT real,
+  # valid-v4 user (Opdiv.Admin, 88888888-...), so pre-fix Save would have
+  # succeeded and persisted the row to that user (201 with their userid); the
+  # assertion data.userid == the path user therefore proves the retarget is
+  # blocked, not merely that a malformed id was rejected.
+  - url: "http://localhost:8080/api/v1/users/aa000088-8888-4888-8888-888888888888/assignedfismasystems"
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1003
+        userid: "88888888-8888-4888-8888-888888888888"
+    expect:
+      status: 201
+      body:
+        json:
+          data:
+            userid: "aa000088-8888-4888-8888-888888888888"
+            fismasystemid: 1003
+
+  # Clean up the assignment written by the body-override case.
+  - url: "http://localhost:8080/api/v1/users/aa000088-8888-4888-8888-888888888888/assignedfismasystems/1003"
+    method: DELETE
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+
+  # #449 read endpoint: the assignable-systems picker returns 200 for an
+  # unscoped admin. The scoped-caller intersection and the sharesOpDiv target
+  # gate are covered by the controller/model tests.
+  - url: "http://localhost:8080/api/v1/users/aa000088-8888-4888-8888-888888888888/assignablefismasystems"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
   # PUT returns 204 (No Content) per controller.respond; assert the write
   # path completes cleanly. Audit-on-write is covered by the POST assertion
   # above.

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -154,6 +154,15 @@ func (u *User) CanManageFismaSystem(opdivID *int32) bool {
 	return opdivID != nil && u.IsAssignedOpDiv(*opdivID)
 }
 
+// CanBeAssignedFismaSystem reports whether a system in the given OpDiv may be
+// assigned to this (target) user: the system's OpDiv must be one the user holds
+// a grant for. Fail closed - a nil OpDiv or a user with no grants can hold no
+// system. Independent of the acting admin's tier; this closes the OWNER/HHS_ADMIN
+// cross-OpDiv gap in the assignment write (#449).
+func (u *User) CanBeAssignedFismaSystem(opdivID *int32) bool {
+	return opdivID != nil && u.IsAssignedOpDiv(*opdivID)
+}
+
 // CanAssignRole reports whether this user may assign the given role to another
 // user. Prevents tier escalation: an OPDIV_ADMIN can only mint roles at or below
 // the OpDiv tier, an HHS_ADMIN can mint anything except the platform OWNER tier,

--- a/backend/internal/model/users_test.go
+++ b/backend/internal/model/users_test.go
@@ -73,6 +73,26 @@ func TestUser_IsAssignedOpDiv(t *testing.T) {
 	assert.False(t, empty.IsAssignedOpDiv(1))
 }
 
+func TestUser_CanBeAssignedFismaSystem(t *testing.T) {
+	id1, id2 := int32(1), int32(2)
+	target := &User{AssignedOpDivIDs: []*int32{&id1, &id2}}
+
+	// System's OpDiv is one the target holds a grant for.
+	assert.True(t, target.CanBeAssignedFismaSystem(&id1))
+	assert.True(t, target.CanBeAssignedFismaSystem(&id2))
+
+	// System's OpDiv is not in the target's set.
+	other := int32(3)
+	assert.False(t, target.CanBeAssignedFismaSystem(&other))
+
+	// Fail closed on a nil OpDiv (system without an OpDiv should never be assigned).
+	assert.False(t, target.CanBeAssignedFismaSystem(nil))
+
+	// Fail closed on a target with no OpDiv grants (e.g. a not-yet-provisioned user).
+	empty := &User{}
+	assert.False(t, empty.CanBeAssignedFismaSystem(&id1))
+}
+
 func TestUser_CanAccessFismaSystem(t *testing.T) {
 	opdivCMS := int32(2)
 	opdivCDC := int32(3)


### PR DESCRIPTION
## Summary

Closes #449 — an unscoped admin (`OWNER`/`HHS_ADMIN`) could assign a FISMA system to a user in a **different OpDiv** (e.g. an FDA system to a CMS user). The assignment write validated the acting admin's authority over the system and the user, but never checked that the system's OpDiv is one the **target user** actually belongs to.

## Root cause

`CreateUserFismaSystem` enforced two checks on the acting admin — `guardManageFismaSystem` (admin manages the system's OpDiv) and `CanManageUser` (admin shares an OpDiv with the target). For an `OPDIV_ADMIN` these are always the same OpDiv, so the gap was masked. But an unscoped admin passes both for *every* OpDiv, so a cross-OpDiv assignment slipped through and the user gained access to a system outside their OpDiv.

## Changes

**Write enforcement (the fix)**
- New `User.CanBeAssignedFismaSystem(opdivID)` — reports whether a system in the given OpDiv may be assigned to this (target) user. Fail-closed: a nil OpDiv or a user with no OpDiv grants can hold no system.
- `CreateUserFismaSystem` now rejects (403) unless the system's `opdiv_id` is in the target user's assigned OpDiv set, **regardless of the acting admin's tier**. `guardManageFismaSystem` already fetched the system, so it's reused (no extra query).
- **Hardened against body override:** the path `userid` is re-pinned after JSON decode, so a request body carrying its own `"userid"` cannot retarget the write to a user other than the one the guards validated (this would otherwise reopen the gap).
- `DeleteUserFismaSystem` is intentionally left unchanged so an admin can still remove a stray/legacy cross-OpDiv assignment.

**Scoped read endpoint for the picker**
- New `GET /users/{userid}/assignablefismasystems` — returns systems in the target user's OpDivs (resolved into `FindFismaSystemsInput.OpDivIDs` + `RestrictToOpDivIDs`), intersected with the caller's own OpDivs when the caller is OpDiv-scoped, so the picker never offers a system the caller couldn't actually assign. Gated with the same `sharesOpDiv` read check the other per-user endpoints use. Backs the paired UI issue (ztmf-ui#586); server-side enforcement stands on its own.

## Behavior notes

- Enforcement is **strict fail-closed**: a user with **no OpDiv grant** (e.g. a not-yet-provisioned ISSO/ISSM) can be assigned **no** systems. Provisioning must grant an OpDiv before assigning systems. This only affects the *create* path — existing assignments are untouched, so no one loses access.
- ⚠️ **Frontend impact:** the provisioning flow must grant the OpDiv *before* assigning systems, or it will get a `403`. Tracked in ztmf-ui#586.

## Testing

- **Unit** — `TestUser_CanBeAssignedFismaSystem` (in-set / out-of-set / nil OpDiv / zero-grant), plus controller gate tests for the new read endpoint.
- **E2E (Emberfall)** — added cases: cross-OpDiv assign → `403`, in-OpDiv assign → `201`, body-`userid` override ignored (asserts `data.userid` == path user, using a valid-v4 UUID of a different real user so it exercises the real retarget path), and the read endpoint → `200`.
- **Seed** — granted the assignment-test ISSO fixture (Thrawn) an EMPIRE OpDiv so it represents a properly-provisioned user under the new invariant. One additive line; the fixture is used only by the assignment tests.

Verification: `go build ./...`, `go vet ./...`, `go test -short ./...`, and `make test-e2e` (**159 passed, 0 failed**).

## Acceptance criteria

- [x] The assignment write rejects any system whose `opdiv_id` is not in the target user's assigned OpDiv set.
- [x] The existing `OPDIV_ADMIN` path is unchanged (already safe).
- [x] Scoped read endpoint for "systems assignable to user Y".
- [x] Server-side enforcement stands on its own; the UI picker is a convenience, not the only guard.
