### PR TITLE
feat(hooks): auto-regenerate openapi.yaml in pre-commit (#391)

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -71,6 +71,27 @@ if echo "$STAGED_FILES" | grep -q '\.go$'; then
     fi
     echo "✓ Go compilation successful"
 
+    # --- OpenAPI spec sync (#391) -----------------------------------------
+    # swag parses the whole backend tree (--dir ./ --parseInternal), so any
+    # staged backend Go change can affect the generated spec. Regen costs ~1s,
+    # so it always runs rather than guessing which files are API-relevant (a
+    # wrong guess costs the CI round-trip this hook exists to prevent).
+    # Limitation: swag reads the working tree, not the index — with partially
+    # staged Go files the spec may include unstaged edits. CI's
+    # OpenAPI-Spec-Check remains the backstop for that case.
+    echo "→ Regenerating OpenAPI spec..."
+    if ! SWAG_OUT=$(make generate-openapi 2>&1); then
+        echo "$SWAG_OUT"
+        echo "❌ OpenAPI generation failed. Fix annotations before committing."
+        exit 1
+    fi
+    if ! git diff --quiet -- backend/openapi.yaml; then
+        git add backend/openapi.yaml
+        echo "✓ openapi.yaml regenerated and staged"
+    else
+        echo "✓ openapi.yaml already up to date"
+    fi
+
     echo "→ Running unit tests..."
     # Source dev.compose.env so tests that read DB_* env (e.g. controller tests
     # that touch pgx) point at the local compose-dev Postgres on :54321 instead


### PR DESCRIPTION
Closes #391.

## Summary

Contributors sometimes forget to run `make generate-openapi` after touching annotated handlers or response models, so spec drift only surfaces in CI's `OpenAPI-Spec-Check` and costs a review round-trip (#390 most recently). This is the pre-commit auto-stage flavor the ticket recommends: when any backend Go file is staged, the hook runs `make generate-openapi` and, if `backend/openapi.yaml` changed, stages the regenerated file so the commit always carries an up-to-date spec. CI stays read-only and unchanged as the backstop.

Design notes:

- **Triggers on any staged backend `.go` file** rather than trying to detect API-relevant files. swag parses the whole backend tree (`--dir ./ --parseInternal`), so a struct change with no annotation in sight can still alter the spec; a false negative costs the CI round-trip this hook exists to prevent, while a false positive costs about a second (measured ~1.2s).
- **Generation failure blocks the commit** with swag's output shown, so broken annotations never reach CI.
- **A staged hand-edit to `openapi.yaml` is replaced by the canonical regen**, enforcing the never-hand-edit rule mechanically (a hand-edit is what caused the #390 drift).
- **Known limitation, documented in the hook:** swag reads the working tree, not the index, so partially staged Go files can leak unstaged edits into the spec. CI's drift check remains the backstop for that case.

## Validation

Exercised through real `git commit` runs:

| Scenario | Result |
| --- | --- |
| Annotation change staged | Spec regenerated + auto-staged; committed spec byte-identical to a fresh regen |
| Non-API Go change staged | Regen runs, byte-identical, "already up to date", spec untouched |
| No Go files staged | Regen (and the whole Go branch) skipped entirely |
| Broken annotation (`nosuchpkg.NoSuchType`) | Commit blocked, swag's ParseComment error shown |
| Hand-edited + staged `openapi.yaml` | Replaced by canonical regen, no trace of the hand-edit in the commit |

`make test-unit`, `make test-integration`, `make test-e2e` all green locally (emberfall: Ran 172, Failed 0).

Expected-red: Snyk / secret-dependent CI (fork PR, no repo secrets).