### PR TITLE
Add System Delegate role for contractor/support-staff data-call access

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -94,6 +94,14 @@ INSERT INTO public.users (userid, email, fullname, role, identity_provider)
     VALUES ('66666666-6666-6666-6666-666666666666', 'Isso.User@nowhere.xyz', 'ISSO Test User', 'ISSO', 'okta')
     ON CONFLICT DO NOTHING;
 
+-- System Delegate fixture (#455): contractor/support-staff tier, system-scoped
+-- like ISSO but answers-only (barred from target maturity). Assigned to Death Star
+-- (1001), which is enrolled in the open Audit cycle so E2E can exercise score writes.
+-- v4-conforming UUID so it satisfies isValidUUID when used as a path param.
+INSERT INTO public.users (userid, email, fullname, role, identity_provider)
+    VALUES ('55555555-5555-4555-8555-555555555555', 'Delegate.User@nowhere.xyz', 'System Delegate Test User', 'SYSTEM_DELEGATE', 'okta')
+    ON CONFLICT DO NOTHING;
+
 -- Pre-deleted user fixture for RestoreUser tests.
 -- UUID is v4-conforming (4 at position 14, 8 at position 19) so it satisfies
 -- isValidUUID's strict regex when used as a path param.
@@ -322,6 +330,7 @@ INSERT INTO public.users_fismasystems VALUES ('22222222-2222-2222-2222-222222222
 INSERT INTO public.users_fismasystems VALUES ('33333333-3333-3333-3333-333333333333', 1001) ON CONFLICT DO NOTHING; -- Veers -> Death Star  
 INSERT INTO public.users_fismasystems VALUES ('44444444-4444-4444-4444-444444444444', 1003) ON CONFLICT DO NOTHING; -- Krennic -> Shield Gen
 INSERT INTO public.users_fismasystems VALUES ('66666666-6666-6666-6666-666666666666', 1003) ON CONFLICT DO NOTHING; -- Emberfall ISSO -> Shield Gen (for system_enrichment access E2E tests)
+INSERT INTO public.users_fismasystems VALUES ('55555555-5555-4555-8555-555555555555', 1001) ON CONFLICT DO NOTHING; -- System Delegate -> Death Star (answers-only E2E: score write allowed, target maturity 403)
 
 -- DataCall-System Assignments (Systems participating in audits)
 INSERT INTO public.datacalls_fismasystems VALUES (3, 1001) ON CONFLICT DO NOTHING; -- DS-1 in FY2024 review

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -265,6 +265,30 @@ func TestSaveFismaSystemTargetMaturity_ISSONotAssignedForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// A System Delegate assigned to the system is still forbidden from writing target
+// maturity (#455): it is answers-only, and target maturity is not an answer. This
+// asserts the carve-out fires on assignment, not merely the not-assigned path.
+func TestSaveFismaSystemTargetMaturity_SystemDelegateForbidden(t *testing.T) {
+	delegate := &model.User{
+		UserID:               "44444444-4444-4444-4444-444444444444",
+		Email:                "delegate@test.com",
+		Role:                 "SYSTEM_DELEGATE",
+		AssignedFismaSystems: []*int32{int32Ptr(1)},
+	}
+	body := jsonBody(t, map[string]any{
+		"target_maturity_tier":          "Advanced",
+		"target_maturity_justification": "should never write",
+	})
+	r := httptest.NewRequest("PUT", "/api/v1/fismasystems/1/target-maturity", body)
+	r.Header.Set("Content-Type", "application/json")
+	r = mux.SetURLVars(r, map[string]string{"fismasystemid": "1"})
+	r = withUser(r, delegate)
+	w := httptest.NewRecorder()
+
+	SaveFismaSystemTargetMaturity(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 // --- ListScores ---
 
 func TestListScores_ReadonlyAdminAllowed(t *testing.T) {

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -265,28 +265,55 @@ func TestSaveFismaSystemTargetMaturity_ISSONotAssignedForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
-// A System Delegate assigned to the system is still forbidden from writing target
-// maturity (#455): it is answers-only, and target maturity is not an answer. This
-// asserts the carve-out fires on assignment, not merely the not-assigned path.
-func TestSaveFismaSystemTargetMaturity_SystemDelegateForbidden(t *testing.T) {
+// TestSystemDelegate_ForbiddenNonAnswerSurfaces pins the delegate invariant
+// (#455): a delegate may reach nothing an ISSO can that is not a data-call
+// answer. The carve-out is enforced by explicit IsSystemDelegate() rejections
+// rather than a central guard, so this table is the loud tripwire - if a future
+// PR adds an ISSO/ISSM-writable non-answer surface without guarding it, add a row
+// here and it will fail until the guard is in place.
+//
+// The delegate is assigned to the target system on purpose: assignment must NOT
+// grant these surfaces, so a passing row proves the carve-out fires on the role,
+// not merely on a missing assignment.
+func TestSystemDelegate_ForbiddenNonAnswerSurfaces(t *testing.T) {
 	delegate := &model.User{
 		UserID:               "44444444-4444-4444-4444-444444444444",
 		Email:                "delegate@test.com",
 		Role:                 "SYSTEM_DELEGATE",
 		AssignedFismaSystems: []*int32{int32Ptr(1)},
 	}
-	body := jsonBody(t, map[string]any{
-		"target_maturity_tier":          "Advanced",
-		"target_maturity_justification": "should never write",
-	})
-	r := httptest.NewRequest("PUT", "/api/v1/fismasystems/1/target-maturity", body)
-	r.Header.Set("Content-Type", "application/json")
-	r = mux.SetURLVars(r, map[string]string{"fismasystemid": "1"})
-	r = withUser(r, delegate)
-	w := httptest.NewRecorder()
 
-	SaveFismaSystemTargetMaturity(w, r)
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		request func() *http.Request
+	}{
+		{
+			name:    "target maturity write",
+			handler: SaveFismaSystemTargetMaturity,
+			request: func() *http.Request {
+				body := jsonBody(t, map[string]any{
+					"target_maturity_tier":          "Advanced",
+					"target_maturity_justification": "should never write",
+				})
+				r := httptest.NewRequest("PUT", "/api/v1/fismasystems/1/target-maturity", body)
+				r.Header.Set("Content-Type", "application/json")
+				return mux.SetURLVars(r, map[string]string{"fismasystemid": "1"})
+			},
+		},
+		// Add a row when a new ISSO/ISSM-writable non-answer surface lands, and
+		// add the matching IsSystemDelegate() guard to its handler.
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := withUser(tc.request(), delegate)
+			w := httptest.NewRecorder()
+			tc.handler(w, r)
+			assert.Equal(t, http.StatusForbidden, w.Code,
+				"delegate must be forbidden from non-answer surface %q", tc.name)
+		})
+	}
 }
 
 // --- ListScores ---

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -276,9 +276,13 @@ func TestSaveFismaSystemTargetMaturity_ISSONotAssignedForbidden(t *testing.T) {
 // grant these surfaces, so a passing row proves the carve-out fires on the role,
 // not merely on a missing assignment.
 func TestSystemDelegate_ForbiddenNonAnswerSurfaces(t *testing.T) {
+	// Identity matches the SYSTEM_DELEGATE row in _test_data_empire.sql so the
+	// delegate is the same conceptual user across this unit test and the Emberfall
+	// E2E. (The value is inert here - this test never hits the DB - but a shared
+	// identity avoids the confusion of a mismatched or seed-colliding UUID.)
 	delegate := &model.User{
-		UserID:               "44444444-4444-4444-4444-444444444444",
-		Email:                "delegate@test.com",
+		UserID:               "55555555-5555-4555-8555-555555555555",
+		Email:                "Delegate.User@nowhere.xyz",
 		Role:                 "SYSTEM_DELEGATE",
 		AssignedFismaSystems: []*int32{int32Ptr(1)},
 	}

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -420,6 +420,13 @@ func SaveFismaSystemTargetMaturity(w http.ResponseWriter, r *http.Request) {
 		respond(w, r, nil, ErrForbidden)
 		return
 	}
+	// System Delegates are answers-only (#455): target maturity is the ISSO/ISSM
+	// risk assertion (#398), not a data-call answer, so it is off-limits to them
+	// even on a system they are assigned to.
+	if authdUser.IsSystemDelegate() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
 	if !authdUser.IsAdmin() && !authdUser.IsAssignedFismaSystem(fismaSystemID) {
 		respond(w, r, nil, ErrForbidden)
 		return

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -22,6 +22,12 @@ opDivAdminHeaders: &opDivAdminHeaders
 opDivReadonlyHeaders: &opDivReadonlyHeaders
   authorization: "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6Im9wZGl2LnJlYWRvbmx5QGVtcGlyZS50ZXN0In0.enezNI1lnuNFcXzcxZqm0CTalZfbOV40dolVjoFxnII"
 
+# System Delegate (#455): contractor/support-staff, system-scoped like ISSO but
+# answers-only. Assigned to Death Star (1001) only. Email claim
+# delegate.user@nowhere.xyz. Must 403 on target maturity even for 1001.
+delegateHeaders: &delegateHeaders
+  authorization: "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImRlbGVnYXRlLnVzZXJAbm93aGVyZS54eXoifQ.yo5KvkCAnmcBbTGRNQZEfnaE8uXSe8zfgmofOiaL_rU"
+
 # Data definitions using YAML anchors.
 # The deadline is intentionally far-future — beyond the empire seed's
 # furthest-out call (Audit Fields Smoke Cycle, 2099-12-31) — so this
@@ -2127,6 +2133,92 @@ tests:
       status: 200
       headers:
         content-type: "application/json"
+
+  # ==========================================================================
+  # System Delegate RBAC (#455)
+  # delegateHeaders is assigned to Death Star (1001) only. It behaves exactly
+  # like an ISSO EXCEPT it is barred from writing target maturity (answers-only).
+  # ==========================================================================
+
+  # Delegate can authenticate; role is distinguishable from ISSO in the response.
+  - url: http://localhost:8080/api/v1/users/current
+    method: GET
+    headers:
+      <<: *delegateHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            email: "Delegate.User@nowhere.xyz"
+            role: "SYSTEM_DELEGATE"
+
+  # Carve-out: delegate is FORBIDDEN from writing target maturity even on its
+  # assigned system (1001). This is the one behavioral difference from ISSO/ISSM.
+  - url: http://localhost:8080/api/v1/fismasystems/1001/target-maturity
+    method: PUT
+    headers:
+      <<: *delegateHeaders
+      content-type: "application/json"
+    body:
+      json:
+        target_maturity_tier: "Advanced"
+        target_maturity_justification: "delegate must never write this"
+    expect:
+      status: 403
+
+  # Delegate CAN read scores for its assigned system (1001).
+  - url: http://localhost:8080/api/v1/scores/aggregate?fismasystemid=1001&include_pillars=true
+    method: GET
+    headers:
+      <<: *delegateHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # Delegate reading an UNASSIGNED system (Shield Gen, 1003) gets empty data, not
+  # 403 - same system-scoped list behavior as ISSO.
+  - url: http://localhost:8080/api/v1/scores/aggregate?fismasystemid=1003&include_pillars=true
+    method: GET
+    headers:
+      <<: *delegateHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # Delegate is locked out of the admin surface: audit trail 403.
+  - url: http://localhost:8080/api/v1/events
+    method: GET
+    headers:
+      <<: *delegateHeaders
+    expect:
+      status: 403
+
+  # Delegate is locked out of user management: list 403.
+  - url: http://localhost:8080/api/v1/users
+    method: GET
+    headers:
+      <<: *delegateHeaders
+    expect:
+      status: 403
+
+  # Delegate cannot create users (write blocked).
+  - url: http://localhost:8080/api/v1/users
+    method: POST
+    headers:
+      <<: *delegateHeaders
+      content-type: "application/json"
+    body:
+      json:
+        email: "blocked@example.com"
+        fullname: "Blocked User"
+        role: "ISSO"
+    expect:
+      status: 403
 
   # ==========================================================================
   # OpDiv-scoped RBAC enforcement (feature/opdiv-rbac-enforcement)

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -2169,6 +2169,60 @@ tests:
     expect:
       status: 403
 
+  # Headline capability: delegate CAN write a data-call answer on its assigned
+  # system (1001, open Audit cycle 5). The role's whole reason to exist - a
+  # regression that neutered it (e.g. a stray IsSystemDelegate 403 copied into
+  # SaveScore) must fail here. Response echoes the delegate as the editor.
+  - url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *delegateHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1001
+        functionoptionid: 1
+        datacallid: 5
+        notes: "delegate audit answer - assigned system"
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            fismasystemid: 1001
+            functionoptionid: 1
+            last_edited_by:
+              email: "Delegate.User@nowhere.xyz"
+              role: "SYSTEM_DELEGATE"
+
+  # Delegate CANNOT mark a system it is NOT assigned to (Shield Gen 1003) complete.
+  # (The assigned-system mark-complete path is exercised by the ISSO/admin suites;
+  # re-marking an already-enrolled system is a 404 by the endpoint's INSERT ...
+  # ON CONFLICT DO NOTHING semantics, independent of role, so it is not asserted here.)
+  - url: http://localhost:8080/api/v1/datacalls/5/fismasystems/1003
+    method: PUT
+    headers:
+      <<: *delegateHeaders
+    expect:
+      status: 403
+
+  # Delegate CANNOT write an answer for an unassigned system (Shield Gen 1003).
+  - url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *delegateHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1003
+        functionoptionid: 1
+        datacallid: 5
+        notes: "delegate write to unassigned system - should be blocked"
+    expect:
+      status: 403
+
   # Delegate CAN read scores for its assigned system (1001).
   - url: http://localhost:8080/api/v1/scores/aggregate?fismasystemid=1001&include_pillars=true
     method: GET

--- a/backend/internal/model/massemails.go
+++ b/backend/internal/model/massemails.go
@@ -15,11 +15,12 @@ var (
 	// 1. we don't need to allocate memory (for the life of the process) for things that might not be used
 	// 2. placing all the stmntBuilder.Select()... statements here would read like a jumbled mess
 	massEmailGroups = map[string]func() squirrel.SelectBuilder{
-		"ISSO":  sqlForISSO,
-		"ISSM":  sqlForISSM,
-		"DCC":   sqlForDCC,
-		"ALL":   sqlForALL, // ISSO, ISSM, DCC; excludes every admin tier
-		"ADMIN": sqlForADMIN,
+		"ISSO":            sqlForISSO,
+		"ISSM":            sqlForISSM,
+		"SYSTEM_DELEGATE": sqlForSystemDelegate,
+		"DCC":             sqlForDCC,
+		"ALL":             sqlForALL, // ISSO, ISSM, SYSTEM_DELEGATE, DCC; excludes every admin tier
+		"ADMIN":           sqlForADMIN,
 	}
 )
 
@@ -170,6 +171,17 @@ func sqlForISSM() squirrel.SelectBuilder {
 		Where("role='ISSM'")
 }
 
+// sqlForSystemDelegate selects the contractor/support-staff delegates (#455).
+// Like ISSM, delegates are addressed purely by role from the users table (there
+// is no per-system delegate contact column on fismasystems). They do data-call
+// work, so admins need a way to reach the cohort directly and via ALL.
+func sqlForSystemDelegate() squirrel.SelectBuilder {
+	return stmntBuilder.
+		Select("email").
+		From("users").
+		Where("role='SYSTEM_DELEGATE'")
+}
+
 func sqlForDCC() squirrel.SelectBuilder {
 	return stmntBuilder.
 		Select("DISTINCT string_to_table(datacallcontact,';') AS email").
@@ -178,11 +190,12 @@ func sqlForDCC() squirrel.SelectBuilder {
 
 func sqlForALL() squirrel.SelectBuilder {
 	issm, _, _ := sqlForISSM().ToSql()
+	delegate, _, _ := sqlForSystemDelegate().ToSql()
 	dcc, _, _ := sqlForDCC().ToSql()
 	issoU, _, _ := sqlForISSOUsers().ToSql()
 	issoFs, _, _ := sqlForISSOFismaSystems().ToSql()
 
 	return stmntBuilder.
 		Select("DISTINCT email as email").
-		From(fmt.Sprintf("(%s UNION ALL %s UNION ALL %s UNION ALL %s)", issm, dcc, issoU, issoFs))
+		From(fmt.Sprintf("(%s UNION ALL %s UNION ALL %s UNION ALL %s UNION ALL %s)", issm, delegate, dcc, issoU, issoFs))
 }

--- a/backend/internal/model/massemails_integration_test.go
+++ b/backend/internal/model/massemails_integration_test.go
@@ -52,7 +52,7 @@ func TestMassEmailRecipientsSkipsNullIntegration(t *testing.T) {
 
 	// Every group whose recipient query touches a nullable column must now
 	// succeed rather than error on the NULL.
-	for _, group := range []string{"ISSO", "DCC", "ALL"} {
+	for _, group := range []string{"ISSO", "ISSM", "SYSTEM_DELEGATE", "DCC", "ALL"} {
 		t.Run(group, func(t *testing.T) {
 			m := &MassEmail{Group: group, Subject: "regression subject", Body: "regression body"}
 			recipients, err := m.Recipients(ctx)

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -105,6 +105,14 @@ func (u *User) HasAdminRead() bool {
 // and carrying none of the admin/OpDiv classifications - with one deliberate
 // carve-out: a delegate is barred from writing a system's target maturity (the
 // ISSO/ISSM risk assertion, #398), because that is not a data-call answer.
+//
+// Invariant: a delegate may reach nothing an ISSO can that is not a data-call
+// answer. That invariant is enforced by explicit IsSystemDelegate() rejections,
+// not a central guard, so it must be maintained by hand. Current carve-out site:
+//   - SaveFismaSystemTargetMaturity (controller/fismasystems.go)
+// If you add another ISSO/ISSM-writable surface that is not a data-call answer,
+// add the same guard there AND a row to TestSystemDelegate_ForbiddenNonAnswerSurfaces
+// (controller/authorization_test.go) so the invariant fails loudly when next touched.
 func (u *User) IsSystemDelegate() bool { return u.Role == "SYSTEM_DELEGATE" }
 
 // IsAssignedOpDiv reports whether the user has a grant in users_opdivs for

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -100,6 +100,13 @@ func (u *User) HasAdminRead() bool {
 	return u.IsAdmin() || u.IsReadOnlyAdmin()
 }
 
+// IsSystemDelegate reports the contractor/support-staff tier (#455). It is
+// system-scoped exactly like ISSO/ISSM - gated everywhere by IsAssignedFismaSystem
+// and carrying none of the admin/OpDiv classifications - with one deliberate
+// carve-out: a delegate is barred from writing a system's target maturity (the
+// ISSO/ISSM risk assertion, #398), because that is not a data-call answer.
+func (u *User) IsSystemDelegate() bool { return u.Role == "SYSTEM_DELEGATE" }
+
 // IsAssignedOpDiv reports whether the user has a grant in users_opdivs for
 // the given OpDiv id. Used in scope predicates that need to confirm an
 // OpDiv-scoped admin owns the resource they are touching.
@@ -166,7 +173,7 @@ func (u *User) CanAssignRole(role string) bool {
 		return role != "OWNER"
 	case "OPDIV_ADMIN":
 		switch role {
-		case "OPDIV_ADMIN", "OPDIV_READONLY_ADMIN", "ISSO", "ISSM":
+		case "OPDIV_ADMIN", "OPDIV_READONLY_ADMIN", "ISSO", "ISSM", "SYSTEM_DELEGATE":
 			return true
 		}
 	}

--- a/backend/internal/model/users_test.go
+++ b/backend/internal/model/users_test.go
@@ -35,6 +35,9 @@ var roleMatrix = []roleMatrixRow{
 	// System-scoped tiers (unchanged)
 	{role: "ISSO"},
 	{role: "ISSM"},
+	// Contractor/support-staff tier (#455): system-scoped like ISSO/ISSM, so
+	// every admin/OpDiv helper is false, same as those rows.
+	{role: "SYSTEM_DELEGATE"},
 	// Unknown roles - all helpers must return false.
 	{role: ""},
 	{role: "UNKNOWN"},
@@ -52,6 +55,13 @@ func TestUser_RoleHelpers(t *testing.T) {
 			assert.Equal(t, tt.isReadOnlyAdmin, u.IsReadOnlyAdmin(), "IsReadOnlyAdmin")
 			assert.Equal(t, tt.hasAdminRead, u.HasAdminRead(), "HasAdminRead")
 		})
+	}
+}
+
+func TestUser_IsSystemDelegate(t *testing.T) {
+	assert.True(t, (&User{Role: "SYSTEM_DELEGATE"}).IsSystemDelegate(), "delegate role")
+	for _, role := range []string{"ISSO", "ISSM", "OPDIV_ADMIN", "OWNER", "HHS_ADMIN", "", "UNKNOWN"} {
+		assert.False(t, (&User{Role: role}).IsSystemDelegate(), role+" is not a delegate")
 	}
 }
 
@@ -204,8 +214,13 @@ func TestUser_CanAssignRole(t *testing.T) {
 		{"OPDIV_ADMIN", "OPDIV_READONLY_ADMIN", true},
 		{"OPDIV_ADMIN", "ISSO", true},
 		{"OPDIV_ADMIN", "ISSM", true},
-		{"OPDIV_READONLY_ADMIN", "ISSO", false}, // read-only cannot assign at all
+		{"OPDIV_ADMIN", "SYSTEM_DELEGATE", true},
+		{"HHS_ADMIN", "SYSTEM_DELEGATE", true},
+		{"OWNER", "SYSTEM_DELEGATE", true},
+		{"OPDIV_READONLY_ADMIN", "ISSO", false},            // read-only cannot assign at all
+		{"OPDIV_READONLY_ADMIN", "SYSTEM_DELEGATE", false}, // read-only cannot assign at all
 		{"ISSO", "ISSO", false},
+		{"SYSTEM_DELEGATE", "SYSTEM_DELEGATE", false}, // delegate cannot assign roles
 	}
 	for _, tt := range tests {
 		t.Run(tt.actor+"->"+tt.target, func(t *testing.T) {

--- a/backend/internal/model/validations.go
+++ b/backend/internal/model/validations.go
@@ -21,6 +21,7 @@ var roles = map[string]interface{}{
 	"OPDIV_READONLY_ADMIN": nil, // single-OpDiv read-only, scoped via users_opdivs
 	"ISSO":                 nil, // system-scoped via users_fismasystems
 	"ISSM":                 nil, // system-scoped via users_fismasystems
+	"SYSTEM_DELEGATE":      nil, // contractor/support staff: system-scoped, data-call answers only (#455)
 }
 
 var rgxUUID = regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")

--- a/backend/internal/model/validations_test.go
+++ b/backend/internal/model/validations_test.go
@@ -26,6 +26,7 @@ func TestIsValidRole(t *testing.T) {
 		// System-scoped roles, unchanged across the transition.
 		{"ISSO is valid", "ISSO", true},
 		{"ISSM is valid", "ISSM", true},
+		{"SYSTEM_DELEGATE is valid", "SYSTEM_DELEGATE", true},
 
 		// Negative cases.
 		{"lowercase admin is invalid", "admin", false},


### PR DESCRIPTION
> **Paired deployment.** This backend PR and the companion ztmf-ui PR (role picker + UI gating) are meant to ship together. Merging either to `main` auto-deploys it. Backend-alone is non-breaking - the API accepts the new role, it just is not selectable in the UI until the ztmf-ui PR lands - so do not mark this ready for merge until the ztmf-ui PR is ready to go out alongside it.

## Summary

Adds a new system-scoped user role, `SYSTEM_DELEGATE`, so contractors and support staff can be granted read/write access to specific FISMA systems' data-call answers without inheriting any of the ISSO/ISSM system-configuration surface.

Closes #455 (backend portion).

## Background

FDA and NIH reported they could not grant enough people access to complete Zero Trust data calls under the existing ISSO/ISSM roles, so teams fell back to spreadsheets. This role fills that gap. ISSM is intentionally left untouched (it is reserved for later ABAC auto-grant work), which is why this is a distinct role rather than a change to ISSM.

## What it does

The delegate's RBAC is identical to ISSO/ISSM - system-scoped via `users_fismasystems`, gated by `IsAssignedFismaSystem` for score reads/writes and data-call completion - with one deliberate carve-out: a delegate is forbidden from writing a system's target maturity, because that is the ISSO's risk assertion (#398), not a data-call answer.

- Register `SYSTEM_DELEGATE` in the role validation map
- Add an `IsSystemDelegate` helper and allow `OPDIV_ADMIN` and up to assign the role (non-escalating - same tier ceiling as ISSO/ISSM)
- Forbid delegates from `SaveFismaSystemTargetMaturity`
- Unit + controller coverage for the helper, assignability, and the carve-out
- Empire seed delegate user + Emberfall access-matrix block (answers 200, target maturity 403, admin surface 403)

## Notes

- **No schema migration.** `users.role` is free-text `VARCHAR(30)` gated by the app validation map; the only constraint is the legacy denylist, which the new value does not violate.
- Delegate actions are distinguishable from ISSO in the audit trail via the stored role value (AC #4).
- The AC set is split: this PR is backend only. The frontend role picker + UI gating land in a separate ztmf-ui PR, and the two documentation ACs (training material, admin how-to guide) are handled outside code. Both PRs are intended to ship together.

## Testing

- `make test-unit` - pass
- `make test-e2e` (Emberfall, ephemeral) - Failed: 0, including the new delegate access-matrix block
- OpenAPI regenerated - no drift
