### PR TITLE
feat(hooks): auto-regenerate openapi.yaml in pre-commit (#391)

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -71,6 +71,27 @@ if echo "$STAGED_FILES" | grep -q '\.go$'; then
     fi
     echo "✓ Go compilation successful"
 
+    # --- OpenAPI spec sync (#391) -----------------------------------------
+    # swag parses the whole backend tree (--dir ./ --parseInternal), so any
+    # staged backend Go change can affect the generated spec. Regen costs ~1s,
+    # so it always runs rather than guessing which files are API-relevant (a
+    # wrong guess costs the CI round-trip this hook exists to prevent).
+    # Limitation: swag reads the working tree, not the index — with partially
+    # staged Go files the spec may include unstaged edits. CI's
+    # OpenAPI-Spec-Check remains the backstop for that case.
+    echo "→ Regenerating OpenAPI spec..."
+    if ! SWAG_OUT=$(make generate-openapi 2>&1); then
+        echo "$SWAG_OUT"
+        echo "❌ OpenAPI generation failed. Fix annotations before committing."
+        exit 1
+    fi
+    if ! git diff --quiet -- backend/openapi.yaml; then
+        git add backend/openapi.yaml
+        echo "✓ openapi.yaml regenerated and staged"
+    else
+        echo "✓ openapi.yaml already up to date"
+    fi
+
     echo "→ Running unit tests..."
     # Source dev.compose.env so tests that read DB_* env (e.g. controller tests
     # that touch pgx) point at the local compose-dev Postgres on :54321 instead


### PR DESCRIPTION
This is the in-repo version of #469 by @voidspooks, moved onto an in-repo branch so the org-secret CI gates (Snyk + the backend / Deploy jobs) run — they can't on a fork PR because it doesn't receive the org secrets. The commit is carried over unchanged and authorship is preserved; credit for the work is Cameron Testerman's.

Refs #469 · Closes #391

## What this adds

Adds an OpenAPI-regen step to the existing `.hooks/pre-commit` (wired via `git config core.hooksPath .hooks`). When any staged file is a backend `.go`, after the existing `go build` check the hook runs `make generate-openapi` and, if `backend/openapi.yaml` changed, stages the regenerated spec so every commit carries an up-to-date spec. A generation failure blocks the commit with swag's output shown, and a staged hand-edit to `openapi.yaml` is replaced by the canonical regen (the never-hand-edit rule, enforced mechanically). CI's `OpenAPI-Spec-Check` stays read-only as the backstop. Closes #391 — the spec drift that today only surfaces in CI and costs a review round-trip (e.g. #390).

## Verification

Reviewed and rehomed on a go. Detail in the review comment below.
