### PR TITLE
Add isso self service endpoints

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -23,6 +23,10 @@ UPDATE public.opdivs SET is_parent = TRUE WHERE LOWER(code) = 'empire';
 -- migration only enables code='CMS', so set the test OpDiv explicitly here.
 -- REBELLION is intentionally left disabled to exercise the OpDiv-gated 404.
 UPDATE public.opdivs SET insights_enabled = TRUE WHERE LOWER(code) = 'empire';
+-- Enable the System Delegate self-service capability (#467) for EMPIRE so the
+-- ISSO add flow is exercisable; REBELLION is left disabled (migration default
+-- false) to exercise the toggle-off refusal (ErrDelegatesNotEnabled).
+UPDATE public.opdivs SET system_delegate_enabled = TRUE WHERE LOWER(code) = 'empire';
 
 -- 13 sister divisions of the Empire.
 INSERT INTO public.opdivs (code, name, is_parent, active) VALUES
@@ -337,6 +341,27 @@ INSERT INTO public.users_fismasystems VALUES ('33333333-3333-3333-3333-333333333
 INSERT INTO public.users_fismasystems VALUES ('44444444-4444-4444-4444-444444444444', 1003) ON CONFLICT DO NOTHING; -- Krennic -> Shield Gen
 INSERT INTO public.users_fismasystems VALUES ('66666666-6666-6666-6666-666666666666', 1003) ON CONFLICT DO NOTHING; -- Emberfall ISSO -> Shield Gen (for system_enrichment access E2E tests)
 INSERT INTO public.users_fismasystems VALUES ('55555555-5555-4555-8555-555555555555', 1001) ON CONFLICT DO NOTHING; -- System Delegate -> Death Star (answers-only E2E: score write allowed, target maturity 403)
+
+-- System Delegate self-service fixtures (#467). All are SYSTEM_DELEGATEs so the
+-- reuse-vs-reject branches of the add flow are exercisable against Death Star
+-- (system 1001, EMPIRE OpDiv, capability enabled above).
+--   - Reuse.Delegate: already a delegate holding EMPIRE and NOT yet on any system,
+--     so the existing-eligible path can attach it.
+--   - Wrong.Opdiv.Delegate: a delegate holding REBELLION (not EMPIRE), so the add
+--     flow must reject it as administrator-required.
+INSERT INTO public.users (userid, email, fullname, role, identity_provider)
+    VALUES ('5e1e6a7e-0000-4000-8000-000000000001', 'Reuse.Delegate@empire.test', 'Reuse Delegate', 'SYSTEM_DELEGATE', 'entra')
+    ON CONFLICT DO NOTHING;
+INSERT INTO public.users_opdivs (userid, opdiv_id)
+    SELECT '5e1e6a7e-0000-4000-8000-000000000001', opdiv_id FROM public.opdivs WHERE code = 'EMPIRE'
+    ON CONFLICT DO NOTHING;
+
+INSERT INTO public.users (userid, email, fullname, role, identity_provider)
+    VALUES ('5e1e6a7e-0000-4000-8000-000000000002', 'Wrong.Opdiv.Delegate@rebellion.test', 'Wrong OpDiv Delegate', 'SYSTEM_DELEGATE', 'entra')
+    ON CONFLICT DO NOTHING;
+INSERT INTO public.users_opdivs (userid, opdiv_id)
+    SELECT '5e1e6a7e-0000-4000-8000-000000000002', opdiv_id FROM public.opdivs WHERE code = 'REBELLION'
+    ON CONFLICT DO NOTHING;
 
 -- DataCall-System Assignments (Systems participating in audits)
 INSERT INTO public.datacalls_fismasystems VALUES (3, 1001) ON CONFLICT DO NOTHING; -- DS-1 in FY2024 review

--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -23,6 +23,10 @@ const (
 	CodeForbiddenOrigin       = "FORBIDDEN_ORIGIN"
 	CodeAccountNotProvisioned = "ACCOUNT_NOT_PROVISIONED"
 	CodeSelfDeleteForbidden = "SELF_DELETE_FORBIDDEN"
+	// Set by the controller (sanitizeErr), not the middleware: the ISSO delegate add
+	// flow rejected an existing account it cannot self-serve, so the FE renders "an
+	// administrator must handle this user" instead of a generic validation error (#467).
+	CodeDelegateRequiresAdmin = "DELEGATE_REQUIRES_ADMIN"
 )
 
 // Package-level seams over the model lookups so tests can stub them without a
@@ -153,6 +157,19 @@ func Middleware(next http.Handler) http.Handler {
 			log.Printf("deleted user attempted to access the API: %s\n", user.Email)
 			writeJSONError(w, http.StatusForbidden,
 				"Your ZTMF account is no longer active. Contact your administrator.",
+				CodeAccountNotProvisioned)
+			return
+		}
+
+		if user.IsExpired() {
+			// A System Delegate whose access_expires_at has passed (#467). Denied
+			// through the same rejection path and code as a soft-deleted user, so
+			// the FE renders the same terminal "contact your administrator" copy.
+			// The row and its assignments are retained for renewal and audit; this
+			// is a lazy, authoritative check with no scheduled job.
+			log.Printf("expired delegate attempted to access the API: %s\n", user.Email)
+			writeJSONError(w, http.StatusForbidden,
+				"Your ZTMF delegate access has expired. Contact your administrator.",
 				CodeAccountNotProvisioned)
 			return
 		}

--- a/backend/cmd/api/internal/auth/middleware_test.go
+++ b/backend/cmd/api/internal/auth/middleware_test.go
@@ -214,6 +214,72 @@ func TestMiddleware(t *testing.T) {
 		assert.Equal(t, CodeAccountNotProvisioned, body.Code)
 	})
 
+	t.Run("authed + expired delegate -> 403 ACCOUNT_NOT_PROVISIONED", func(t *testing.T) {
+		past := time.Now().Add(-time.Hour)
+		stubFindUserByEmail(t, func(_ context.Context, email string) (*model.User, error) {
+			return &model.User{
+				UserID:          "55555555-5555-4555-8555-555555555555",
+				Email:           email,
+				Role:            "SYSTEM_DELEGATE",
+				AccessExpiresAt: &past,
+			}, nil
+		})
+
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		r.Header.Set(cfg.Auth.HeaderField, "Bearer "+mintBearer(t, "expired.delegate@empire.test"))
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.False(t, called, "expired delegate must not reach the next handler")
+		body := decodeBody(t, w)
+		assert.Equal(t, CodeAccountNotProvisioned, body.Code)
+	})
+
+	t.Run("authed + delegate not yet expired -> pass through", func(t *testing.T) {
+		future := time.Now().Add(24 * time.Hour)
+		stubFindUserByEmail(t, func(_ context.Context, email string) (*model.User, error) {
+			return &model.User{
+				UserID:          "55555555-5555-4555-8555-555555555555",
+				Email:           email,
+				Role:            "SYSTEM_DELEGATE",
+				AccessExpiresAt: &future,
+			}, nil
+		})
+
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		r.Header.Set(cfg.Auth.HeaderField, "Bearer "+mintBearer(t, "active.delegate@empire.test"))
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.True(t, called, "a delegate with a future expiry must pass through")
+	})
+
+	t.Run("authed + regular user with null expiry -> pass through", func(t *testing.T) {
+		stubFindUserByEmail(t, func(_ context.Context, email string) (*model.User, error) {
+			return &model.User{
+				UserID: "11111111-1111-1111-1111-111111111111",
+				Email:  email,
+				Role:   "ISSO",
+			}, nil
+		})
+
+		var called bool
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/users/current", nil)
+		r.Header.Set(cfg.Auth.HeaderField, "Bearer "+mintBearer(t, "regular@empire.test"))
+		w := httptest.NewRecorder()
+
+		Middleware(nextFn(&called)).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.True(t, called, "a non-delegate with null expiry is never expired")
+	})
+
 	t.Run("authed + lookup errors (non-ErrNoData) -> 500", func(t *testing.T) {
 		stubFindUserByEmail(t, func(context.Context, string) (*model.User, error) {
 			return nil, errors.New("simulated db connection blip")

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -286,15 +286,23 @@ func TestSystemDelegate_ForbiddenNonAnswerSurfaces(t *testing.T) {
 		Role:                 "SYSTEM_DELEGATE",
 		AssignedFismaSystems: []*int32{int32Ptr(1)},
 	}
+	const delegateID = "66666666-6666-4666-8666-666666666666"
 
+	// wantStatus is per-case because the two surfaces deny differently on purpose:
+	// target maturity is an explicit IsSystemDelegate() 403, while the delegate
+	// self-service endpoints fail closed with 404 (not-leak) since a delegate is
+	// neither an admin nor an ISSO. Both are denials; the point of the table is
+	// that assignment to the system never opens the surface to a delegate.
 	cases := []struct {
-		name    string
-		handler http.HandlerFunc
-		request func() *http.Request
+		name       string
+		handler    http.HandlerFunc
+		request    func() *http.Request
+		wantStatus int
 	}{
 		{
-			name:    "target maturity write",
-			handler: SaveFismaSystemTargetMaturity,
+			name:       "target maturity write",
+			handler:    SaveFismaSystemTargetMaturity,
+			wantStatus: http.StatusForbidden,
 			request: func() *http.Request {
 				body := jsonBody(t, map[string]any{
 					"target_maturity_tier":          "Advanced",
@@ -305,8 +313,39 @@ func TestSystemDelegate_ForbiddenNonAnswerSurfaces(t *testing.T) {
 				return mux.SetURLVars(r, map[string]string{"fismasystemid": "1"})
 			},
 		},
+		{
+			name:       "add system delegate",
+			handler:    AddSystemDelegate,
+			wantStatus: http.StatusNotFound,
+			request: func() *http.Request {
+				body := jsonBody(t, map[string]any{"email": "x@y.z", "fullname": "X"})
+				r := httptest.NewRequest("POST", "/api/v1/fismasystems/1/delegates", body)
+				r.Header.Set("Content-Type", "application/json")
+				return mux.SetURLVars(r, map[string]string{"fismasystemid": "1"})
+			},
+		},
+		{
+			name:       "remove system delegate",
+			handler:    RemoveSystemDelegate,
+			wantStatus: http.StatusNotFound,
+			request: func() *http.Request {
+				r := httptest.NewRequest("DELETE", "/api/v1/fismasystems/1/delegates/"+delegateID, nil)
+				return mux.SetURLVars(r, map[string]string{"fismasystemid": "1", "userid": delegateID})
+			},
+		},
+		{
+			name:       "renew system delegate",
+			handler:    RenewSystemDelegate,
+			wantStatus: http.StatusNotFound,
+			request: func() *http.Request {
+				body := jsonBody(t, map[string]any{"access_expires_at": "2030-01-01T00:00:00Z"})
+				r := httptest.NewRequest("PATCH", "/api/v1/fismasystems/1/delegates/"+delegateID, body)
+				r.Header.Set("Content-Type", "application/json")
+				return mux.SetURLVars(r, map[string]string{"fismasystemid": "1", "userid": delegateID})
+			},
+		},
 		// Add a row when a new ISSO/ISSM-writable non-answer surface lands, and
-		// add the matching IsSystemDelegate() guard to its handler.
+		// add the matching guard to its handler.
 	}
 
 	for _, tc := range cases {
@@ -314,8 +353,8 @@ func TestSystemDelegate_ForbiddenNonAnswerSurfaces(t *testing.T) {
 			r := withUser(tc.request(), delegate)
 			w := httptest.NewRecorder()
 			tc.handler(w, r)
-			assert.Equal(t, http.StatusForbidden, w.Code,
-				"delegate must be forbidden from non-answer surface %q", tc.name)
+			assert.Equal(t, tc.wantStatus, w.Code,
+				"delegate must be denied on non-answer surface %q", tc.name)
 		})
 	}
 }
@@ -642,7 +681,6 @@ func TestDeleteUser_OtherDeleteSucceeds(t *testing.T) {
 		deleteUser = prevDel
 	})
 
-	
 	variants := map[string]string{
 		"lower-cased": otherIDLower,
 		"upper-cased": strings.ToUpper(otherIDLower),

--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -55,6 +55,11 @@ func respond(w http.ResponseWriter, r *http.Request, data any, err error) {
 		} else {
 			status = 204
 		}
+	default:
+		// PATCH and any other verb: default to 200 so a handler that reaches
+		// respond() on a success path never emits WriteHeader(0). (PATCH success
+		// paths that want the body use respondOK; this is the defensive floor.)
+		status = 200
 	}
 
 	res := response{
@@ -123,8 +128,15 @@ func sanitizeErr(err error) (int, string, error) {
 		status = 403
 		code = auth.CodeSelfDeleteForbidden
 	case errors.Is(err, ErrForbidden),
-		errors.Is(err, model.ErrPastDeadline):
+		errors.Is(err, model.ErrPastDeadline),
+		errors.Is(err, model.ErrDelegatesNotEnabled):
 		status = 403
+	case errors.Is(err, model.ErrDelegateRequiresAdmin):
+		// Well-formed request, but the target account needs an administrator. 400
+		// (not 403) so it does not collide with the FE's global auth handling; the
+		// FE branches on the code, not the status.
+		status = 400
+		code = auth.CodeDelegateRequiresAdmin
 	case errors.Is(err, model.ErrNotUnique),
 		errors.Is(err, ErrMalformed),
 		errors.Is(err, model.ErrNotesTooLong),

--- a/backend/cmd/api/internal/controller/controller_test.go
+++ b/backend/cmd/api/internal/controller/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/CMS-Enterprise/ztmf/backend/cmd/api/internal/auth"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -64,4 +65,13 @@ func TestSanitizeErrMapping(t *testing.T) {
 			assert.Equal(t, tc.wantStatus, status)
 		})
 	}
+}
+
+// The administrator-required rejection carries a machine-readable code the FE
+// branches on (#467), like the auth middleware's ACCOUNT_NOT_PROVISIONED.
+func TestSanitizeErrDelegateRequiresAdminCarriesCode(t *testing.T) {
+	status, code, out := sanitizeErr(model.ErrDelegateRequiresAdmin)
+	assert.Equal(t, 400, status)
+	assert.Equal(t, auth.CodeDelegateRequiresAdmin, code)
+	assert.Equal(t, model.ErrDelegateRequiresAdmin, out, "human-readable message is preserved alongside the code")
 }

--- a/backend/cmd/api/internal/controller/delegates.go
+++ b/backend/cmd/api/internal/controller/delegates.go
@@ -1,0 +1,314 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
+)
+
+// System Delegate self-service (#467). A separate, narrow, system-anchored
+// surface so an ISSO can add/remove/renew SYSTEM_DELEGATE accounts on systems
+// they own, without unlocking the admin Users surface or relaxing the IsAdmin()
+// gates that front every other user write path. The scope is anchored to the
+// {fismasystemid} in the path, and guardManageDelegates rejects an actor who
+// does not own that system with NotFound so system existence is not leaked.
+
+// pathFismaSystemID reads the numeric {fismasystemid} path var. The route regex
+// ([0-9]+) guarantees it parses.
+func pathFismaSystemID(r *http.Request) (int32, bool) {
+	v, ok := mux.Vars(r)["fismasystemid"]
+	if !ok {
+		return 0, false
+	}
+	var id int32
+	fmt.Sscan(v, &id)
+	return id, id != 0
+}
+
+// guardManageDelegates verifies the acting user may manage delegates on the
+// system and returns the system for the caller to reuse. A missing system, an
+// OpDiv-less system, or an unauthorized actor all return ErrNotFound so the
+// endpoint never leaks which systems exist.
+//
+// The role part of the gate is evaluated in memory BEFORE any DB work: an actor
+// who can never manage delegates here (a delegate, an ISSM, a read-only tier, or
+// an ISSO not assigned to this system) is rejected up front. This fails closed
+// even if the DB is unreachable and keeps the security boundary unit-testable.
+// The OpDiv-scope tightening for an OPDIV_ADMIN needs the system's OpDiv, so it
+// runs after the load via the authoritative CanManageSystemDelegates check.
+func guardManageDelegates(r *http.Request, authdUser *model.User, id int32) (*model.FismaSystem, error) {
+	// Cheap fail-closed pre-check: only an admin write tier, or an ISSO assigned
+	// to this system, may proceed. An OPDIV_ADMIN passes here and is narrowed to
+	// its OpDiv after the system loads.
+	if !authdUser.IsAdmin() && !(authdUser.Role == "ISSO" && authdUser.IsAssignedFismaSystem(id)) {
+		return nil, ErrNotFound
+	}
+
+	sys, err := model.FindFismaSystem(r.Context(), model.FindFismaSystemsInput{FismaSystemID: &id})
+	if err != nil {
+		return nil, err
+	}
+	if sys == nil || sys.OpDivID == nil {
+		return nil, ErrNotFound
+	}
+	if !authdUser.CanManageSystemDelegates(id, sys.OpDivID) {
+		return nil, ErrNotFound
+	}
+	return sys, nil
+}
+
+// guardDelegateTarget authorizes the actor to manage delegates on the system and
+// confirms the path userid is a SYSTEM_DELEGATE assigned to that system. Shared by
+// remove and renew so the ISSO invariant (act only on a delegate assigned to this
+// system; NotFound rather than Forbidden so an ISSO cannot probe whether a given
+// user is, say, an admin on the system) lives in one place.
+func guardDelegateTarget(r *http.Request, authdUser *model.User, id int32, userID string) error {
+	if _, gerr := guardManageDelegates(r, authdUser, id); gerr != nil {
+		return gerr
+	}
+	target, err := model.FindUserByID(r.Context(), userID)
+	if err != nil {
+		return err
+	}
+	if !target.IsSystemDelegate() || !target.IsAssignedFismaSystem(id) {
+		return ErrNotFound
+	}
+	return nil
+}
+
+//	@Summary	List the System Delegates assigned to a FISMA system
+//	@Tags		delegates
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		fismasystemid	path	int	true	"FISMA System ID"
+//	@Success	200	{object}	apiResponse[[]model.User]
+//	@Failure	403	{object}	apiResponse[any]
+//	@Failure	404	{object}	apiResponse[any]
+//	@Failure	500	{object}	apiResponse[any]
+//	@Router		/fismasystems/{fismasystemid}/delegates [get]
+func ListSystemDelegates(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	id, ok := pathFismaSystemID(r)
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	// The delegate roster is hidden from delegates themselves (mirrors the FE
+	// section visibility). Reject a delegate actor in memory before any DB work
+	// so it fails closed and stays unit-testable; 404 to match the no-leak posture.
+	if authdUser.IsSystemDelegate() {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	// Read gate: any other user who can see the system can see its delegate
+	// roster. A non-viewer (or a system that does not exist) is NotFound, not
+	// Forbidden, consistent with the write guard's no-leak behavior.
+	sys, err := model.FindFismaSystem(r.Context(), model.FindFismaSystemsInput{FismaSystemID: &id})
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+	if sys == nil || !authdUser.CanAccessFismaSystem(sys.OpDivID, id) {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	delegates, err := model.FindDelegatesByFismaSystem(r.Context(), id)
+	respond(w, r, delegates, err)
+}
+
+//	@Summary	List existing delegates eligible to attach to a FISMA system
+//	@Description	Existing SYSTEM_DELEGATE users in the system's OpDiv that are not already assigned to it - the set the add flow would accept. Backs the FE attach picker (#598).
+//	@Tags		delegates
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		fismasystemid	path	int		true	"FISMA System ID"
+//	@Param		q				query	string	false	"Filter by email or name (substring)"
+//	@Success	200	{object}	apiResponse[[]model.User]
+//	@Failure	403	{object}	apiResponse[any]
+//	@Failure	404	{object}	apiResponse[any]
+//	@Failure	500	{object}	apiResponse[any]
+//	@Router		/fismasystems/{fismasystemid}/delegate-candidates [get]
+func ListDelegateCandidates(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	id, ok := pathFismaSystemID(r)
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	// Same write-gate as add/remove: a candidate list is only useful to someone
+	// who could actually attach one, and it must not leak systems the actor does
+	// not manage.
+	sys, gerr := guardManageDelegates(r, authdUser, id)
+	if gerr != nil {
+		respond(w, r, nil, gerr)
+		return
+	}
+
+	candidates, err := model.FindDelegateCandidatesForSystem(r.Context(), id, *sys.OpDivID, r.URL.Query().Get("q"))
+	respond(w, r, candidates, err)
+}
+
+// addDelegateBody is the POST payload. getJSON disallows unknown fields, so a
+// client cannot smuggle role/userid/opdiv - those are entirely server-controlled.
+type addDelegateBody struct {
+	Email           string     `json:"email"`
+	FullName        string     `json:"fullname"`
+	AccessExpiresAt *time.Time `json:"access_expires_at"`
+}
+
+//	@Summary	Add or invite a System Delegate on a FISMA system
+//	@Tags		delegates
+//	@Accept		json
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		fismasystemid	path	int				true	"FISMA System ID"
+//	@Param		body			body	addDelegateBody	true	"Delegate to add"
+//	@Success	201	{object}	apiResponse[model.User]
+//	@Failure	400	{object}	apiResponse[any]
+//	@Failure	403	{object}	apiResponse[any]
+//	@Failure	404	{object}	apiResponse[any]
+//	@Failure	500	{object}	apiResponse[any]
+//	@Router		/fismasystems/{fismasystemid}/delegates [post]
+func AddSystemDelegate(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	id, ok := pathFismaSystemID(r)
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	sys, gerr := guardManageDelegates(r, authdUser, id)
+	if gerr != nil {
+		respond(w, r, nil, gerr)
+		return
+	}
+	// Only the add flow needs the OpDiv (capability toggle + IdP derivation), so
+	// it is loaded here rather than in the shared guard - remove/renew/candidates
+	// do not pay for a query they would discard.
+	opdiv, err := model.FindOpDivByID(r.Context(), *sys.OpDivID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	body := addDelegateBody{}
+	if err := getJSON(r.Body, &body); err != nil {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+
+	delegate, err := model.AddSystemDelegate(r.Context(), sys, opdiv, authdUser.UserID, body.Email, body.FullName, body.AccessExpiresAt)
+	respond(w, r, delegate, err)
+}
+
+//	@Summary	Remove a System Delegate from a FISMA system
+//	@Tags		delegates
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		fismasystemid	path	int		true	"FISMA System ID"
+//	@Param		userid			path	string	true	"Delegate User ID"
+//	@Success	204	"No Content"
+//	@Failure	403	{object}	apiResponse[any]
+//	@Failure	404	{object}	apiResponse[any]
+//	@Failure	500	{object}	apiResponse[any]
+//	@Router		/fismasystems/{fismasystemid}/delegates/{userid} [delete]
+func RemoveSystemDelegate(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	id, ok := pathFismaSystemID(r)
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+	userID, ok := mux.Vars(r)["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	if err := guardDelegateTarget(r, authdUser, id, userID); err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	uf := &model.UserFismaSystem{UserID: userID, FismaSystemID: id}
+	// Assignment only: the user row and any other system assignments are retained
+	// for renewal and audit (#467 decision 4). A plain sequential re-remove is
+	// already caught above (target no longer assigned to this system -> 404);
+	// tolerating ErrNoData here only covers the concurrent race where two requests
+	// both pass the assignment check and one deletes the row first, keeping that a
+	// 204 rather than a spurious 404.
+	err := uf.Delete(r.Context())
+	if errors.Is(err, model.ErrNoData) {
+		err = nil
+	}
+	respond(w, r, nil, err)
+}
+
+// renewDelegateBody is the PATCH payload. access_expires_at is optional; the
+// model defaults it to three months out and rejects a past date.
+type renewDelegateBody struct {
+	AccessExpiresAt *time.Time `json:"access_expires_at"`
+}
+
+//	@Summary	Renew or adjust a System Delegate's expiration
+//	@Tags		delegates
+//	@Accept		json
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		fismasystemid	path	int					true	"FISMA System ID"
+//	@Param		userid			path	string				true	"Delegate User ID"
+//	@Param		body			body	renewDelegateBody	true	"New expiration"
+//	@Success	200	{object}	apiResponse[model.User]
+//	@Failure	400	{object}	apiResponse[any]
+//	@Failure	403	{object}	apiResponse[any]
+//	@Failure	404	{object}	apiResponse[any]
+//	@Failure	500	{object}	apiResponse[any]
+//	@Router		/fismasystems/{fismasystemid}/delegates/{userid} [patch]
+func RenewSystemDelegate(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	id, ok := pathFismaSystemID(r)
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+	userID, ok := mux.Vars(r)["userid"]
+	if !ok {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	if err := guardDelegateTarget(r, authdUser, id, userID); err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	// An empty body is allowed and means "renew to the default" (SetDelegateExpiry
+	// treats a nil date as now+3mo). Only a present-but-malformed body / unknown
+	// field is a 400. io.EOF is the empty-body signal from the JSON decoder.
+	body := renewDelegateBody{}
+	if err := getJSON(r.Body, &body); err != nil && !errors.Is(err, io.EOF) {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+
+	delegate, err := model.SetDelegateExpiry(r.Context(), userID, body.AccessExpiresAt)
+	// PATCH would default to 204 in respond(); use respondOK so the updated
+	// delegate (with its new expiry) is returned to the caller.
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+	respondOK(w, delegate)
+}

--- a/backend/cmd/api/internal/controller/delegates_test.go
+++ b/backend/cmd/api/internal/controller/delegates_test.go
@@ -1,0 +1,130 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+// Injection defense: the add body must accept only email/fullname/access_expires_at,
+// so a client can never smuggle role/opdiv/userid to escalate. getJSON sets
+// DisallowUnknownFields; this pins that guarantee for the delegate payload.
+func TestAddDelegateBody_RejectsUnknownFields(t *testing.T) {
+	err := getJSON(strings.NewReader(`{"email":"x@y.z","fullname":"X","role":"OWNER"}`), &addDelegateBody{})
+	assert.Error(t, err, "an unknown field (role) must be rejected, not silently ignored")
+
+	err = getJSON(strings.NewReader(`{"email":"x@y.z","fullname":"X"}`), &addDelegateBody{})
+	assert.NoError(t, err, "a clean body must parse")
+}
+
+// These tests pin the delegate-management authorization gate, which is decided
+// in memory before any DB work (guardManageDelegates' pre-check). A denied actor
+// must get 404 (not-leak) without ever reaching the database, so these assertions
+// hold with no DB. Allowed actors pass the gate and then fail later on the absent
+// DB; the happy paths are covered by the integration suite, so here we only assert
+// that an allowed actor is NOT gated (not 404/403).
+
+const (
+	delegateSystemID   = "1"
+	delegateTargetUUID = "66666666-6666-4666-8666-666666666666"
+)
+
+func delegateReq(t *testing.T, method, body string, u *model.User, vars map[string]string) (*httptest.ResponseRecorder, *http.Request) {
+	t.Helper()
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, "/api/v1/fismasystems/1/delegates", jsonBody(t, map[string]any{"email": "new@empire.test", "fullname": "New Delegate"}))
+		r.Header.Set("Content-Type", "application/json")
+	} else {
+		r = httptest.NewRequest(method, "/api/v1/fismasystems/1/delegates", nil)
+	}
+	r = mux.SetURLVars(r, vars)
+	return httptest.NewRecorder(), withUser(r, u)
+}
+
+// deniedActors can never manage delegates on a system: a delegate, an ISSM (even
+// assigned), an ISSO not assigned to the system, and the read-only tiers.
+func deniedActors() map[string]*model.User {
+	return map[string]*model.User{
+		"delegate assigned": {UserID: "55555555-5555-4555-8555-555555555555", Role: "SYSTEM_DELEGATE", AssignedFismaSystems: []*int32{int32Ptr(1)}},
+		"ISSM assigned":     {UserID: "77777777-7777-4777-8777-777777777777", Role: "ISSM", AssignedFismaSystems: []*int32{int32Ptr(1)}},
+		"ISSO unassigned":   {UserID: "33333333-3333-4333-8333-333333333333", Role: "ISSO"},
+		"readonly admin":    readonlyAdmin,
+	}
+}
+
+func TestAddSystemDelegate_DeniedActorsNotFound(t *testing.T) {
+	for name, u := range deniedActors() {
+		t.Run(name, func(t *testing.T) {
+			w, r := delegateReq(t, "POST", "body", u, map[string]string{"fismasystemid": delegateSystemID})
+			AddSystemDelegate(w, r)
+			assert.Equal(t, http.StatusNotFound, w.Code)
+		})
+	}
+}
+
+func TestRemoveSystemDelegate_DeniedActorsNotFound(t *testing.T) {
+	for name, u := range deniedActors() {
+		t.Run(name, func(t *testing.T) {
+			w, r := delegateReq(t, "DELETE", "", u, map[string]string{"fismasystemid": delegateSystemID, "userid": delegateTargetUUID})
+			RemoveSystemDelegate(w, r)
+			assert.Equal(t, http.StatusNotFound, w.Code)
+		})
+	}
+}
+
+func TestRenewSystemDelegate_DeniedActorsNotFound(t *testing.T) {
+	for name, u := range deniedActors() {
+		t.Run(name, func(t *testing.T) {
+			w, r := delegateReq(t, "PATCH", "", u, map[string]string{"fismasystemid": delegateSystemID, "userid": delegateTargetUUID})
+			RenewSystemDelegate(w, r)
+			assert.Equal(t, http.StatusNotFound, w.Code)
+		})
+	}
+}
+
+// A delegate assigned to the system must not be able to read the roster (the
+// section is hidden from delegates); rejected in memory as 404 before any DB.
+func TestListSystemDelegates_DelegateForbidden(t *testing.T) {
+	delegate := &model.User{
+		UserID:               "55555555-5555-4555-8555-555555555555",
+		Role:                 "SYSTEM_DELEGATE",
+		AssignedFismaSystems: []*int32{int32Ptr(1)},
+	}
+	r := httptest.NewRequest("GET", "/api/v1/fismasystems/1/delegates", nil)
+	r = mux.SetURLVars(r, map[string]string{"fismasystemid": delegateSystemID})
+	w := httptest.NewRecorder()
+	ListSystemDelegates(w, withUser(r, delegate))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestListDelegateCandidates_DeniedActorsNotFound(t *testing.T) {
+	for name, u := range deniedActors() {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/api/v1/fismasystems/1/delegate-candidates?q=foo", nil)
+			r = mux.SetURLVars(r, map[string]string{"fismasystemid": delegateSystemID})
+			w := httptest.NewRecorder()
+			ListDelegateCandidates(w, withUser(r, u))
+			assert.Equal(t, http.StatusNotFound, w.Code)
+		})
+	}
+}
+
+// An ISSO assigned to the system, and an unscoped admin, both pass the gate; with
+// no DB they fail downstream, but must not be gated with 403/404.
+func TestAddSystemDelegate_AllowedActorsPassGate(t *testing.T) {
+	issoAssigned := &model.User{UserID: "33333333-3333-4333-8333-333333333333", Role: "ISSO", AssignedFismaSystems: []*int32{int32Ptr(1)}}
+	for name, u := range map[string]*model.User{"ISSO assigned": issoAssigned, "OWNER": adminUser} {
+		t.Run(name, func(t *testing.T) {
+			w, r := delegateReq(t, "POST", "body", u, map[string]string{"fismasystemid": delegateSystemID})
+			AddSystemDelegate(w, r)
+			assert.NotEqual(t, http.StatusNotFound, w.Code, "gate must pass for %s", name)
+			assert.NotEqual(t, http.StatusForbidden, w.Code, "gate must pass for %s", name)
+		})
+	}
+}

--- a/backend/cmd/api/internal/controller/opdivs.go
+++ b/backend/cmd/api/internal/controller/opdivs.go
@@ -77,3 +77,58 @@ func SaveOpDiv(w http.ResponseWriter, r *http.Request) {
 	o, err := o.Save(r.Context())
 	respond(w, r, o, err)
 }
+
+// SetOpDivSystemDelegateEnabled flips the per-OpDiv "Add System Delegate Role"
+// capability (#467 decisions 6 and 7). It is a dedicated endpoint rather than a
+// field on SaveOpDiv because SaveOpDiv is OWNER-only (the OpDiv list is the tenant
+// boundary), whereas this toggle is settable by both Owner and HHS admin - and by
+// no one else, so an OPDIV_ADMIN (who is IsAdmin) is rejected here.
+//
+//	@Summary	Enable or disable the System Delegate role for an OpDiv
+//	@Tags		opdivs
+//	@Accept		json
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		opdiv_id	path		int										true	"OpDiv ID"
+//	@Param		body		body		object{enabled=bool}					true	"Toggle state"
+//	@Success	200			{object}	apiResponse[model.OpDiv]
+//	@Failure	400			{object}	apiResponse[any]
+//	@Failure	403			{object}	apiResponse[any]
+//	@Failure	404			{object}	apiResponse[any]
+//	@Failure	500			{object}	apiResponse[any]
+//	@Router		/opdivs/{opdiv_id}/system-delegate-enabled [put]
+func SetOpDivSystemDelegateEnabled(w http.ResponseWriter, r *http.Request) {
+	authdUser := model.UserFromContext(r.Context())
+	if !authdUser.CanWriteHHSWide() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	var opdivID int32
+	if v, ok := mux.Vars(r)["opdiv_id"]; ok {
+		fmt.Sscan(v, &opdivID)
+	}
+	if opdivID == 0 {
+		respond(w, r, nil, ErrNotFound)
+		return
+	}
+
+	body := struct {
+		Enabled *bool `json:"enabled"`
+	}{}
+	if err := getJSON(r.Body, &body); err != nil || body.Enabled == nil {
+		log.Println(err)
+		respond(w, r, nil, ErrMalformed)
+		return
+	}
+
+	o, err := model.SetOpDivSystemDelegateEnabled(r.Context(), opdivID, *body.Enabled)
+	// PUT-as-action: return 200 with the updated OpDiv (like RestoreUser /
+	// ReactivateFismaSystem). respond() would treat PUT as an in-place 204 that
+	// drops the body, but the FE needs the new flag value back.
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+	respondOK(w, o)
+}

--- a/backend/cmd/api/internal/controller/opdivs_test.go
+++ b/backend/cmd/api/internal/controller/opdivs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,3 +33,43 @@ func TestSaveOpDiv_OwnerOnly(t *testing.T) {
 }
 
 func ptr32(i int32) *int32 { return &i }
+
+// SetOpDivSystemDelegateEnabled is settable by Owner and HHS admin only (#467
+// decision 7). Unlike SaveOpDiv it is NOT OWNER-only - HHS_ADMIN must pass - but
+// an OPDIV_ADMIN (though IsAdmin) and every scoped/read-only tier must be
+// rejected. The CanWriteHHSWide gate runs before any DB call.
+func TestSetOpDivSystemDelegateEnabled_HHSWideOnly(t *testing.T) {
+	body := func() *httptest.ResponseRecorder { return httptest.NewRecorder() }
+
+	forbidden := []*model.User{
+		{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{ptr32(2)}},
+		{Role: "OPDIV_READONLY_ADMIN"},
+		{Role: "HHS_READONLY_ADMIN"},
+		{Role: "ISSO"},
+		{Role: "SYSTEM_DELEGATE"},
+	}
+	for _, u := range forbidden {
+		t.Run("forbidden for "+u.Role, func(t *testing.T) {
+			r := withUser(httptest.NewRequest("PUT", "/api/v1/opdivs/2/system-delegate-enabled", jsonBody(t, map[string]any{"enabled": true})), u)
+			r = mux.SetURLVars(r, map[string]string{"opdiv_id": "2"})
+			w := body()
+			SetOpDivSystemDelegateEnabled(w, r)
+			assert.Equal(t, http.StatusForbidden, w.Code)
+		})
+	}
+
+	allowed := []*model.User{
+		{Role: "OWNER"},
+		{Role: "HHS_ADMIN"},
+	}
+	for _, u := range allowed {
+		t.Run("gate passes for "+u.Role, func(t *testing.T) {
+			r := withUser(httptest.NewRequest("PUT", "/api/v1/opdivs/2/system-delegate-enabled", jsonBody(t, map[string]any{"enabled": true})), u)
+			r = mux.SetURLVars(r, map[string]string{"opdiv_id": "2"})
+			w := body()
+			SetOpDivSystemDelegateEnabled(w, r)
+			// Passes the role gate; without a DB it fails downstream, but must not be 403.
+			assert.NotEqual(t, http.StatusForbidden, w.Code)
+		})
+	}
+}

--- a/backend/cmd/api/internal/controller/users.go
+++ b/backend/cmd/api/internal/controller/users.go
@@ -151,6 +151,12 @@ func SaveUser(w http.ResponseWriter, r *http.Request) {
 		user.UserID = v
 	}
 
+	// access_expires_at is owned exclusively by the System Delegate flow
+	// (AddSystemDelegate / SetDelegateExpiry, #467). Regular users never expire,
+	// so blank any client-supplied value here; otherwise a body carrying
+	// access_expires_at would let this admin path set an expiry on a non-delegate.
+	user.AccessExpiresAt = nil
+
 	// Tier escalation guard: the acting admin may not assign a role above their
 	// own authority (an OPDIV_ADMIN can't mint HHS/OWNER tiers, etc.).
 	if user.Role != "" && !authdUser.CanAssignRole(user.Role) {

--- a/backend/cmd/api/internal/migrations/0049opdivsystemdelegateflag.go
+++ b/backend/cmd/api/internal/migrations/0049opdivsystemdelegateflag.go
@@ -1,0 +1,24 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add opdivs.system_delegate_enabled toggle (default off, opt-in per OpDiv)",
+		`
+-- The System Delegate self-service capability (ISSO#467) is enabled per OpDiv
+-- via the "Add System Delegate Role" toggle on the Manage OpDivs panel. Persist
+-- it as a per-OpDiv flag rather than hardcoding any OpDiv (e.g. code='CMS'), so
+-- turning the capability on for an OpDiv is a single write from the panel and no
+-- OpDiv is special-cased in the code path.
+--
+-- Defaults FALSE: the capability is opt-in, so no OpDiv can have System Delegates
+-- added until an HHS admin / Owner explicitly enables it. NOT NULL keeps the add-
+-- flow gate a simple boolean check (no three-valued logic). IF NOT EXISTS for
+-- idempotent retry.
+
+ALTER TABLE public.opdivs
+    ADD COLUMN IF NOT EXISTS system_delegate_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+        `,
+		`
+ALTER TABLE public.opdivs DROP COLUMN IF EXISTS system_delegate_enabled;
+        `)
+}

--- a/backend/cmd/api/internal/migrations/0050usersaccessexpiry.go
+++ b/backend/cmd/api/internal/migrations/0050usersaccessexpiry.go
@@ -1,0 +1,22 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"add users.access_expires_at for System Delegate expiry (nullable, null = never)",
+		`
+-- System Delegate accounts (ISSO#467) carry a mandatory expiration set at the
+-- ISSO add flow. Enforcement is lazy and authoritative in the auth middleware
+-- (the same place soft-deleted users are rejected): a row with
+-- access_expires_at < now() is denied access, no scheduled job required.
+--
+-- Nullable with no default: regular (non-delegate) users stay NULL and never
+-- expire. Only the delegate add/renew paths set it. IF NOT EXISTS for idempotent
+-- retry.
+
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS access_expires_at TIMESTAMP WITH TIME ZONE;
+        `,
+		`
+ALTER TABLE public.users DROP COLUMN IF EXISTS access_expires_at;
+        `)
+}

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -63,6 +63,15 @@ func Handler() http.Handler {
 	// returns a list of data calls that this fisma system has marked complete
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/datacalls", controller.ListFismaSystemDataCalls).Methods("GET")
 
+	// System Delegate self-service (#467): ISSO-reachable add/remove/renew, scoped
+	// to the system in the path. Not behind the admin-only user write paths.
+	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/delegates", controller.ListSystemDelegates).Methods("GET")
+	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/delegates", controller.AddSystemDelegate).Methods("POST")
+	// Existing delegates eligible to attach to this system (FE attach picker, #598).
+	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/delegate-candidates", controller.ListDelegateCandidates).Methods("GET")
+	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/delegates/{userid:"+userIdPattern+"}", controller.RemoveSystemDelegate).Methods("DELETE")
+	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/delegates/{userid:"+userIdPattern+"}", controller.RenewSystemDelegate).Methods("PATCH")
+
 	// TODO: deprecate this in favor of non-nested URIs
 	router.HandleFunc("/api/v1/fismasystems/{fismasystemid:[0-9]+}/questions", controller.ListFismaSystemQuestions).Methods("GET")
 
@@ -71,6 +80,8 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/opdivs", controller.ListOpDivs).Methods("GET")
 	router.HandleFunc("/api/v1/opdivs", controller.SaveOpDiv).Methods("POST")
 	router.HandleFunc("/api/v1/opdivs/{opdiv_id:[0-9]+}", controller.SaveOpDiv).Methods("PUT")
+	// "Add System Delegate Role" per-OpDiv toggle (#467); Owner + HHS admin only.
+	router.HandleFunc("/api/v1/opdivs/{opdiv_id:[0-9]+}/system-delegate-enabled", controller.SetOpDivSystemDelegateEnabled).Methods("PUT")
 
 	router.HandleFunc("/api/v1/users", controller.ListUsers).Methods("GET")
 	router.HandleFunc("/api/v1/users", controller.SaveUser).Methods("POST")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -397,6 +397,143 @@ tests:
   # response templater cannot substitute the underscore-keyed opdiv_id from the
   # create response, so a capture-dependent PUT case is omitted here.
 
+  # System Delegate role toggle (#467, decision 7): Owner + HHS admin only. The
+  # CanWriteHHSWide gate runs before any DB work, so an OPDIV_ADMIN (though
+  # IsAdmin) and an ISSO are 403 regardless of the target OpDiv. opdiv_id 1 is a
+  # real seeded OpDiv, so the OWNER case actually updates and returns 200.
+  - url: http://localhost:8080/api/v1/opdivs/1/system-delegate-enabled
+    method: PUT
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        enabled: true
+    expect:
+      status: 403
+
+  - url: http://localhost:8080/api/v1/opdivs/1/system-delegate-enabled
+    method: PUT
+    headers:
+      <<: *opDivAdminHeaders
+      content-type: "application/json"
+    body:
+      json:
+        enabled: true
+    expect:
+      status: 403
+
+  - url: http://localhost:8080/api/v1/opdivs/1/system-delegate-enabled
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        enabled: true
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # System Delegate self-service (#467). Scope is anchored to the system in the
+  # path; a non-owner is 404 (not-leak). Death Star (1001, EMPIRE) has the
+  # capability enabled in the seed; the ISSO fixture (Isso.User) is assigned to
+  # Shield Gen (1003), not the Death Star.
+  #
+  # A delegate can never manage delegates, even on a system it is assigned to
+  # (the ISSO invariant): 404 rather than a 403 that would confirm the system.
+  - url: http://localhost:8080/api/v1/fismasystems/1001/delegates
+    method: POST
+    headers:
+      <<: *delegateHeaders
+      content-type: "application/json"
+    body:
+      json:
+        email: "should-not@matter.test"
+        fullname: "Nope"
+    expect:
+      status: 404
+
+  # An ISSO not assigned to the target system cannot see or manage its delegates.
+  - url: http://localhost:8080/api/v1/fismasystems/1001/delegates
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 404
+
+  - url: http://localhost:8080/api/v1/fismasystems/1001/delegates
+    method: POST
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        email: "new.delegate@empire.test"
+        fullname: "New Delegate"
+    expect:
+      status: 404
+
+  # An ISSO assigned to the system may list its delegates.
+  - url: http://localhost:8080/api/v1/fismasystems/1003/delegates
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  # Success-path sequence (must run in order): Isso.User is assigned to Shield Gen
+  # (1003, EMPIRE, capability enabled). Reuse.Delegate is a seeded EMPIRE delegate
+  # not yet on any system, so the ISSO can attach (201), renew (200), then remove
+  # (204). Uses the seeded delegate's fixed UUID so the PATCH/DELETE paths are known
+  # without capturing the POST response.
+  - url: http://localhost:8080/api/v1/fismasystems/1003/delegates
+    method: POST
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        email: "Reuse.Delegate@empire.test"
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+
+  - url: http://localhost:8080/api/v1/fismasystems/1003/delegates/5e1e6a7e-0000-4000-8000-000000000001
+    method: PATCH
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        access_expires_at: "2030-01-01T00:00:00Z"
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+
+  - url: http://localhost:8080/api/v1/fismasystems/1003/delegates/5e1e6a7e-0000-4000-8000-000000000001
+    method: DELETE
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 204
+
+  # Invariant: an ISSO can only ever affect SYSTEM_DELEGATE records. Isso.User is
+  # assigned to Shield Gen (1003), as is Director Krennic (an ISSO). Trying to
+  # remove a co-ISSO via the delegate endpoint must be 404 (target is not a
+  # delegate), not a 204 that would let an ISSO unassign a peer.
+  - url: http://localhost:8080/api/v1/fismasystems/1003/delegates/44444444-4444-4444-4444-444444444444
+    method: DELETE
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 404
+
   # DataCalls Endpoints
   - id: createDataCall
     url: http://localhost:8080/api/v1/datacalls

--- a/backend/internal/model/delegates_integration_test.go
+++ b/backend/internal/model/delegates_integration_test.go
@@ -1,0 +1,408 @@
+package model
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// System Delegate self-service (#467) against the empire seed. Death Star
+// (system 1001) is in the EMPIRE OpDiv, which _test_data_empire.sql enables for
+// the capability; REBELLION systems (1005) are left disabled. See the fixtures
+// block in _test_data_empire.sql for the seeded delegate rows used here.
+const (
+	deathStarID              int32 = 1001                                   // EMPIRE OpDiv, capability enabled
+	rebellionSystemID        int32 = 1005                                   // REBELLION OpDiv, capability disabled
+	delegateActorID                = "33333333-3333-3333-3333-333333333333" // Veers, ISSO assigned to Death Star
+	reuseDelegateEmail             = "Reuse.Delegate@empire.test"           // delegate in EMPIRE, no system yet
+	wrongOpDivDelegateEmail        = "Wrong.Opdiv.Delegate@rebellion.test"  // delegate in REBELLION
+	existingNonDelegateEmail       = "Admiral.Piett@executor.empire"        // an ISSO, not a delegate
+	newPersonEmail                 = "Newbie.Delegate@empire.test"          // created/removed by the new-person test
+)
+
+// loadSysOpDiv mirrors the controller: resolve the system and its OpDiv so the
+// model add flow can be driven exactly as production drives it.
+func loadSysOpDiv(t *testing.T, ctx context.Context, id int32) (*FismaSystem, *OpDiv) {
+	t.Helper()
+	sys, err := FindFismaSystem(ctx, FindFismaSystemsInput{FismaSystemID: &id})
+	require.NoError(t, err)
+	require.NotNil(t, sys)
+	require.NotNil(t, sys.OpDivID)
+	opdiv, err := FindOpDivByID(ctx, *sys.OpDivID)
+	require.NoError(t, err)
+	require.NotNil(t, opdiv)
+	return sys, opdiv
+}
+
+func hardDeleteUserByEmail(t *testing.T, email string) {
+	t.Helper()
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer conn.Release()
+	// users_opdivs / users_fismasystems cascade on the FK; events reference the
+	// actor, not this user, so they are left intact.
+	_, err = conn.Exec(context.Background(), "DELETE FROM users WHERE LOWER(email)=LOWER($1)", email)
+	require.NoError(t, err)
+}
+
+func TestAddSystemDelegate_NewPersonIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	hardDeleteUserByEmail(t, newPersonEmail)
+	t.Cleanup(func() { hardDeleteUserByEmail(t, newPersonEmail) })
+
+	sys, opdiv := loadSysOpDiv(t, ctx, deathStarID)
+
+	created, err := AddSystemDelegate(ctx, sys, opdiv, delegateActorID, newPersonEmail, "Newbie Delegate", nil)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	assert.Equal(t, "SYSTEM_DELEGATE", created.Role, "new person is minted as a delegate")
+	assert.Equal(t, "entra", created.IdentityProvider, "EMPIRE (non-CMS) derives entra")
+	require.NotNil(t, created.AccessExpiresAt, "delegate must have an expiry")
+	assert.True(t, created.AccessExpiresAt.After(time.Now()), "default expiry is in the future")
+
+	// The delegate now holds the system's OpDiv and the system assignment.
+	full, err := FindUserByID(ctx, created.UserID)
+	require.NoError(t, err)
+	assert.True(t, full.IsAssignedOpDiv(*sys.OpDivID), "delegate inherits the system's OpDiv")
+	assert.True(t, full.IsAssignedFismaSystem(deathStarID), "delegate is assigned to the system")
+}
+
+func TestAddSystemDelegate_ExistingEligibleAttachesOnlyIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	before, err := FindUserByEmail(ctx, reuseDelegateEmail)
+	require.NoError(t, err)
+	// Clean up just the assignment this test creates, leaving the seeded user.
+	t.Cleanup(func() {
+		uf := &UserFismaSystem{UserID: before.UserID, FismaSystemID: deathStarID}
+		_ = uf.Delete(context.Background())
+	})
+
+	sys, opdiv := loadSysOpDiv(t, ctx, deathStarID)
+
+	got, err := AddSystemDelegate(ctx, sys, opdiv, delegateActorID, reuseDelegateEmail, "", nil)
+	require.NoError(t, err, "an existing eligible delegate attaches without error")
+	require.NotNil(t, got)
+
+	// Assignment added; role, OpDiv, and expiry untouched (expiry stays nil).
+	assert.Nil(t, got.AccessExpiresAt, "attach must not set an expiry on an existing delegate")
+	full, err := FindUserByID(ctx, before.UserID)
+	require.NoError(t, err)
+	assert.True(t, full.IsAssignedFismaSystem(deathStarID))
+	assert.Equal(t, "SYSTEM_DELEGATE", full.Role)
+}
+
+func TestAddSystemDelegate_RejectionsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	sys, opdiv := loadSysOpDiv(t, ctx, deathStarID)
+
+	t.Run("existing delegate in a different OpDiv is admin-required", func(t *testing.T) {
+		_, err := AddSystemDelegate(ctx, sys, opdiv, delegateActorID, wrongOpDivDelegateEmail, "", nil)
+		assert.ErrorIs(t, err, ErrDelegateRequiresAdmin)
+	})
+
+	t.Run("existing non-delegate is admin-required", func(t *testing.T) {
+		_, err := AddSystemDelegate(ctx, sys, opdiv, delegateActorID, existingNonDelegateEmail, "", nil)
+		assert.ErrorIs(t, err, ErrDelegateRequiresAdmin)
+	})
+
+	t.Run("capability off for the OpDiv is refused", func(t *testing.T) {
+		rebSys, rebOpDiv := loadSysOpDiv(t, ctx, rebellionSystemID)
+		_, err := AddSystemDelegate(ctx, rebSys, rebOpDiv, delegateActorID, "someone.new@rebellion.test", "New", nil)
+		assert.ErrorIs(t, err, ErrDelegatesNotEnabled)
+	})
+}
+
+// A new person must supply a name (the AC collects "Name and Email"), and the
+// fullname column is NOT NULL. An empty name is rejected before any write.
+func TestAddSystemDelegate_NewPersonMissingName_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	sys, opdiv := loadSysOpDiv(t, ctx, deathStarID)
+
+	const email = "noname.delegate@empire.test"
+	hardDeleteUserByEmail(t, email)
+	t.Cleanup(func() { hardDeleteUserByEmail(t, email) })
+
+	_, err := AddSystemDelegate(ctx, sys, opdiv, delegateActorID, email, "   ", nil)
+	var iie *InvalidInputError
+	assert.ErrorAs(t, err, &iie, "a blank name must be rejected")
+
+	// And nothing was created.
+	_, ferr := FindUserByEmail(ctx, email)
+	assert.ErrorIs(t, ferr, ErrNoData, "no user should be created when the name is missing")
+}
+
+func TestSetDelegateExpiry_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	reuse, err := FindUserByEmail(ctx, reuseDelegateEmail)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Restore the seeded null expiry so this test is repeatable.
+		conn, _ := db.Conn(context.Background())
+		if conn != nil {
+			defer conn.Release()
+			_, _ = conn.Exec(context.Background(), "UPDATE users SET access_expires_at=NULL WHERE userid=$1", reuse.UserID)
+		}
+	})
+
+	future := time.Now().AddDate(0, 6, 0)
+	updated, err := SetDelegateExpiry(ctx, reuse.UserID, &future)
+	require.NoError(t, err)
+	require.NotNil(t, updated.AccessExpiresAt)
+	assert.WithinDuration(t, future, *updated.AccessExpiresAt, time.Second)
+
+	// A non-delegate userid matches no row (role predicate) -> ErrNoData.
+	piett, err := FindUserByEmail(ctx, existingNonDelegateEmail)
+	require.NoError(t, err)
+	_, err = SetDelegateExpiry(ctx, piett.UserID, &future)
+	assert.ErrorIs(t, err, ErrNoData, "must not set an expiry on a non-delegate")
+}
+
+func TestFindDelegatesByFismaSystem_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	delegates, err := FindDelegatesByFismaSystem(ctx, deathStarID)
+	require.NoError(t, err)
+	// The seed assigns the System Delegate Test User (5555...) to Death Star.
+	found := false
+	for _, d := range delegates {
+		assert.Equal(t, "SYSTEM_DELEGATE", d.Role, "only delegates are returned")
+		if d.UserID == "55555555-5555-4555-8555-555555555555" {
+			found = true
+		}
+	}
+	assert.True(t, found, "the seeded Death Star delegate must be listed")
+}
+
+func TestFindDelegateCandidatesForSystem_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	sys, _ := loadSysOpDiv(t, ctx, deathStarID)
+
+	candidates, err := FindDelegateCandidatesForSystem(ctx, deathStarID, *sys.OpDivID, "")
+	require.NoError(t, err)
+
+	emails := map[string]bool{}
+	for _, c := range candidates {
+		assert.Equal(t, "SYSTEM_DELEGATE", c.Role, "only delegates are candidates")
+		assert.False(t, c.Deleted, "deleted users are not candidates")
+		emails[c.Email] = true
+	}
+
+	// Reuse.Delegate is an EMPIRE delegate not yet on Death Star -> eligible.
+	assert.True(t, emails[reuseDelegateEmail], "an eligible unassigned EMPIRE delegate must be a candidate")
+	// The seeded Death Star delegate is already assigned -> excluded.
+	assert.False(t, emails["Delegate.User@nowhere.xyz"], "an already-assigned delegate must not be a candidate")
+	// Wrong.Opdiv.Delegate is in REBELLION, not EMPIRE -> excluded.
+	assert.False(t, emails[wrongOpDivDelegateEmail], "a delegate in a different OpDiv must not be a candidate")
+
+	// The q filter narrows by name/email substring.
+	filtered, err := FindDelegateCandidatesForSystem(ctx, deathStarID, *sys.OpDivID, "reuse")
+	require.NoError(t, err)
+	for _, c := range filtered {
+		assert.Contains(t, strings.ToLower(c.Email+" "+c.FullName), "reuse", "q must filter to matching rows")
+	}
+}
+
+// Re-roling a delegate away from SYSTEM_DELEGATE must clear its access_expires_at
+// so the stale expiry can never lock out the now-regular user (#467, AC "regular
+// users never expire").
+func TestSaveUser_ClearsExpiryOnReRole_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	const email = "rerole.delegate@empire.test"
+	hardDeleteUserByEmail(t, email)
+	t.Cleanup(func() { hardDeleteUserByEmail(t, email) })
+
+	sys, opdiv := loadSysOpDiv(t, ctx, deathStarID)
+	created, err := AddSystemDelegate(ctx, sys, opdiv, delegateActorID, email, "Re-role Delegate", nil)
+	require.NoError(t, err)
+	require.NotNil(t, created.AccessExpiresAt, "delegate starts with an expiry")
+
+	// Admin re-roles the delegate to ISSO via Save (the update path).
+	created.Role = "ISSO"
+	updated, err := created.Save(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, updated.AccessExpiresAt, "re-role away from delegate must clear the expiry")
+	assert.False(t, updated.IsExpired(), "a re-roled user is never expired")
+
+	// Confirm it persisted (not just the RETURNING row).
+	reloaded, err := FindUserByID(ctx, created.UserID)
+	require.NoError(t, err)
+	assert.Nil(t, reloaded.AccessExpiresAt, "cleared expiry must persist")
+}
+
+// The admin user path (Save) must uphold the delegate expiry invariant (#467):
+// a SYSTEM_DELEGATE always carries a non-null expiry, every other role is null,
+// and an edit that keeps the delegate role must not disturb a renewed expiry.
+func TestSaveUser_DelegateExpiryInvariant_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	const delEmail = "admin.created.delegate@empire.test"
+	const regEmail = "admin.created.regular@empire.test"
+	for _, e := range []string{delEmail, regEmail} {
+		hardDeleteUserByEmail(t, e)
+	}
+	t.Cleanup(func() {
+		for _, e := range []string{delEmail, regEmail} {
+			hardDeleteUserByEmail(t, e)
+		}
+	})
+
+	// Admin-created delegate gets a default expiry (not NULL).
+	created, err := (&User{Email: delEmail, FullName: "Admin Created", Role: "SYSTEM_DELEGATE"}).Save(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, created.AccessExpiresAt, "admin-created delegate must default an expiry")
+	assert.True(t, created.AccessExpiresAt.After(time.Now()))
+
+	// Non-delegate stays NULL.
+	reg, err := (&User{Email: regEmail, FullName: "Admin Regular", Role: "ISSO"}).Save(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, reg.AccessExpiresAt, "a non-delegate must never carry an expiry")
+
+	// Promoting a regular user to delegate defaults an expiry.
+	reg.Role = "SYSTEM_DELEGATE"
+	promoted, err := reg.Save(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, promoted.AccessExpiresAt, "promotion to delegate must default an expiry")
+
+	// A renewed expiry survives an unrelated edit (name change) - COALESCE preserves it.
+	renewed := time.Now().AddDate(1, 0, 0) // +1yr, distinct from the +3mo default
+	_, err = SetDelegateExpiry(ctx, created.UserID, &renewed)
+	require.NoError(t, err)
+	created.FullName = "Renamed Delegate"
+	edited, err := created.Save(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, edited.AccessExpiresAt)
+	assert.WithinDuration(t, renewed, *edited.AccessExpiresAt, time.Second, "editing a delegate must preserve its renewed expiry")
+
+	// Demoting a delegate clears the expiry.
+	created.Role = "ISSO"
+	demoted, err := created.Save(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, demoted.AccessExpiresAt, "demotion from delegate clears the expiry")
+}
+
+// A soft-deleted delegate cannot be renewed (deleted=false predicate).
+func TestSetDelegateExpiry_SoftDeletedRejected_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	const email = "softdel.delegate@empire.test"
+	hardDeleteUserByEmail(t, email)
+	t.Cleanup(func() { hardDeleteUserByEmail(t, email) })
+
+	created, err := (&User{Email: email, FullName: "SoftDel Delegate", Role: "SYSTEM_DELEGATE"}).Save(ctx)
+	require.NoError(t, err)
+	require.NoError(t, DeleteUser(ctx, created.UserID))
+
+	future := time.Now().AddDate(0, 3, 0)
+	_, err = SetDelegateExpiry(ctx, created.UserID, &future)
+	assert.ErrorIs(t, err, ErrNoData, "renewing a soft-deleted delegate must be rejected")
+}
+
+// Today the system_delegate_enabled capability is written through
+// SetOpDivSystemDelegateEnabled (Owner + HHS admin); OpDiv.Save deliberately leaves
+// it alone, so a body carrying the flag through create or update is ignored (#467
+// review - keeps the write gate in one place). If we later decide Save should also
+// manage it, update this test to match the new policy.
+func TestSaveOpDiv_IgnoresSystemDelegateEnabled_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	const code = "SDLTEST"
+	del := func() {
+		conn, err := db.Conn(context.Background())
+		require.NoError(t, err)
+		defer conn.Release()
+		_, _ = conn.Exec(context.Background(), "DELETE FROM opdivs WHERE code=$1", code)
+	}
+	del()
+	t.Cleanup(del)
+
+	enabled := true
+
+	// Create with the flag set in the body -> ignored, defaults to false.
+	created, err := (&OpDiv{Code: code, Name: "SDL Test OpDiv", SystemDelegateEnabled: &enabled}).Save(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, created.SystemDelegateEnabled)
+	assert.False(t, *created.SystemDelegateEnabled, "Save must not set system_delegate_enabled on create")
+
+	// Update with the flag set in the body -> still ignored.
+	created.Name = "SDL Test OpDiv (edited)"
+	created.SystemDelegateEnabled = &enabled
+	updated, err := created.Save(ctx)
+	require.NoError(t, err)
+	assert.False(t, *updated.SystemDelegateEnabled, "Save must not set system_delegate_enabled on update")
+
+	// The dedicated setter does change it.
+	toggled, err := SetOpDivSystemDelegateEnabled(ctx, created.OpDivID, true)
+	require.NoError(t, err)
+	require.NotNil(t, toggled.SystemDelegateEnabled)
+	assert.True(t, *toggled.SystemDelegateEnabled, "the dedicated setter updates the flag")
+}
+
+func TestSetOpDivSystemDelegateEnabled_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	// REBELLION starts disabled; flip it on then back off.
+	rebSys, rebOpDiv := loadSysOpDiv(t, ctx, rebellionSystemID)
+	require.NotNil(t, rebOpDiv.SystemDelegateEnabled)
+	require.False(t, *rebOpDiv.SystemDelegateEnabled, "REBELLION starts disabled")
+	opdivID := *rebSys.OpDivID
+
+	t.Cleanup(func() {
+		_, _ = SetOpDivSystemDelegateEnabled(context.Background(), opdivID, false)
+	})
+
+	on, err := SetOpDivSystemDelegateEnabled(ctx, opdivID, true)
+	require.NoError(t, err)
+	require.NotNil(t, on.SystemDelegateEnabled)
+	assert.True(t, *on.SystemDelegateEnabled)
+
+	off, err := SetOpDivSystemDelegateEnabled(ctx, opdivID, false)
+	require.NoError(t, err)
+	require.NotNil(t, off.SystemDelegateEnabled)
+	assert.False(t, *off.SystemDelegateEnabled)
+}

--- a/backend/internal/model/errors.go
+++ b/backend/internal/model/errors.go
@@ -19,6 +19,16 @@ var (
 	ErrNoReference  = errors.New("reference not found")
 	ErrPastDeadline = errors.New("deadline has passed")
 	ErrNotesTooLong = errors.New("notes exceed maximum length of 2000 characters")
+	// ErrDelegatesNotEnabled is returned when the System Delegate add flow targets
+	// a system whose OpDiv has the "Add System Delegate Role" capability off (#467).
+	// Mapped to 403 in the controller's sanitizeErr.
+	ErrDelegatesNotEnabled = errors.New("system delegate role is not enabled for this opdiv")
+	// ErrDelegateRequiresAdmin is returned when the ISSO add flow is given an
+	// existing email it cannot self-serve (a non-delegate, a delegate in a
+	// different OpDiv, or a soft-deleted account). The controller maps it to a
+	// machine-readable code so the FE can branch to "an administrator must handle
+	// this user" copy rather than string-matching (#467).
+	ErrDelegateRequiresAdmin = errors.New("this user must be added by an administrator")
 )
 
 type InvalidInputError struct {

--- a/backend/internal/model/opdivs.go
+++ b/backend/internal/model/opdivs.go
@@ -25,6 +25,12 @@ type OpDiv struct {
 	// an update that omits it must leave the column untouched, not reset it to
 	// false (which would silently disable enrichment for an enabled OpDiv).
 	InsightsEnabled *bool `json:"insights_enabled" db:"insights_enabled"`
+	// SystemDelegateEnabled gates the ISSO System Delegate self-service capability
+	// (#467) for systems in this OpDiv: the "Add System Delegate Role" toggle on
+	// the Manage OpDivs panel. Pointer for the same reason as the flags above.
+	// Only Owner / HHS admin may set it (see SetOpDivSystemDelegateEnabled and the
+	// controller gate); the ISSO add flow is refused when it is false.
+	SystemDelegateEnabled *bool `json:"system_delegate_enabled" db:"system_delegate_enabled"`
 }
 
 // FindOpDivsInput holds optional filters for listing OpDivs.
@@ -37,7 +43,7 @@ type FindOpDivsInput struct {
 // and by the onboarding workbook importer to validate opdiv codes.
 func FindOpDivs(ctx context.Context, input FindOpDivsInput) ([]*OpDiv, error) {
 	sqlb := stmntBuilder.
-		Select("opdiv_id", "code", "name", "is_parent", "active", "insights_enabled").
+		Select("opdiv_id", "code", "name", "is_parent", "active", "insights_enabled", "system_delegate_enabled").
 		From("public.opdivs").
 		OrderBy("(NOT is_parent), code")
 
@@ -85,14 +91,18 @@ func (o *OpDiv) Save(ctx context.Context) (*OpDiv, error) {
 	var sqlb SqlBuilder
 	if o.OpDivID == 0 {
 		// Create: a new OpDiv is always active; is_parent and insights_enabled
-		// default to false when the optional fields are omitted.
+		// default to false when the optional fields are omitted. system_delegate_enabled
+		// is left to its migration default (false) and, for now, set through
+		// SetOpDivSystemDelegateEnabled (the Owner + HHS admin toggle, #467) so the
+		// capability's write gate stays in one place. Current product decision, not a
+		// hard rule - revisit if Save should manage it too.
 		isParent := o.IsParent != nil && *o.IsParent
 		insightsEnabled := o.InsightsEnabled != nil && *o.InsightsEnabled
 		sqlb = stmntBuilder.
 			Insert("public.opdivs").
 			Columns("code", "name", "is_parent", "active", "insights_enabled").
 			Values(o.Code, o.Name, isParent, true, insightsEnabled).
-			Suffix("RETURNING opdiv_id, code, name, is_parent, active, insights_enabled")
+			Suffix("RETURNING opdiv_id, code, name, is_parent, active, insights_enabled, system_delegate_enabled")
 	} else {
 		ub := stmntBuilder.
 			Update("public.opdivs").
@@ -110,9 +120,13 @@ func (o *OpDiv) Save(ctx context.Context) (*OpDiv, error) {
 		if o.InsightsEnabled != nil {
 			ub = ub.Set("insights_enabled", *o.InsightsEnabled)
 		}
+		// system_delegate_enabled is not set here for now: the capability toggle is
+		// written through SetOpDivSystemDelegateEnabled (Owner + HHS admin, #467) so
+		// its write gate stays in one place. Current product decision - revisit if
+		// Save should manage it too.
 		sqlb = ub.
 			Where("opdiv_id=?", o.OpDivID).
-			Suffix("RETURNING opdiv_id, code, name, is_parent, active, insights_enabled")
+			Suffix("RETURNING opdiv_id, code, name, is_parent, active, insights_enabled, system_delegate_enabled")
 	}
 
 	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByName[OpDiv])
@@ -126,4 +140,30 @@ func (o *OpDiv) Save(ctx context.Context) (*OpDiv, error) {
 		return nil, err
 	}
 	return saved, nil
+}
+
+// FindOpDivByID returns a single OpDiv by id, including its capability flags.
+// Used by the System Delegate add flow to read the request system's OpDiv code
+// (for identity-provider derivation) and its system_delegate_enabled toggle.
+func FindOpDivByID(ctx context.Context, opdivID int32) (*OpDiv, error) {
+	sqlb := stmntBuilder.
+		Select("opdiv_id", "code", "name", "is_parent", "active", "insights_enabled", "system_delegate_enabled").
+		From("public.opdivs").
+		Where("opdiv_id=?", opdivID)
+
+	return queryRow(ctx, sqlb, pgx.RowToStructByName[OpDiv])
+}
+
+// SetOpDivSystemDelegateEnabled flips the per-OpDiv "Add System Delegate Role"
+// toggle (#467 decisions 6 and 7). It is intentionally separate from Save (which
+// is OWNER-only, tenant-boundary) so the controller can gate it to Owner + HHS
+// admin without widening Save. Audited automatically via queryRow.
+func SetOpDivSystemDelegateEnabled(ctx context.Context, opdivID int32, enabled bool) (*OpDiv, error) {
+	sqlb := stmntBuilder.
+		Update("public.opdivs").
+		Set("system_delegate_enabled", enabled).
+		Where("opdiv_id=?", opdivID).
+		Suffix("RETURNING opdiv_id, code, name, is_parent, active, insights_enabled, system_delegate_enabled")
+
+	return queryRow(ctx, sqlb, pgx.RowToStructByName[OpDiv])
 }

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -18,6 +20,11 @@ type User struct {
 	IdentityProvider     string   `json:"identity_provider" db:"identity_provider"`
 	AssignedFismaSystems []*int32 `json:"-"`
 	AssignedOpDivIDs     []*int32 `json:"assignedopdivids" db:"assignedopdivids"`
+	// AccessExpiresAt is the System Delegate expiry (#467). Null for every non-
+	// delegate user (they never expire). A delegate whose AccessExpiresAt is in
+	// the past is denied at authentication (see IsExpired and the auth middleware),
+	// while the row and its assignments are retained for renewal and audit.
+	AccessExpiresAt *time.Time `json:"access_expires_at" db:"access_expires_at"`
 }
 
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
@@ -114,6 +121,38 @@ func (u *User) HasAdminRead() bool {
 // add the same guard there AND a row to TestSystemDelegate_ForbiddenNonAnswerSurfaces
 // (controller/authorization_test.go) so the invariant fails loudly when next touched.
 func (u *User) IsSystemDelegate() bool { return u.Role == "SYSTEM_DELEGATE" }
+
+// IsExpired reports whether a System Delegate's access has lapsed (#467). Only a
+// SYSTEM_DELEGATE can expire: the role gate is defense-in-depth so that a stale
+// access_expires_at left on a user who was re-roled away from delegate can never
+// lock out a now-regular user (Save also clears the column on that re-role). A
+// null expiry (every non-delegate, and a delegate with none) is never expired.
+// The auth middleware calls this to deny an expired delegate via the same
+// rejection path as a soft-deleted user, without deleting the row.
+func (u *User) IsExpired() bool {
+	return u.IsSystemDelegate() && u.AccessExpiresAt != nil && u.AccessExpiresAt.Before(time.Now())
+}
+
+// CanWriteHHSWide is the gate for HHS-wide write actions that an OPDIV_ADMIN must
+// NOT reach even though IsAdmin() includes them - currently the per-OpDiv "Add
+// System Delegate Role" toggle, which only Owner and HHS admin may set (#467
+// decision 7).
+func (u *User) CanWriteHHSWide() bool {
+	return u.Role == "OWNER" || u.Role == "HHS_ADMIN"
+}
+
+// CanManageSystemDelegates reports whether this user may add/remove/renew System
+// Delegates on the given system (#467). An admin who can manage the system passes
+// (OWNER/HHS_ADMIN unscoped; OPDIV_ADMIN only in their OpDiv). Among non-admins,
+// only an ISSO assigned to that system qualifies - ISSM is excluded (decision 5)
+// and a SYSTEM_DELEGATE never qualifies, so a delegate cannot mint other
+// delegates even though it is assigned to the system.
+func (u *User) CanManageSystemDelegates(fismasystemID int32, opdivID *int32) bool {
+	if u.CanManageFismaSystem(opdivID) {
+		return true
+	}
+	return u.Role == "ISSO" && u.IsAssignedFismaSystem(fismasystemID)
+}
 
 // IsAssignedOpDiv reports whether the user has a grant in users_opdivs for
 // the given OpDiv id. Used in scope predicates that need to confirm an
@@ -248,23 +287,47 @@ func (u *User) Save(ctx context.Context) (*User, error) {
 		if idp == "" {
 			idp = "okta"
 		}
+		// Invariant: a SYSTEM_DELEGATE always carries an expiry (#467). The ISSO
+		// self-service flow sets its own via AddSystemDelegate; this covers the admin
+		// create path, defaulting to three months when none was supplied. Every other
+		// role stays whatever was passed - the controller blanks it to NULL - so
+		// non-delegates never expire.
+		exp := u.AccessExpiresAt
+		if u.Role == "SYSTEM_DELEGATE" && exp == nil {
+			d := defaultDelegateExpiry()
+			exp = &d
+		}
 		sqlb = stmntBuilder.
 			Insert("users").
-			Columns("email", "fullname", "role", "identity_provider").
-			Values(u.Email, u.FullName, u.Role, idp).
-			Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider")
+			Columns("email", "fullname", "role", "identity_provider", "access_expires_at").
+			Values(u.Email, u.FullName, u.Role, idp, exp).
+			Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at")
 	} else {
 		// identity_provider is intentionally not updatable through Save() in
 		// Stage C. A user's IdP is set at provisioning time and only changes
 		// through a deliberate admin action that does not exist yet. When
 		// that path lands (Stage C+) it will be a separate model function.
-		sqlb = stmntBuilder.
+		//
+		// access_expires_at upholds the delegate invariant (#467): a SYSTEM_DELEGATE
+		// always keeps a non-null expiry, every other role is null. COALESCE preserves
+		// a delegate's current expiry (so an unrelated name/email edit does not disturb
+		// a renewed date) and defaults to three months only when there is none - e.g.
+		// an admin promoting a regular user to delegate. Explicit expiry changes go
+		// through SetDelegateExpiry (renew). Re-roling a delegate to any other tier
+		// clears the stale value so IsExpired can never lock out a now-regular user.
+		ub := stmntBuilder.
 			Update("users").
 			Set("email", u.Email).
 			Set("fullname", u.FullName).
-			Set("role", u.Role).
+			Set("role", u.Role)
+		if u.Role == "SYSTEM_DELEGATE" {
+			ub = ub.Set("access_expires_at", squirrel.Expr("COALESCE(access_expires_at, ?)", defaultDelegateExpiry()))
+		} else {
+			ub = ub.Set("access_expires_at", nil)
+		}
+		sqlb = ub.
 			Where("userid=?", u.UserID).
-			Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider")
+			Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at")
 	}
 
 	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
@@ -360,6 +423,7 @@ func FindUsers(ctx context.Context, fui *FindUsersInput) ([]*User, error) {
 			"users.role",
 			"users.deleted",
 			"users.identity_provider",
+			"users.access_expires_at",
 			"(SELECT ARRAY_AGG(opdiv_id) FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids",
 		).
 		From("public.users").
@@ -418,6 +482,7 @@ func findUser(ctx context.Context, where string, args []any) (*User, error) {
 			"users.role",
 			"users.deleted",
 			"users.identity_provider",
+			"users.access_expires_at",
 			"(SELECT ARRAY_AGG(fismasystemid) FROM users_fismasystems WHERE userid = users.userid) AS assignedfismasystems",
 			"(SELECT ARRAY_AGG(opdiv_id)      FROM users_opdivs       WHERE userid = users.userid) AS assignedopdivids",
 		).
@@ -511,4 +576,273 @@ func RestoreUser(ctx context.Context, userid string) (*User, error) {
 		return nil, trapError(err)
 	}
 	return &restored, nil
+}
+
+// SetDelegateExpiry sets a System Delegate's access_expires_at (the PATCH/renew
+// path, #467). expiresAt is optional and defaults to three months out, matching
+// the add flow; a past date is rejected. The role predicate in the WHERE makes
+// it impossible to set an expiry on a non-delegate user: a non-delegate (or
+// missing) userid matches no row, RETURNING is empty, and queryRow surfaces
+// ErrNoData (the controller maps that to 404). Audited automatically via queryRow.
+//
+// Scope note (accepted per the epic's per-user-expiry decision): access_expires_at
+// is a single per-user column, so renewing a delegate assigned to more than one
+// system changes their access everywhere, even for systems in OpDivs the acting
+// ISSO does not manage. Multi-OpDiv delegates only arise via an admin grant (self-
+// service only ever grants the system's own OpDiv), and the target is a low-
+// privilege contractor account. Revisit if delegates become per-assignment-scoped
+// (would move this column to users_fismasystems); flagged for the post-data-call
+// role review.
+// defaultDelegateExpiry is the mandatory-expiry default window for System
+// Delegates (#467 decision 2): three months from now. Single source of the term
+// so the add, renew, and admin-Save paths cannot drift.
+func defaultDelegateExpiry() time.Time { return time.Now().AddDate(0, 3, 0) }
+
+// resolveDelegateExpiry applies the delegate expiry rule (#467): default to three
+// months when the caller supplies none, and reject a past date. Shared by the add
+// and renew paths.
+func resolveDelegateExpiry(expiresAt *time.Time) (time.Time, error) {
+	exp := defaultDelegateExpiry()
+	if expiresAt != nil {
+		exp = *expiresAt
+	}
+	if exp.Before(time.Now()) {
+		return time.Time{}, &InvalidInputError{data: map[string]any{"access_expires_at": "must be a future date"}}
+	}
+	return exp, nil
+}
+
+// identityProviderForOpDivCode returns the IdP a user in the given OpDiv routes
+// to: CMS is Okta, everything else Entra (#467). Mirrors the SQL rule in
+// deriveIdentityProvider (usersopdivs.go) for the transactional delegate-create
+// path, which cannot call that helper (it runs on its own connection) - keep the
+// two in sync.
+func identityProviderForOpDivCode(code string) string {
+	if code == "CMS" {
+		return "okta"
+	}
+	return "entra"
+}
+
+func SetDelegateExpiry(ctx context.Context, userid string, expiresAt *time.Time) (*User, error) {
+	if !isValidUUID(userid) {
+		return nil, ErrNoData
+	}
+
+	exp, err := resolveDelegateExpiry(expiresAt)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlb := stmntBuilder.
+		Update("users").
+		Set("access_expires_at", exp).
+		// deleted=false: never renew a soft-deleted delegate. A non-delegate, a
+		// missing id, or a soft-deleted row all match nothing -> ErrNoData -> 404.
+		Where("userid=? AND role='SYSTEM_DELEGATE' AND deleted=false", userid).
+		Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at")
+
+	return queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
+}
+
+// FindDelegatesByFismaSystem returns the SYSTEM_DELEGATE users assigned to a
+// system, for the delegates section on the system detail page (#467). Only the
+// delegate tier is returned - ISSO/ISSM assignees are not delegates and are
+// excluded by the role predicate.
+func FindDelegatesByFismaSystem(ctx context.Context, fismasystemid int32) ([]*User, error) {
+	sqlb := stmntBuilder.
+		Select(
+			"users.userid",
+			"users.email",
+			"users.fullname",
+			"users.role",
+			"users.deleted",
+			"users.identity_provider",
+			"users.access_expires_at",
+		).
+		From("users").
+		Join("users_fismasystems ufs ON ufs.userid = users.userid").
+		Where("ufs.fismasystemid=?", fismasystemid).
+		Where("users.role='SYSTEM_DELEGATE'").
+		OrderBy("users.fullname")
+
+	return query(ctx, sqlb, pgx.RowToAddrOfStructByNameLax[User])
+}
+
+// FindDelegateCandidatesForSystem returns the existing users an ISSO may attach
+// to a system through self-service (#467/#598): the eligibility set the add
+// flow's existing-user branch would accept. A candidate is a non-deleted
+// SYSTEM_DELEGATE that already holds the system's OpDiv and is NOT already
+// assigned to this system (nothing to add otherwise). The optional q filters by
+// email or full name (case-insensitive substring) so the FE picker can search.
+// The backend is the authority here, so the picker can offer exactly this set
+// and never has to reproduce the eligibility rule.
+func FindDelegateCandidatesForSystem(ctx context.Context, fismasystemid, opdivID int32, q string) ([]*User, error) {
+	sqlb := stmntBuilder.
+		Select(
+			"users.userid",
+			"users.email",
+			"users.fullname",
+			"users.role",
+			"users.deleted",
+			"users.identity_provider",
+			"users.access_expires_at",
+		).
+		From("users").
+		Where("users.role='SYSTEM_DELEGATE'").
+		Where("users.deleted=false").
+		Where("EXISTS (SELECT 1 FROM users_opdivs uo WHERE uo.userid=users.userid AND uo.opdiv_id=?)", opdivID).
+		Where("NOT EXISTS (SELECT 1 FROM users_fismasystems uf WHERE uf.userid=users.userid AND uf.fismasystemid=?)", fismasystemid)
+
+	if q = strings.TrimSpace(q); q != "" {
+		like := "%" + strings.ToLower(q) + "%"
+		sqlb = sqlb.Where("(LOWER(users.email) LIKE ? OR LOWER(users.fullname) LIKE ?)", like, like)
+	}
+
+	sqlb = sqlb.OrderBy("users.fullname")
+
+	return query(ctx, sqlb, pgx.RowToAddrOfStructByNameLax[User])
+}
+
+// AddSystemDelegate is the model half of the ISSO self-service add flow (#467).
+// The controller has already authorized the actor for the system and loaded the
+// system and its OpDiv; this function owns the add rules so the administrator-
+// required guidance (an InvalidInputError) is built in-package and the branch
+// logic is unit-testable. It never sets or changes an existing user's role or
+// OpDiv, and never assigns a role other than SYSTEM_DELEGATE.
+//
+//   - New person (email resolves to no user): create the delegate, grant the
+//     system's OpDiv (granted_by = actor), and assign the system, all in one
+//     transaction so a partial failure cannot strand an orphan user. identity_
+//     provider is derived by the same rule as deriveIdentityProvider (CMS => okta,
+//     else entra), computed inline because that helper runs on its own connection
+//     and cannot participate in this transaction.
+//   - Existing eligible delegate (already SYSTEM_DELEGATE and already holds the
+//     system's OpDiv): insert only the users_fismasystems assignment; do not touch
+//     role, OpDiv, or expiry (renewal is the separate PATCH path).
+//   - Every other existing-user case (soft-deleted, non-delegate, no OpDiv, or a
+//     different OpDiv): rejected with an administrator-required InvalidInputError.
+func AddSystemDelegate(ctx context.Context, sys *FismaSystem, opdiv *OpDiv, actorID, email, fullname string, expiresAt *time.Time) (*User, error) {
+	if opdiv == nil || opdiv.SystemDelegateEnabled == nil || !*opdiv.SystemDelegateEnabled {
+		return nil, ErrDelegatesNotEnabled
+	}
+	if sys == nil || sys.OpDivID == nil {
+		return nil, ErrNoData
+	}
+	if !isValidEmail(email) {
+		return nil, &InvalidInputError{data: map[string]any{"email": "a valid email is required"}}
+	}
+
+	// Mandatory expiry, default three months (#467 decisions 1 and 2). A past
+	// date is rejected rather than silently creating an already-locked-out account.
+	exp, err := resolveDelegateExpiry(expiresAt)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := FindUserByEmail(ctx, email)
+	if err != nil && !errors.Is(err, ErrNoData) {
+		return nil, err
+	}
+
+	if existing != nil {
+		// Existing user: self-service is permitted only for an already-provisioned
+		// delegate in the same OpDiv. Everything else is an administrator's job.
+		switch {
+		case existing.Deleted:
+			// Same generic sentinel as any other ineligible existing account: do not
+			// disclose to the ISSO that a soft-deleted account exists (#467 review).
+			// The branch stays separate from the default so a deleted delegate is
+			// never silently reattached by the eligible case below.
+			return nil, ErrDelegateRequiresAdmin
+		case existing.IsSystemDelegate() && existing.IsAssignedOpDiv(*sys.OpDivID):
+			uf := &UserFismaSystem{UserID: existing.UserID, FismaSystemID: sys.FismaSystemID}
+			if _, err := uf.Save(ctx); err != nil {
+				return nil, err
+			}
+			return existing, nil
+		default:
+			return nil, ErrDelegateRequiresAdmin
+		}
+	}
+
+	// New person: require a name and create the delegate atomically.
+	if strings.TrimSpace(fullname) == "" {
+		return nil, &InvalidInputError{data: map[string]any{"fullname": "a name is required for a new delegate"}}
+	}
+
+	idp := identityProviderForOpDivCode(opdiv.Code)
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, trapError(err)
+	}
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		conn.Release()
+		return nil, trapError(err)
+	}
+	defer func() {
+		tx.Rollback(ctx)
+		conn.Release()
+	}()
+
+	var created User
+	err = tx.QueryRow(ctx,
+		`INSERT INTO users (email, fullname, role, identity_provider, access_expires_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at`,
+		email, fullname, "SYSTEM_DELEGATE", idp, exp,
+	).Scan(&created.UserID, &created.Email, &created.FullName, &created.Role, &created.Deleted, &created.IdentityProvider, &created.AccessExpiresAt)
+	if err != nil {
+		e := trapError(err)
+		// A concurrent request may have created this email between the FindUserByEmail
+		// lookup above and this insert. Return the state-aware guidance rather than a
+		// bare "not unique" so the caller sees the same message the admin create path
+		// gives (the case-insensitive email unique index is the constraint hit).
+		if errors.Is(e, ErrNotUnique) {
+			return nil, &InvalidInputError{data: map[string]any{"email": "a user with this email already exists"}}
+		}
+		return nil, e
+	}
+
+	if _, err = tx.Exec(ctx,
+		"INSERT INTO users_opdivs (userid, opdiv_id, granted_by) VALUES ($1, $2, $3)",
+		created.UserID, *sys.OpDivID, actorID,
+	); err != nil {
+		return nil, trapError(err)
+	}
+
+	if _, err = tx.Exec(ctx,
+		"INSERT INTO users_fismasystems (userid, fismasystemid) VALUES ($1, $2)",
+		created.UserID, sys.FismaSystemID,
+	); err != nil {
+		return nil, trapError(err)
+	}
+
+	// Audit manually: the transaction bypasses queryRow's automatic recordEvent
+	// hook (same reason RestoreUser records by hand). One row per grant so the
+	// trail shows the delegate create, the OpDiv grant, and the system assignment.
+	uo := UserOpDiv{UserID: created.UserID, OpDivID: *sys.OpDivID, GrantedBy: &actorID}
+	uf := UserFismaSystem{UserID: created.UserID, FismaSystemID: sys.FismaSystemID}
+	for _, ev := range []struct {
+		resource string
+		payload  any
+	}{
+		{"users", created},
+		{"users_opdivs", uo},
+		{"users_fismasystems", uf},
+	} {
+		if _, err = tx.Exec(ctx,
+			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
+			actorID, "created", ev.resource, ev.payload,
+		); err != nil {
+			return nil, trapError(err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, trapError(err)
+	}
+	return &created, nil
 }

--- a/backend/internal/model/users_test.go
+++ b/backend/internal/model/users_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -355,3 +356,122 @@ func TestUser_Validate(t *testing.T) {
 		})
 	}
 }
+
+// --- System Delegate self-service (#467) ---
+
+func TestUser_IsExpired(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+	delegate := func(exp *time.Time) *User { return &User{Role: "SYSTEM_DELEGATE", AccessExpiresAt: exp} }
+
+	assert.False(t, (&User{}).IsExpired(), "nil expiry (regular user) is never expired")
+	assert.False(t, delegate(nil).IsExpired(), "delegate with nil expiry is not expired")
+	assert.False(t, delegate(&future).IsExpired(), "delegate with future expiry is not expired")
+	assert.True(t, delegate(&past).IsExpired(), "delegate with past expiry is expired")
+	// Role gate (defense-in-depth): a user re-roled away from delegate is never
+	// locked out by a stale expiry, even if the column was not yet cleared.
+	assert.False(t, (&User{Role: "ISSO", AccessExpiresAt: &past}).IsExpired(),
+		"a non-delegate with a stale past expiry must not be treated as expired")
+}
+
+func TestUser_CanWriteHHSWide(t *testing.T) {
+	for _, role := range []string{"OWNER", "HHS_ADMIN"} {
+		assert.True(t, (&User{Role: role}).CanWriteHHSWide(), role+" may set HHS-wide toggles")
+	}
+	for _, role := range []string{"HHS_READONLY_ADMIN", "OPDIV_ADMIN", "OPDIV_READONLY_ADMIN", "ISSO", "ISSM", "SYSTEM_DELEGATE", ""} {
+		assert.False(t, (&User{Role: role}).CanWriteHHSWide(), role+" may not set HHS-wide toggles")
+	}
+}
+
+func TestUser_CanManageSystemDelegates(t *testing.T) {
+	opdiv := int32(2)
+	other := int32(9)
+	sysID := int32(1)
+
+	tests := []struct {
+		name string
+		user *User
+		want bool
+	}{
+		{"OWNER unscoped", &User{Role: "OWNER"}, true},
+		{"HHS_ADMIN unscoped", &User{Role: "HHS_ADMIN"}, true},
+		{"OPDIV_ADMIN holding the system's OpDiv", &User{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{&opdiv}}, true},
+		{"OPDIV_ADMIN holding a different OpDiv", &User{Role: "OPDIV_ADMIN", AssignedOpDivIDs: []*int32{&other}}, false},
+		{"ISSO assigned to the system", &User{Role: "ISSO", AssignedFismaSystems: []*int32{&sysID}}, true},
+		{"ISSO not assigned", &User{Role: "ISSO"}, false},
+		{"ISSM assigned (excluded)", &User{Role: "ISSM", AssignedFismaSystems: []*int32{&sysID}}, false},
+		{"delegate assigned (excluded)", &User{Role: "SYSTEM_DELEGATE", AssignedFismaSystems: []*int32{&sysID}}, false},
+		{"HHS_READONLY_ADMIN", &User{Role: "HHS_READONLY_ADMIN"}, false},
+		{"OPDIV_READONLY_ADMIN with grant", &User{Role: "OPDIV_READONLY_ADMIN", AssignedOpDivIDs: []*int32{&opdiv}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.user.CanManageSystemDelegates(sysID, &opdiv))
+		})
+	}
+}
+
+// TestAddSystemDelegate_PreDBValidation covers the checks that run before any
+// database access, so they need no DB: the OpDiv capability gate, email
+// validation, and the mandatory future-expiry rule.
+func TestAddSystemDelegate_PreDBValidation(t *testing.T) {
+	opdivID := int32(2)
+	sys := &FismaSystem{FismaSystemID: 1, OpDivID: &opdivID}
+	enabled := &OpDiv{OpDivID: 2, Code: "REBELLION", SystemDelegateEnabled: boolPtr(true)}
+	disabled := &OpDiv{OpDivID: 2, Code: "REBELLION", SystemDelegateEnabled: boolPtr(false)}
+	past := time.Now().Add(-time.Hour)
+
+	t.Run("toggle off -> ErrDelegatesNotEnabled", func(t *testing.T) {
+		_, err := AddSystemDelegate(context.Background(), sys, disabled, adminUUID, "new@empire.test", "New", nil)
+		assert.ErrorIs(t, err, ErrDelegatesNotEnabled)
+	})
+
+	t.Run("invalid email -> InvalidInputError", func(t *testing.T) {
+		_, err := AddSystemDelegate(context.Background(), sys, enabled, adminUUID, "not-an-email", "New", nil)
+		var iie *InvalidInputError
+		assert.ErrorAs(t, err, &iie)
+	})
+
+	t.Run("past expiry -> InvalidInputError", func(t *testing.T) {
+		_, err := AddSystemDelegate(context.Background(), sys, enabled, adminUUID, "new@empire.test", "New", &past)
+		var iie *InvalidInputError
+		assert.ErrorAs(t, err, &iie)
+	})
+}
+
+func TestSetDelegateExpiry_PastDateRejected(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	_, err := SetDelegateExpiry(context.Background(), adminUUID, &past)
+	var iie *InvalidInputError
+	assert.ErrorAs(t, err, &iie)
+}
+
+func TestResolveDelegateExpiry(t *testing.T) {
+	// nil defaults to ~3 months out (a lower bound of ~2.5mo tolerates clock skew).
+	got, err := resolveDelegateExpiry(nil)
+	assert.NoError(t, err)
+	assert.True(t, got.After(time.Now().AddDate(0, 2, 20)), "nil must default to roughly three months")
+
+	// An explicit future date passes through unchanged.
+	future := time.Now().Add(24 * time.Hour)
+	got, err = resolveDelegateExpiry(&future)
+	assert.NoError(t, err)
+	assert.WithinDuration(t, future, got, time.Second)
+
+	// A past date is rejected.
+	past := time.Now().Add(-time.Hour)
+	_, err = resolveDelegateExpiry(&past)
+	var iie *InvalidInputError
+	assert.ErrorAs(t, err, &iie)
+}
+
+func TestIdentityProviderForOpDivCode(t *testing.T) {
+	assert.Equal(t, "okta", identityProviderForOpDivCode("CMS"), "CMS routes to Okta")
+	for _, code := range []string{"REBELLION", "CDC", "NIH", ""} {
+		assert.Equal(t, "entra", identityProviderForOpDivCode(code), code+" routes to Entra")
+	}
+}
+
+// adminUUID is a valid v4-shaped UUID (version nibble 4, variant nibble 8) so it
+// passes isValidUUID; the all-1s form used elsewhere as a display id does not.
+const adminUUID = "11111111-1111-4111-8111-111111111111"

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -19,6 +19,15 @@ components:
         notes:
           type: string
       type: object
+    controller.addDelegateBody:
+      properties:
+        access_expires_at:
+          type: string
+        email:
+          type: string
+        fullname:
+          type: string
+      type: object
     controller.apiResponse-any:
       properties:
         data: {}
@@ -277,6 +286,11 @@ components:
         idp:
           type: string
       type: object
+    controller.renewDelegateBody:
+      properties:
+        access_expires_at:
+          type: string
+      type: object
     controller.setUserOpDivsInput:
       properties:
         opdiv_ids:
@@ -517,6 +531,14 @@ components:
           type: string
         opdiv_id:
           type: integer
+        system_delegate_enabled:
+          description: |-
+            SystemDelegateEnabled gates the ISSO System Delegate self-service capability
+            (#467) for systems in this OpDiv: the "Add System Delegate Role" toggle on
+            the Manage OpDivs panel. Pointer for the same reason as the flags above.
+            Only Owner / HHS admin may set it (see SetOpDivSystemDelegateEnabled and the
+            controller gate); the ISSO add flow is refused when it is false.
+          type: boolean
       type: object
     model.Pillar:
       properties:
@@ -710,6 +732,13 @@ components:
       type: object
     model.User:
       properties:
+        access_expires_at:
+          description: |-
+            AccessExpiresAt is the System Delegate expiry (#467). Null for every non-
+            delegate user (they never expire). A delegate whose AccessExpiresAt is in
+            the past is denied at authentication (see IsExpired and the auth middleware),
+            while the row and its assignments are retained for renewal and audit.
+          type: string
         assignedopdivids:
           items:
             type: integer
@@ -1508,6 +1537,249 @@ paths:
       summary: List data calls a FISMA system has completed
       tags:
       - fismasystems
+  /fismasystems/{fismasystemid}/delegate-candidates:
+    get:
+      description: Existing SYSTEM_DELEGATE users in the system's OpDiv that are not
+        already assigned to it - the set the add flow would accept. Backs the FE attach
+        picker (#598).
+      parameters:
+      - description: FISMA System ID
+        in: path
+        name: fismasystemid
+        required: true
+        schema:
+          type: integer
+      - description: Filter by email or name (substring)
+        in: query
+        name: q
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-array_model_User'
+          description: OK
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: List existing delegates eligible to attach to a FISMA system
+      tags:
+      - delegates
+  /fismasystems/{fismasystemid}/delegates:
+    get:
+      parameters:
+      - description: FISMA System ID
+        in: path
+        name: fismasystemid
+        required: true
+        schema:
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-array_model_User'
+          description: OK
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: List the System Delegates assigned to a FISMA system
+      tags:
+      - delegates
+    post:
+      parameters:
+      - description: FISMA System ID
+        in: path
+        name: fismasystemid
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/controller.addDelegateBody'
+                description: Delegate to add
+                summary: body
+        description: Delegate to add
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-model_User'
+          description: Created
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Add or invite a System Delegate on a FISMA system
+      tags:
+      - delegates
+  /fismasystems/{fismasystemid}/delegates/{userid}:
+    delete:
+      parameters:
+      - description: FISMA System ID
+        in: path
+        name: fismasystemid
+        required: true
+        schema:
+          type: integer
+      - description: Delegate User ID
+        in: path
+        name: userid
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No Content
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Remove a System Delegate from a FISMA system
+      tags:
+      - delegates
+    patch:
+      parameters:
+      - description: FISMA System ID
+        in: path
+        name: fismasystemid
+        required: true
+        schema:
+          type: integer
+      - description: Delegate User ID
+        in: path
+        name: userid
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/controller.renewDelegateBody'
+                description: New expiration
+                summary: body
+        description: New expiration
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-model_User'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Renew or adjust a System Delegate's expiration
+      tags:
+      - delegates
   /fismasystems/{fismasystemid}/questions:
     get:
       parameters:
@@ -2024,6 +2296,64 @@ paths:
       security:
       - bearerAuth: []
       summary: Create or update an OpDiv
+      tags:
+      - opdivs
+  /opdivs/{opdiv_id}/system-delegate-enabled:
+    put:
+      parameters:
+      - description: OpDiv ID
+        in: path
+        name: opdiv_id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - properties:
+                  enabled:
+                    type: boolean
+                title: body
+                type: object
+        description: Toggle state
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-model_OpDiv'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Enable or disable the System Delegate role for an OpDiv
       tags:
       - opdivs
   /questions:


### PR DESCRIPTION
Part of epic CMS-Enterprise/ztmf#467 · backend sub-issue Closes CMS-Enterprise/ztmf#462 · paired frontend CMS-Enterprise/ztmf-ui#598.

## Summary

Adds **ISSO self-service** for the `SYSTEM_DELEGATE` role (contractor/support-staff access to a system's data-call answers, introduced in #458). Today the only way to create or assign any user is the admin-gated Users surface — every user write path begins with `IsAdmin()`, and an ISSO is not an admin — so standing up a delegate requires an administrator round-trip.

This adds a **separate, narrow, system-anchored** API surface so an ISSO can add / remove / renew delegates on a FISMA system they are assigned to, and only that system, without unlocking the admin Users table or relaxing any existing `IsAdmin()` gate. Delegates carry a **mandatory expiration** and are denied at authentication once lapsed (via the same rejection path as a soft-deleted user); regular users never expire and are unaffected. The capability is enabled **per-OpDiv** via an admin-managed toggle.

## Endpoints

| Method | Path | Who | Purpose |
|---|---|---|---|
| `GET` | `/fismasystems/{id}/delegates` | system viewers | Current delegates on the system (with `access_expires_at` for the expired badge) |
| `GET` | `/fismasystems/{id}/delegate-candidates?q=` | ISSO/admin managing the system | Existing delegates eligible to attach (picker) |
| `POST` | `/fismasystems/{id}/delegates` | ISSO/admin managing the system | Add a new person (Name+Email) or attach an existing eligible delegate |
| `PATCH` | `/fismasystems/{id}/delegates/{userid}` | ISSO/admin managing the system | Renew/adjust a delegate's expiration |
| `DELETE` | `/fismasystems/{id}/delegates/{userid}` | ISSO/admin managing the system | Remove a delegate from this system |
| `PUT` | `/opdivs/{opdiv_id}/system-delegate-enabled` | **Owner + HHS admin only** | Toggle the "Add System Delegate Role" capability for an OpDiv |

`GET /opdivs` now returns `system_delegate_enabled` on each OpDiv (read side of the toggle).

## Behavior & decisions (per epic #467)

- **Actor scope:** ISSO only among non-admins (ISSM and delegates excluded); admins who manage the system also pass. Unauthorized/missing systems return **404** (no-leak), never 403.
- **New person:** ISSO supplies Name + Email; role is forced to `SYSTEM_DELEGATE`, OpDiv is inherited from the system (never client-supplied), and the user + OpDiv grant + system assignment + audit events are written in **one transaction**.
- **Existing user:** attachable via self-service **only** if already a `SYSTEM_DELEGATE` in the system's OpDiv. Every other case (non-delegate, different OpDiv, soft-deleted) is rejected with a machine-readable **`DELEGATE_REQUIRES_ADMIN`** code (400) so the FE can route to "an administrator must handle this user."
- **Expiry:** mandatory for delegates, default **3 months**; nullable column so non-delegates stay null. A delegate whose expiry has passed is denied at auth (`ACCOUNT_NOT_PROVISIONED`); the row and its assignments are retained for renewal/audit. The admin user path also upholds the invariant (a delegate always carries an expiry; re-roling away from delegate clears it).
- **Per-OpDiv toggle:** `system_delegate_enabled`, default off (opt-in). Settable only by Owner + HHS admin (OPDIV_ADMIN is rejected despite being `IsAdmin`). The ISSO add flow is refused when the toggle is off for the system's OpDiv.
- **Audit:** every grant and revoke is recorded in the `events` trail (`granted_by` on the OpDiv grant).

## Data model / migrations

- `0049` — `opdivs.system_delegate_enabled BOOLEAN NOT NULL DEFAULT FALSE`
- `0050` — `users.access_expires_at TIMESTAMPTZ` (nullable)

## Testing

- **Unit:** authorization matrix for all 5 delegate endpoints + the toggle (denied actors → 404 / 403), the delegate access-invariant table (add/remove/renew), role/expiry helpers, `sanitizeErr` code mapping, and auth-middleware expiry denial.
- **Integration (`make test-integration`, live Postgres):** new-person create (tx, IdP derivation, default expiry, OpDiv+system assignment), existing-eligible attach-only, all rejection branches, renew (incl. soft-deleted rejection), candidate include/exclude + filter, the admin delegate-expiry invariant (create/promote default, edit preserves, demote clears), and the toggle single-write-path.
- **E2E (Emberfall):** full add→renew→remove success sequence, toggle role-gate (Owner/HHS 200, ISSO/OPDIV_ADMIN 403), and the no-leak/invariant denials — **183/183 passing.**
- **OpenAPI** regenerated from swaggo annotations (no drift).

## Possible follow-ups / Open design decisions

- **Admin-surface expiry management.** The admin Users path upholds the invariant (a delegate always gets a default 3-month expiry; re-roling away from delegate clears it) but cannot *set or adjust an explicit expiration* — explicit renewal is only via the system-scoped `PATCH /fismasystems/{id}/delegates/{userid}`, which requires the delegate to already be assigned to a system. Follow-up: let admins set/renew a delegate's expiry from the Users surface (covers a delegate not yet assigned to any system).
- **Schema-level invariant.** "Only a `SYSTEM_DELEGATE` may carry a non-null `access_expires_at`" is enforced in application code (`Save`, `IsExpired`, `SaveUser`), not by a DB constraint. Follow-up: add a `CHECK (role = 'SYSTEM_DELEGATE' OR access_expires_at IS NULL)` so a future write path can't silently reintroduce the "never-expires" bug.
- **Cross-OpDiv renewal.** `access_expires_at` is per-user (per the epic's decision), so renewing a delegate assigned to more than one system affects its access everywhere — including systems in OpDivs the acting ISSO does not manage. Revisit if delegates become per-assignment-scoped.
- **Actor scope.** ISSO-only among non-admins for now (epic decision 5 explicitly defers "how the roles evolve after the data call"); ISSM/other roles are a later decision.
- **Expired candidates.** The candidate picker / attach path can surface an already-expired delegate (cosmetic; the auth gate remains authoritative, so no access is granted). Should this picker exclude expired delegates?

## Frontend / dependencies

Paired frontend work is tracked in CMS-Enterprise/ztmf-ui#598: the ISSO **Delegates section** on the FISMA system detail page, and the **"Add System Delegate Role" toggle** on the Manage OpDivs panel. The per-OpDiv toggle in this PR is API- and migration-only for now (no UI); the full request/response contract is documented for the FE.
