### PR TITLE
fix(#471, #478): make the -short suite independent of database state

### DIFF
--- a/backend/cmd/api/internal/controller/delegates.go
+++ b/backend/cmd/api/internal/controller/delegates.go
@@ -31,6 +31,15 @@ func pathFismaSystemID(r *http.Request) (int32, bool) {
 	return id, id != 0
 }
 
+// mayManageDelegates is the cheap fail-closed pre-check of the delegate
+// management gate: only an admin write tier, or an ISSO assigned to this
+// system, may proceed. An OPDIV_ADMIN passes here and is narrowed to its OpDiv
+// after the system loads. Pure (no I/O), so the role boundary stays assertable
+// with no database (#478).
+func mayManageDelegates(u *model.User, id int32) bool {
+	return u.IsAdmin() || (u.Role == "ISSO" && u.IsAssignedFismaSystem(id))
+}
+
 // guardManageDelegates verifies the acting user may manage delegates on the
 // system and returns the system for the caller to reuse. A missing system, an
 // OpDiv-less system, or an unauthorized actor all return ErrNotFound so the
@@ -43,10 +52,7 @@ func pathFismaSystemID(r *http.Request) (int32, bool) {
 // The OpDiv-scope tightening for an OPDIV_ADMIN needs the system's OpDiv, so it
 // runs after the load via the authoritative CanManageSystemDelegates check.
 func guardManageDelegates(r *http.Request, authdUser *model.User, id int32) (*model.FismaSystem, error) {
-	// Cheap fail-closed pre-check: only an admin write tier, or an ISSO assigned
-	// to this system, may proceed. An OPDIV_ADMIN passes here and is narrowed to
-	// its OpDiv after the system loads.
-	if !authdUser.IsAdmin() && !(authdUser.Role == "ISSO" && authdUser.IsAssignedFismaSystem(id)) {
+	if !mayManageDelegates(authdUser, id) {
 		return nil, ErrNotFound
 	}
 

--- a/backend/cmd/api/internal/controller/delegates_test.go
+++ b/backend/cmd/api/internal/controller/delegates_test.go
@@ -115,16 +115,16 @@ func TestListDelegateCandidates_DeniedActorsNotFound(t *testing.T) {
 	}
 }
 
-// An ISSO assigned to the system, and an unscoped admin, both pass the gate; with
-// no DB they fail downstream, but must not be gated with 403/404.
+// An ISSO assigned to the system, and an unscoped admin, both pass the gate.
+// Asserted against the pure pre-check rather than the full handler: past the
+// gate the handler does real DB work, so its status depends on the environment
+// (an absent DB errors, a live one 404s unless the seed carries this system),
+// which made the handler-level assertion pass only when the DB was unreachable (#478).
 func TestAddSystemDelegate_AllowedActorsPassGate(t *testing.T) {
 	issoAssigned := &model.User{UserID: "33333333-3333-4333-8333-333333333333", Role: "ISSO", AssignedFismaSystems: []*int32{int32Ptr(1)}}
 	for name, u := range map[string]*model.User{"ISSO assigned": issoAssigned, "OWNER": adminUser} {
 		t.Run(name, func(t *testing.T) {
-			w, r := delegateReq(t, "POST", "body", u, map[string]string{"fismasystemid": delegateSystemID})
-			AddSystemDelegate(w, r)
-			assert.NotEqual(t, http.StatusNotFound, w.Code, "gate must pass for %s", name)
-			assert.NotEqual(t, http.StatusForbidden, w.Code, "gate must pass for %s", name)
+			assert.True(t, mayManageDelegates(u, 1), "gate must pass for %s", name)
 		})
 	}
 }

--- a/backend/cmd/api/internal/migrations/0001initialschema.go
+++ b/backend/cmd/api/internal/migrations/0001initialschema.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"initial schema",
 		`
 CREATE TABLE IF NOT EXISTS public.pillars

--- a/backend/cmd/api/internal/migrations/0002orderingcolumns.go
+++ b/backend/cmd/api/internal/migrations/0002orderingcolumns.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"ordering columns",
 		`ALTER TABLE IF EXISTS public.pillars ADD COLUMN IF NOT EXISTS "ordr" smallint DEFAULT 0;
 		 ALTER TABLE IF EXISTS public.questions ADD COLUMN IF NOT EXISTS "ordr" smallint DEFAULT 0;

--- a/backend/cmd/api/internal/migrations/0003fixdatacenterspelling.go
+++ b/backend/cmd/api/internal/migrations/0003fixdatacenterspelling.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"fix mispelling",
 		`UPDATE public.fismasystems SET datacenterenvironment='DECOMMISSIONED' where datacenterenvironment='DECOMISSIONED';`,
 		"")

--- a/backend/cmd/api/internal/migrations/0004orderingcolumnsfunctions.go
+++ b/backend/cmd/api/internal/migrations/0004orderingcolumnsfunctions.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"ordering columns",
 		`ALTER TABLE IF EXISTS public.functions ADD COLUMN IF NOT EXISTS "ordr" smallint DEFAULT 0;
 		`,

--- a/backend/cmd/api/internal/migrations/0005datacallsnewcolumns.go
+++ b/backend/cmd/api/internal/migrations/0005datacallsnewcolumns.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"datacalls new columnds",
 		`ALTER TABLE IF EXISTS public.datacalls ADD COLUMN IF NOT EXISTS "emailsubject" varchar(100);
 		ALTER TABLE IF EXISTS public.datacalls ADD COLUMN IF NOT EXISTS "emailbody" varchar(2000);

--- a/backend/cmd/api/internal/migrations/0006userevents.go
+++ b/backend/cmd/api/internal/migrations/0006userevents.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"user events",
 		`CREATE TABLE IF NOT EXISTS public.events
 		 (

--- a/backend/cmd/api/internal/migrations/0007scoresdatacallconstraint.go
+++ b/backend/cmd/api/internal/migrations/0007scoresdatacallconstraint.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"scores datacallid constraint",
 		`ALTER TABLE public.scores DROP CONSTRAINT IF EXISTS scores_datacallid_fkey;
 		ALTER TABLE public.scores ADD CONSTRAINT scores_datacallid_fkey FOREIGN KEY (datacallid) REFERENCES datacalls(datacallid) ON DELETE CASCADE;

--- a/backend/cmd/api/internal/migrations/0008massemails.go
+++ b/backend/cmd/api/internal/migrations/0008massemails.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		// this table will only ever hold 1 row which will be updated when emails are sent
 		// change history will then be captured in the events log
 		"massemails table",

--- a/backend/cmd/api/internal/migrations/0009usersrole.go
+++ b/backend/cmd/api/internal/migrations/0009usersrole.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		// change char to varchar to avoid padding characters
 		"users table role type",
 		`ALTER TABLE public.users ALTER COLUMN role TYPE varchar(5);`,

--- a/backend/cmd/api/internal/migrations/0010userssoftdelete.go
+++ b/backend/cmd/api/internal/migrations/0010userssoftdelete.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		// add soft delete capability
 		"users table role type",
 		`ALTER TABLE IF EXISTS public.users ADD COLUMN deleted boolean NOT NULL DEFAULT FALSE;`,

--- a/backend/cmd/api/internal/migrations/0011massemailsgroup.go
+++ b/backend/cmd/api/internal/migrations/0011massemailsgroup.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		// add group column to massemails
 		"massemails group column",
 		`ALTER TABLE IF EXISTS public.massemails ADD COLUMN "group" varchar(5);`,

--- a/backend/cmd/api/internal/migrations/0012datacallsdropemail.go
+++ b/backend/cmd/api/internal/migrations/0012datacallsdropemail.go
@@ -4,7 +4,7 @@ package migrations
 // every id in the array indicates
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"datacalls remove email; create datacalls_fismasystems",
 		`CREATE TABLE IF NOT EXISTS public.datacalls_fismasystems
 		(

--- a/backend/cmd/api/internal/migrations/0013datacallsunique.go
+++ b/backend/cmd/api/internal/migrations/0013datacallsunique.go
@@ -4,7 +4,7 @@ package migrations
 // every id in the array indicates
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"datacalls unique data call column",
 		`ALTER TABLE IF EXISTS public.datacalls DROP CONSTRAINT IF EXISTS datacall_key;
 		ALTER TABLE IF EXISTS public.datacalls ADD CONSTRAINT datacall_key UNIQUE (datacall);

--- a/backend/cmd/api/internal/migrations/0014usersemailuniqueindex.go
+++ b/backend/cmd/api/internal/migrations/0014usersemailuniqueindex.go
@@ -4,7 +4,7 @@ package migrations
 // remove the unique constraint and add a unique index instead
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"users unique index",
 		`ALTER TABLE IF EXISTS public.users DROP CONSTRAINT IF EXISTS users_email_key;
 		 CREATE UNIQUE INDEX email_unique_idx on users (LOWER(email));`,

--- a/backend/cmd/api/internal/migrations/0015cfactssystems.go
+++ b/backend/cmd/api/internal/migrations/0015cfactssystems.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"cfacts systems table",
 		`
 CREATE TABLE IF NOT EXISTS public.cfacts_systems (

--- a/backend/cmd/api/internal/migrations/0016decommissionfismasystems.go
+++ b/backend/cmd/api/internal/migrations/0016decommissionfismasystems.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"fismasystems decommission",
 		`
 ALTER TABLE IF EXISTS public.fismasystems

--- a/backend/cmd/api/internal/migrations/0017enhancedecommission.go
+++ b/backend/cmd/api/internal/migrations/0017enhancedecommission.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"enhance fismasystems decommission",
 		`
 -- Drop incorrectly typed column if exists from failed migration

--- a/backend/cmd/api/internal/migrations/0018readonlyadminrole.go
+++ b/backend/cmd/api/internal/migrations/0018readonlyadminrole.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"widen users role column for READONLY_ADMIN",
 		`ALTER TABLE public.users ALTER COLUMN role TYPE varchar(20);`,
 		`ALTER TABLE public.users ALTER COLUMN role TYPE varchar(5);`)

--- a/backend/cmd/api/internal/migrations/0019datacallcolumnsize.go
+++ b/backend/cmd/api/internal/migrations/0019datacallcolumnsize.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"widen datacalls datacall column from char(9) to varchar(100)",
 		`ALTER TABLE public.datacalls ALTER COLUMN datacall TYPE varchar(100);`,
 		`ALTER TABLE public.datacalls ALTER COLUMN datacall TYPE character(9);`)

--- a/backend/cmd/api/internal/migrations/0020sdlsyncenabled.go
+++ b/backend/cmd/api/internal/migrations/0020sdlsyncenabled.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add sdl_sync_enabled toggle to fismasystems",
 		// UP: Backfill existing rows as enabled (true), then change the column
 		// default to false so new systems must explicitly opt in to SDL sync.

--- a/backend/cmd/api/internal/migrations/0021cfactsgroupacronym.go
+++ b/backend/cmd/api/internal/migrations/0021cfactsgroupacronym.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add group_acronym to cfacts_systems",
 		`
 ALTER TABLE public.cfacts_systems ADD COLUMN IF NOT EXISTS group_acronym VARCHAR(50);

--- a/backend/cmd/api/internal/migrations/0022cfactsauthmethods.go
+++ b/backend/cmd/api/internal/migrations/0022cfactsauthmethods.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add auth_methods and fips_impact_level to cfacts_systems",
 		`
 ALTER TABLE public.cfacts_systems ADD COLUMN IF NOT EXISTS auth_methods TEXT;

--- a/backend/cmd/api/internal/migrations/0023idmscoring.go
+++ b/backend/cmd/api/internal/migrations/0023idmscoring.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"create idm_scoring lookup table for identity enrichment",
 		`
 CREATE TABLE IF NOT EXISTS public.idm_scoring (

--- a/backend/cmd/api/internal/migrations/0024noteslength.go
+++ b/backend/cmd/api/internal/migrations/0024noteslength.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"widen scores notes column from varchar(1000) to varchar(2000)",
 		`ALTER TABLE public.scores ALTER COLUMN notes TYPE character varying(2000);`,
 		`ALTER TABLE public.scores ALTER COLUMN notes TYPE character varying(1000);`)

--- a/backend/cmd/api/internal/migrations/0025reactivatefismasystems.go
+++ b/backend/cmd/api/internal/migrations/0025reactivatefismasystems.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add fismasystems reactivation audit columns",
 		`
 -- Drop incorrectly typed columns if they exist from a failed prior migration attempt.

--- a/backend/cmd/api/internal/migrations/0026opdivstable.go
+++ b/backend/cmd/api/internal/migrations/0026opdivstable.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"create opdivs reference table and seed HHS + OpDivs",
 		`
 CREATE TABLE IF NOT EXISTS public.opdivs (

--- a/backend/cmd/api/internal/migrations/0027fismasystemsopdivcol.go
+++ b/backend/cmd/api/internal/migrations/0027fismasystemsopdivcol.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add fismasystems.opdiv_id (nullable) with FK to opdivs",
 		`
 ALTER TABLE IF EXISTS public.fismasystems

--- a/backend/cmd/api/internal/migrations/0028fismasystemsopdivbackfill.go
+++ b/backend/cmd/api/internal/migrations/0028fismasystemsopdivbackfill.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"backfill fismasystems.opdiv_id to CMS",
 		`
 -- Every fismasystem row predates the multi-OpDiv schema and belongs to CMS by

--- a/backend/cmd/api/internal/migrations/0029fismasystemsopdivnotnull.go
+++ b/backend/cmd/api/internal/migrations/0029fismasystemsopdivnotnull.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"enforce NOT NULL on fismasystems.opdiv_id and add index",
 		`
 ALTER TABLE IF EXISTS public.fismasystems

--- a/backend/cmd/api/internal/migrations/0030usersidentityprovider.go
+++ b/backend/cmd/api/internal/migrations/0030usersidentityprovider.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add users.identity_provider (nullable) per ztmf#266",
 		`
 ALTER TABLE IF EXISTS public.users

--- a/backend/cmd/api/internal/migrations/0031usersidpbackfill.go
+++ b/backend/cmd/api/internal/migrations/0031usersidpbackfill.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"backfill users.identity_provider to okta",
 		`
 -- Every pre-multi-IdP user is a CMS user authenticating via Okta. HHS OpDiv

--- a/backend/cmd/api/internal/migrations/0032usersidpnotnull.go
+++ b/backend/cmd/api/internal/migrations/0032usersidpnotnull.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"enforce NOT NULL on users.identity_provider",
 		`
 ALTER TABLE IF EXISTS public.users

--- a/backend/cmd/api/internal/migrations/0033usersopdivsjunction.go
+++ b/backend/cmd/api/internal/migrations/0033usersopdivsjunction.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"create users_opdivs junction table",
 		`
 CREATE TABLE IF NOT EXISTS public.users_opdivs (

--- a/backend/cmd/api/internal/migrations/0034usersopdivscmsseed.go
+++ b/backend/cmd/api/internal/migrations/0034usersopdivscmsseed.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"seed users_opdivs with CMS grant for every existing user",
 		`
 -- Day 1 of the multi-OpDiv schema: every pre-existing user is a CMS user.

--- a/backend/cmd/api/internal/migrations/0035usersrolewiden.go
+++ b/backend/cmd/api/internal/migrations/0035usersrolewiden.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"widen users.role column to fit new OpDiv role names",
 		`
 -- The new role constants (OPDIV_READONLY_ADMIN at 20 chars, HHS_READONLY_ADMIN

--- a/backend/cmd/api/internal/migrations/0036usersroleswap.go
+++ b/backend/cmd/api/internal/migrations/0036usersroleswap.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"swap legacy roles to multi-OpDiv role taxonomy",
 		`
 -- Stage B: role swap. Maps the legacy ADMIN / READONLY_ADMIN values onto the

--- a/backend/cmd/api/internal/migrations/0037eventsauditindex.go
+++ b/backend/cmd/api/internal/migrations/0037eventsauditindex.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add audit-read indexes on events",
 		`
 -- Per-resource audit fields (ztmf-ui#310) read events via a LATERAL

--- a/backend/cmd/api/internal/migrations/0038systemenrichment.go
+++ b/backend/cmd/api/internal/migrations/0038systemenrichment.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add generic system_enrichment extension table",
 		// UP: Generic, enrichment-agnostic extension point owned by ztmf core. The
 		// CMS-specific enrichment pipeline (private repo) populates the jsonb payload,

--- a/backend/cmd/api/internal/migrations/0039cfactsdrop.go
+++ b/backend/cmd/api/internal/migrations/0039cfactsdrop.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"drop cfacts_systems table",
 		`
 DROP TABLE IF EXISTS public.cfacts_systems;

--- a/backend/cmd/api/internal/migrations/0040rolecleanup.go
+++ b/backend/cmd/api/internal/migrations/0040rolecleanup.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"Stage D: reject legacy ADMIN / READONLY_ADMIN role values",
 		`
 -- Stage D role cleanup. The Stage B swap (0036usersroleswap.go) already

--- a/backend/cmd/api/internal/migrations/0041fismasystemsopdivindex.go
+++ b/backend/cmd/api/internal/migrations/0041fismasystemsopdivindex.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add index on fismasystems.opdiv_id for OpDiv scope predicates",
 		`
 -- OpDiv-scoped RBAC enforcement filters fismasystems by opdiv_id on every

--- a/backend/cmd/api/internal/migrations/0042opdivinsightsflag.go
+++ b/backend/cmd/api/internal/migrations/0042opdivinsightsflag.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add opdivs.insights_enabled flag and enable it for CMS",
 		`
 -- System enrichment (ZTMF Insights) is only available for OpDivs that have an

--- a/backend/cmd/api/internal/migrations/0043hhsschemadelta.go
+++ b/backend/cmd/api/internal/migrations/0043hhsschemadelta.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add HHS onboarding columns to fismasystems and notes_is_ai_summary to scores",
 		`
 -- Eleven new nullable varchar columns on fismasystems to hold HHS inventory

--- a/backend/cmd/api/internal/migrations/0044issoname.go
+++ b/backend/cmd/api/internal/migrations/0044issoname.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add isso_name column to fismasystems",
 		`
 -- isso_name was omitted from migration 0043 which added the other 11 HHS

--- a/backend/cmd/api/internal/migrations/0045datacenterenvironments.go
+++ b/backend/cmd/api/internal/migrations/0045datacenterenvironments.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"create datacenterenvironments mapping table, seed it, rename OPDC, add MAG and data-center-gov function sets",
 		`
 -- ZTMF scores a system by matching its datacenterenvironment against the

--- a/backend/cmd/api/internal/migrations/0046targetmaturity.go
+++ b/backend/cmd/api/internal/migrations/0046targetmaturity.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add target maturity tier and justification to fismasystems",
 		`
 -- Risk-based target maturity level per system (#398, GAO audit response).

--- a/backend/cmd/api/internal/migrations/0047systeminsights.go
+++ b/backend/cmd/api/internal/migrations/0047systeminsights.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add generic system_insights extension table",
 		// UP: Generic, insight-agnostic per-question extension point owned by ztmf
 		// core. The ztmf-insights sync lambda populates the jsonb payload from

--- a/backend/cmd/api/internal/migrations/0048scoresstatus.go
+++ b/backend/cmd/api/internal/migrations/0048scoresstatus.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add per-answer status to scores (state machine replacing events-derived progress)",
 		`
 -- Persist each answer's review state for its data call as a first-class column

--- a/backend/cmd/api/internal/migrations/0049opdivsystemdelegateflag.go
+++ b/backend/cmd/api/internal/migrations/0049opdivsystemdelegateflag.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add opdivs.system_delegate_enabled toggle (default off, opt-in per OpDiv)",
 		`
 -- The System Delegate self-service capability (ISSO#467) is enabled per OpDiv

--- a/backend/cmd/api/internal/migrations/0050usersaccessexpiry.go
+++ b/backend/cmd/api/internal/migrations/0050usersaccessexpiry.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"add users.access_expires_at for System Delegate expiry (nullable, null = never)",
 		`
 -- System Delegate accounts (ISSO#467) carry a mandatory expiration set at the

--- a/backend/cmd/api/internal/migrations/0051usersexpiryrolecheck.go
+++ b/backend/cmd/api/internal/migrations/0051usersexpiryrolecheck.go
@@ -1,7 +1,7 @@
 package migrations
 
 func init() {
-	getMigrator().AppendMigration(
+	appendMigration(
 		"constrain users.access_expires_at to SYSTEM_DELEGATE rows only",
 		`
 -- Defense-in-depth for the System Delegate expiry invariant: only a

--- a/backend/cmd/api/internal/migrations/migrations.go
+++ b/backend/cmd/api/internal/migrations/migrations.go
@@ -1,7 +1,10 @@
 /*
 package migrations is used internally to specify DB schema updates that need to run on process start
 
-All migrations should be appended using the init() function in a file dedicated to the migration.
+All migrations should be registered by calling appendMigration from an init() function in a file
+dedicated to the migration. Registration is pure (append to a slice, no I/O): the database
+connection is only opened by Run(), so importing this package — e.g. from its test binary —
+never requires a reachable database (#471).
 Be aware that multiple init() funcs are executed in lexical file name order, so when adding multiple
 changes in a single PR be sure to name the files in a way that applies them in the right order if the order matters.
 */
@@ -10,26 +13,51 @@ package migrations
 import (
 	"context"
 	"log"
-	"sync"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 	"github.com/jackc/tern/v2/migrate"
 )
 
-var (
-	migrator *migrate.Migrator
-	once     sync.Once
-)
+type migration struct {
+	name    string
+	upSQL   string
+	downSQL string
+}
+
+// registry holds migrations in registration (= lexical file name) order.
+var registry []migration
+
+func appendMigration(name, upSQL, downSQL string) {
+	registry = append(registry, migration{name, upSQL, downSQL})
+}
 
 func Run() {
 	log.Println("executing migrations...")
-	err := getMigrator().Migrate(context.Background())
+
+	ctx := context.Background()
+
+	conn, err := db.MigrationConn(ctx)
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
-	migrator = nil
+
+	migrator, err := migrate.NewMigrator(ctx, conn, "dbversions")
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+
+	for _, m := range registry {
+		migrator.AppendMigration(m.name, m.upSQL, m.downSQL)
+	}
+
+	err = migrator.Migrate(ctx)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 
 	cfg := config.GetInstance()
 
@@ -48,23 +76,4 @@ func Run() {
 			log.Fatal(err)
 		}
 	}
-}
-
-func getMigrator() *migrate.Migrator {
-	if migrator == nil {
-		once.Do(func() {
-			conn, err := db.MigrationConn(context.Background())
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
-
-			migrator, err = migrate.NewMigrator(context.Background(), conn, "dbversions")
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
-		})
-	}
-	return migrator
 }

--- a/backend/cmd/api/internal/migrations/migrations_test.go
+++ b/backend/cmd/api/internal/migrations/migrations_test.go
@@ -1,0 +1,22 @@
+package migrations
+
+import "testing"
+
+// TestRegistryPopulated pins the package's registration contract: init() funcs
+// only append to the registry, so building the test binary and running the
+// -short suite must work with no database reachable (#471). If this test can
+// run at all, registration stayed I/O-free; it then checks the registry
+// actually carries the migrations Run() will execute.
+func TestRegistryPopulated(t *testing.T) {
+	if len(registry) == 0 {
+		t.Fatal("no migrations registered; init() registration is broken")
+	}
+	for i, m := range registry {
+		if m.name == "" {
+			t.Errorf("migration %d has an empty name", i)
+		}
+		if m.upSQL == "" {
+			t.Errorf("migration %d (%s) has empty up SQL", i, m.name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #471. Closes #478.

Two commits, one theme: the `-short` unit suite must not depend on database state.

## Commit 1: fix(#478) delegate gate test

`TestAddSystemDelegate_AllowedActorsPassGate` drove the real `AddSystemDelegate` handler and asserted the response was not 404/403. Allowed actors clear the in-memory role check and proceed to `model.FindFismaSystem(1)`, so the assertion only held when that query failed. Against a live seeded database (which the #472 pre-commit hook guarantees whenever the dev stack is up) the empire seed has no `fismasystemid = 1` and the guard correctly returns not-found, failing the test and blocking every backend commit. Full mechanism on #478.

The fix extracts the fail-closed role pre-check from `guardManageDelegates` into `mayManageDelegates`, a pure helper, and asserts the allowed actors against it directly. Gate behavior is unchanged, and the denied-actor tests are untouched (they already fail closed before any DB work). The controller suite now passes identically with a live dev DB and with no database at all.

## Commit 2: fix(#471) pure migration registration

Every migration file's `init()` called `getMigrator().AppendMigration`, and `getMigrator` opened a live `db.MigrationConn` inside its `once.Do` with `log.Fatal` on failure, so importing the package dialed the database at package-init time, before any test's `testing.Short()` guard could run. `go test -short ./...` failed outright (or hung) without a reachable database, and the Go test cache replaying env-sourced passes masked it. Repro details on #471.

Registration now appends to a plain package-level slice via `appendMigration` (a mechanical one-line rename across all 51 migration files, verifiable with `grep -r getMigrator backend/`, which now returns nothing), and `Run()` opens the connection, builds the tern migrator, replays the registry in registration order, and migrates. Boot behavior is unchanged: same connection path, same `log.Fatal` on failure, same lexical execution order. `TestRegistryPopulated` pins the contract.

## Validation

The #471 acceptance criterion holds: with no DB_* env and a cold cache (`-count=1`), `go test -short ./...` passes with no database reachable. The controller suite passes identically with the live dev DB (env sourced, dev stack up) and with a scrubbed env. `make test-integration` and `make test-e2e` (emberfall) are both green, and the integration run exercises the new boot path for real: the test API container migrates and seeds a fresh ephemeral DB through the reworked `Run()`. `openapi.yaml` is byte-identical after regen, since no API surface changed.

Snyk / secret-dependent checks will show red as usual on fork PRs; maintainers re-run after pulling the branch.
