### PR TITLE
feat(#433): retype system-metadata columns to typed columns (booleans, CHECK-enums, text[])

### DIFF
--- a/backend/cmd/api/internal/migrations/0052fismasystemsretype.go
+++ b/backend/cmd/api/internal/migrations/0052fismasystemsretype.go
@@ -1,0 +1,152 @@
+package migrations
+
+func init() {
+	getMigrator().AppendMigration(
+		"retype fismasystems HHS metadata columns: booleans, enum CHECKs, and a cloud_service_model text[]",
+		`
+-- ztmf#433: the HHS onboarding metadata columns were added as free-text
+-- varchar(255) in 0043. This migration makes them typed and self-validating at
+-- the database layer:
+--   - booleans (hva, cloud_system, legacy): varchar -> boolean, null = unknown
+--     (the epic rule is do NOT coerce a missing value to No);
+--   - enums (fips, system_type, system_operator, goco_coco_gogo): stay varchar
+--     with a CHECK constraint (house style, matching 0046/0048 - avoids the
+--     native ENUM ALTER TYPE dance);
+--   - cloud_service_model: varchar combo -> text[], with a CHECK on the elements.
+--
+-- Existing rows are canonicalized in place first so the type casts and CHECKs
+-- cannot fail the migration. Postgres data is mostly NULL for these fields today
+-- (HHS not yet loaded; CMS rows NULL), so this touches few rows, but the mapping
+-- covers every off-canon spelling catalogued in ztmf#395. Anything still
+-- unmappable is set to NULL ("not yet captured") rather than blocking startup.
+--
+-- The vocabulary endpoint, friendly 400 messages, and the cloud_system=No
+-- cross-field rule are ztmf#395, layered on top of these typed columns.
+--
+-- NOTE: this changes the JSON API contract (bool / array instead of strings) and
+-- breaks the PG->Snowflake SDL export (CORE.ZTMF_FISMASYSTEMS) in the private
+-- ztmf-insights repo. Both are expected and coordinated (danielbowne accepted a
+-- temporary SDL break; the export is patched downstream).
+
+-- 1. Canonicalize enum values in place, collapsing the ztmf#395 variants and
+--    nulling anything off-canon so the CHECKs below hold.
+-- Fold on lower(btrim(...)) like the other three enums below, so casing and
+-- stray whitespace ('major application', ' Major Application') canonicalize
+-- instead of silently dropping to NULL.
+UPDATE public.fismasystems SET system_type = CASE lower(btrim(system_type))
+    WHEN 'minor standalone'               THEN 'Minor Standalone'
+    WHEN 'minor stand-alone'              THEN 'Minor Standalone'
+    WHEN 'minor application (standalone)' THEN 'Minor Standalone'
+    WHEN 'minor application (standlone)'  THEN 'Minor Standalone'
+    WHEN 'minor application'              THEN 'Minor Application'
+    WHEN 'minor application (child)'      THEN 'Minor Application'
+    WHEN 'major application'              THEN 'Major Application'
+    WHEN 'general support system'         THEN 'General Support System'
+    WHEN 'general support services'       THEN 'General Support System'
+    WHEN 'enterprise'                     THEN 'Enterprise'
+    WHEN 'local'                          THEN 'Local'
+    WHEN 'other'                          THEN 'Other'
+    WHEN 'others -'                       THEN 'Other'
+    ELSE NULL
+END
+WHERE system_type IS NOT NULL;
+
+UPDATE public.fismasystems SET fips = CASE
+    WHEN initcap(btrim(fips)) IN ('Low', 'Moderate', 'High') THEN initcap(btrim(fips))
+    ELSE NULL
+END
+WHERE fips IS NOT NULL;
+
+UPDATE public.fismasystems SET system_operator = CASE
+    WHEN initcap(btrim(system_operator)) IN ('Agency', 'Contractor') THEN initcap(btrim(system_operator))
+    ELSE NULL
+END
+WHERE system_operator IS NOT NULL;
+
+UPDATE public.fismasystems SET goco_coco_gogo = CASE
+    WHEN upper(btrim(goco_coco_gogo)) = 'GOVO'                     THEN 'GOGO'
+    WHEN upper(btrim(goco_coco_gogo)) IN ('GOCO', 'COCO', 'GOGO')  THEN upper(btrim(goco_coco_gogo))
+    ELSE NULL
+END
+WHERE goco_coco_gogo IS NOT NULL;
+
+-- 2. Normalize cloud_service_model to a sorted, slash-joined canonical combo
+--    (split on / , ;, case-fold each token, drop unknowns), so the text[] cast
+--    below yields clean canonical elements. Empty result -> NULL.
+--    Deliberately two-step (normalize-to-string here, then string_to_array in
+--    step 4): the column is still varchar at this point and cannot hold an
+--    array, so the '/' round-trip is required, not accidental. Both steps share
+--    the '/' delimiter on purpose - do not "simplify" one without the other.
+UPDATE public.fismasystems SET cloud_service_model = (
+    SELECT string_agg(x, '/' ORDER BY x)
+    FROM (
+        SELECT DISTINCT CASE lower(btrim(t))
+            WHEN 'iaas'  THEN 'IaaS'
+            WHEN 'paas'  THEN 'PaaS'
+            WHEN 'saas'  THEN 'SaaS'
+            WHEN 'other' THEN 'Other'
+            ELSE NULL
+        END AS x
+        FROM regexp_split_to_table(cloud_service_model, '[/,;]+') AS t
+    ) mapped
+    WHERE x IS NOT NULL
+)
+WHERE cloud_service_model IS NOT NULL AND btrim(cloud_service_model) <> '';
+
+-- 3. Retype the booleans. lower()/btrim() folds the YES/yes/NO/no variants;
+--    anything else becomes NULL (unknown), never false.
+ALTER TABLE public.fismasystems
+    ALTER COLUMN hva          TYPE boolean USING (CASE WHEN lower(btrim(hva))          = 'yes' THEN true WHEN lower(btrim(hva))          = 'no' THEN false ELSE NULL END),
+    ALTER COLUMN cloud_system TYPE boolean USING (CASE WHEN lower(btrim(cloud_system)) = 'yes' THEN true WHEN lower(btrim(cloud_system)) = 'no' THEN false ELSE NULL END),
+    ALTER COLUMN legacy       TYPE boolean USING (CASE WHEN lower(btrim(legacy))       = 'yes' THEN true WHEN lower(btrim(legacy))       = 'no' THEN false ELSE NULL END);
+
+-- 4. Retype cloud_service_model to text[].
+ALTER TABLE public.fismasystems
+    ALTER COLUMN cloud_service_model TYPE text[] USING (
+        CASE WHEN cloud_service_model IS NULL OR btrim(cloud_service_model) = '' THEN NULL
+             ELSE string_to_array(cloud_service_model, '/')
+        END
+    );
+
+-- 5. Constrain the enum columns and the array elements to the canonical sets
+--    (NULL-tolerant: null = not yet captured stays valid). These lists must stay
+--    in sync with the ztmf#395 systemattributes selectable=TRUE seed.
+ALTER TABLE public.fismasystems
+    DROP CONSTRAINT IF EXISTS fismasystems_fips_check,
+    DROP CONSTRAINT IF EXISTS fismasystems_system_type_check,
+    DROP CONSTRAINT IF EXISTS fismasystems_system_operator_check,
+    DROP CONSTRAINT IF EXISTS fismasystems_goco_coco_gogo_check,
+    DROP CONSTRAINT IF EXISTS fismasystems_cloud_service_model_check;
+
+ALTER TABLE public.fismasystems
+    ADD CONSTRAINT fismasystems_fips_check
+        CHECK (fips IS NULL OR fips IN ('Low', 'Moderate', 'High')),
+    ADD CONSTRAINT fismasystems_system_type_check
+        CHECK (system_type IS NULL OR system_type IN ('Major Application', 'Minor Application', 'Minor Standalone', 'General Support System', 'Enterprise', 'Local', 'Other')),
+    ADD CONSTRAINT fismasystems_system_operator_check
+        CHECK (system_operator IS NULL OR system_operator IN ('Agency', 'Contractor')),
+    ADD CONSTRAINT fismasystems_goco_coco_gogo_check
+        CHECK (goco_coco_gogo IS NULL OR goco_coco_gogo IN ('GOCO', 'COCO', 'GOGO')),
+    ADD CONSTRAINT fismasystems_cloud_service_model_check
+        CHECK (cloud_service_model IS NULL OR cloud_service_model <@ ARRAY['IaaS', 'PaaS', 'SaaS', 'Other']::text[]);
+		`,
+		`
+-- Reverse the retype. Drop the CHECKs, then cast the typed columns back to
+-- varchar: booleans render as 'Yes'/'No' (NULL stays NULL), the array re-joins
+-- with '/'. The original raw off-canon spellings are not recoverable - the up
+-- migration canonicalized them in place - so this restores the canonical form,
+-- not the pre-0052 free text.
+ALTER TABLE public.fismasystems
+    DROP CONSTRAINT IF EXISTS fismasystems_fips_check,
+    DROP CONSTRAINT IF EXISTS fismasystems_system_type_check,
+    DROP CONSTRAINT IF EXISTS fismasystems_system_operator_check,
+    DROP CONSTRAINT IF EXISTS fismasystems_goco_coco_gogo_check,
+    DROP CONSTRAINT IF EXISTS fismasystems_cloud_service_model_check;
+
+ALTER TABLE public.fismasystems
+    ALTER COLUMN hva          TYPE varchar(255) USING (CASE WHEN hva          IS TRUE THEN 'Yes' WHEN hva          IS FALSE THEN 'No' ELSE NULL END),
+    ALTER COLUMN cloud_system TYPE varchar(255) USING (CASE WHEN cloud_system IS TRUE THEN 'Yes' WHEN cloud_system IS FALSE THEN 'No' ELSE NULL END),
+    ALTER COLUMN legacy       TYPE varchar(255) USING (CASE WHEN legacy       IS TRUE THEN 'Yes' WHEN legacy       IS FALSE THEN 'No' ELSE NULL END),
+    ALTER COLUMN cloud_service_model TYPE varchar(255) USING (array_to_string(cloud_service_model, '/'));
+		`)
+}

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -48,18 +48,23 @@ type FismaSystem struct {
 	ReactivatedDate       *time.Time `json:"reactivated_date"`
 	ReactivationNotes     *string    `json:"reactivation_notes"`
 	OpDivID               *int32     `json:"opdiv_id" db:"opdiv_id"`
-	HVA                   *string    `json:"hva" db:"hva"`
-	FIPS                  *string    `json:"fips" db:"fips"`
-	SystemType            *string    `json:"system_type" db:"system_type"`
-	CloudSystem           *string    `json:"cloud_system" db:"cloud_system"`
-	CloudServiceModel     *string    `json:"cloud_service_model" db:"cloud_service_model"`
-	CloudVendor           *string    `json:"cloud_vendor" db:"cloud_vendor"`
-	SystemOperator        *string    `json:"system_operator" db:"system_operator"`
-	GocoCocGoGo           *string    `json:"goco_coco_gogo" db:"goco_coco_gogo"`
-	SystemOwner           *string    `json:"system_owner" db:"system_owner"`
-	SystemOwnerEmail      *string    `json:"system_owner_email" db:"system_owner_email"`
-	Legacy                *string    `json:"legacy" db:"legacy"`
-	ISSOName              *string    `json:"isso_name" db:"isso_name"`
+	// HHS metadata typed by ztmf#433. Booleans are *bool so NULL stays "unknown"
+	// (the epic rule: never coerce a missing value to false/No).
+	HVA         *bool   `json:"hva" db:"hva"`
+	FIPS        *string `json:"fips" db:"fips"`
+	SystemType  *string `json:"system_type" db:"system_type"`
+	CloudSystem *bool   `json:"cloud_system" db:"cloud_system"`
+	// CloudServiceModel is a decomposed multi-select stored as a text[] column;
+	// nil = omitted/NULL, an empty slice clears it, a populated slice is the set
+	// of canonical values (IaaS/PaaS/SaaS/Other), enforced by a DB CHECK.
+	CloudServiceModel []string `json:"cloud_service_model" db:"cloud_service_model"`
+	CloudVendor       *string  `json:"cloud_vendor" db:"cloud_vendor"`
+	SystemOperator    *string  `json:"system_operator" db:"system_operator"`
+	GocoCocGoGo       *string  `json:"goco_coco_gogo" db:"goco_coco_gogo"`
+	SystemOwner      *string `json:"system_owner" db:"system_owner"`
+	SystemOwnerEmail *string `json:"system_owner_email" db:"system_owner_email"`
+	Legacy           *bool   `json:"legacy" db:"legacy"`
+	ISSOName         *string `json:"isso_name" db:"isso_name"`
 	// Risk-based target maturity (#398). NULL = no ISSO has asserted a target
 	// yet; the UI presents the Advanced default. Written only via
 	// SaveTargetMaturity, never through Save().
@@ -236,12 +241,15 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 				f.FismaUID, f.FismaAcronym, f.FismaName, f.FismaSubsystem, f.Component,
 				f.Groupacronym, f.GroupName, f.DivisionName, f.DataCenterEnvironment,
 				f.DataCallContact, f.ISSOEmail, f.SDLSyncEnabled, opdivVal,
-				// A blank optional field on create is NULL, not "" (ztmf#442).
-				blankToNil(f.HVA), blankToNil(f.FIPS), blankToNil(f.SystemType),
-				blankToNil(f.CloudSystem), blankToNil(f.CloudServiceModel),
+				// A blank optional text field on create is NULL, not "" (ztmf#442).
+				// The typed HHS fields (ztmf#433) pass through raw: a nil *bool
+				// encodes NULL (unknown, never false), and an empty slice is nulled
+				// so a blank multi-select writes NULL rather than an empty array.
+				f.HVA, blankToNil(f.FIPS), blankToNil(f.SystemType),
+				f.CloudSystem, emptyToNil(f.CloudServiceModel),
 				blankToNil(f.CloudVendor), blankToNil(f.SystemOperator),
 				blankToNil(f.GocoCocGoGo), blankToNil(f.SystemOwner),
-				blankToNil(f.SystemOwnerEmail), blankToNil(f.Legacy),
+				blankToNil(f.SystemOwnerEmail), f.Legacy,
 				blankToNil(f.ISSOName),
 			).
 			Suffix("RETURNING " + strings.Join(fismaSystemColumns, ", "))
@@ -262,33 +270,45 @@ func (f *FismaSystem) Save(ctx context.Context) (*FismaSystem, error) {
 			"sdl_sync_enabled":      f.SDLSyncEnabled,
 		}
 		// Metadata fields distinguish three request states (ztmf#442):
-		//   - omitted / null (nil pointer) -> leave the stored value untouched,
-		//     so a partial PUT never wipes importer data (and a scoped-admin edit,
-		//     whose HHS fields copyHHSMetadata has set to the stored values, is a
-		//     no-op here);
-		//   - "" (a cleared form input) -> write NULL, so a blank actually clears
-		//     the value rather than persisting "" or being silently ignored;
+		//   - omitted / null (nil pointer / nil slice) -> leave the stored value
+		//     untouched, so a partial PUT never wipes importer data (and a
+		//     scoped-admin edit, whose HHS fields copyHHSMetadata has set to the
+		//     stored values, is a no-op here);
+		//   - "" (a cleared text input) / empty slice -> write NULL, so a blank
+		//     actually clears the value rather than persisting "" / an empty array;
 		//   - a value -> write it.
 		// blankToNil folds the "" case into a nil *string, which pgx encodes as
 		// NULL; nil-guarding the assignment keeps the omitted case untouched.
 		hhsCols := map[string]*string{
-			"hva":                 f.HVA,
-			"fips":                f.FIPS,
-			"system_type":         f.SystemType,
-			"cloud_system":        f.CloudSystem,
-			"cloud_service_model": f.CloudServiceModel,
-			"cloud_vendor":        f.CloudVendor,
-			"system_operator":     f.SystemOperator,
-			"goco_coco_gogo":      f.GocoCocGoGo,
-			"system_owner":        f.SystemOwner,
-			"system_owner_email":  f.SystemOwnerEmail,
-			"legacy":              f.Legacy,
-			"isso_name":           f.ISSOName,
+			"fips":               f.FIPS,
+			"system_type":        f.SystemType,
+			"cloud_vendor":       f.CloudVendor,
+			"system_operator":    f.SystemOperator,
+			"goco_coco_gogo":     f.GocoCocGoGo,
+			"system_owner":       f.SystemOwner,
+			"system_owner_email": f.SystemOwnerEmail,
+			"isso_name":          f.ISSOName,
 		}
 		for col, val := range hhsCols {
 			if val != nil {
 				setCols[col] = blankToNil(val)
 			}
+		}
+		// The typed HHS fields (ztmf#433) use the same three-state semantics with
+		// their own types. A nil *bool / nil slice means omitted (leave unchanged);
+		// a provided *bool is written as-is (true/false); a provided-but-empty
+		// slice clears cloud_service_model to NULL via emptyToNil.
+		if f.HVA != nil {
+			setCols["hva"] = *f.HVA
+		}
+		if f.CloudSystem != nil {
+			setCols["cloud_system"] = *f.CloudSystem
+		}
+		if f.Legacy != nil {
+			setCols["legacy"] = *f.Legacy
+		}
+		if f.CloudServiceModel != nil {
+			setCols["cloud_service_model"] = emptyToNil(f.CloudServiceModel)
 		}
 		sqlb = stmntBuilder.
 			Update("fismasystems").
@@ -538,6 +558,18 @@ func blankToNil(p *string) *string {
 		return nil
 	}
 	return p
+}
+
+// emptyToNil returns a nil slice for an empty (or nil) slice so a cleared
+// multi-select writes SQL NULL instead of an empty array '{}' (ztmf#433) -
+// the text[] analogue of blankToNil. Callers nil-guard before calling this so a
+// genuinely omitted field (nil slice) stays "leave unchanged" rather than being
+// turned into a clear.
+func emptyToNil(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
 }
 
 func (f *FismaSystem) validate() error {

--- a/backend/internal/model/fismasystems_retype_integration_test.go
+++ b/backend/internal/model/fismasystems_retype_integration_test.go
@@ -1,0 +1,174 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFismaSystemRetypeRoundTripIntegration proves the ztmf#433 retype survives a
+// write/read cycle: booleans stay tri-state (true/false/NULL-unknown) and
+// cloud_service_model round-trips as a text[]. Requires DB_* env vars pointing at
+// a migrated ZTMF database (migration 0052 applied). Skipped under `go test -short`.
+func TestFismaSystemRetypeRoundTripIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+
+	t.Run("TypedInsertAndReadBack", func(t *testing.T) {
+		fips := "Low"
+		fs := &FismaSystem{
+			FismaUID:          "ztmf433-roundtrip-uid",
+			FismaAcronym:      "ZT433RT",
+			FismaName:         "retype round-trip fixture (ztmf#433)",
+			HVA:               boolPtr(true),
+			CloudSystem:       boolPtr(true),
+			Legacy:            boolPtr(false),
+			FIPS:              &fips,
+			CloudServiceModel: []string{"IaaS", "PaaS"},
+		}
+		saved, err := fs.Save(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+		t.Cleanup(func() { hardDeleteFismaSystemByID(saved.FismaSystemID) })
+
+		got, err := FindFismaSystem(ctx, FindFismaSystemsInput{FismaSystemID: &saved.FismaSystemID})
+		require.NoError(t, err)
+		if assert.NotNil(t, got.HVA) {
+			assert.True(t, *got.HVA)
+		}
+		if assert.NotNil(t, got.CloudSystem) {
+			assert.True(t, *got.CloudSystem)
+		}
+		if assert.NotNil(t, got.Legacy) {
+			assert.False(t, *got.Legacy, "false must round-trip as false, distinct from unknown")
+		}
+		assert.ElementsMatch(t, []string{"IaaS", "PaaS"}, got.CloudServiceModel)
+	})
+
+	t.Run("OmittedBooleanStaysNull", func(t *testing.T) {
+		fs := &FismaSystem{
+			FismaUID:     "ztmf433-nullbool-uid",
+			FismaAcronym: "ZT433NB",
+			FismaName:    "null bool fixture (ztmf#433)",
+		}
+		saved, err := fs.Save(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { hardDeleteFismaSystemByID(saved.FismaSystemID) })
+
+		assert.Nil(t, saved.HVA, "an unset boolean must stay NULL/unknown, never coerced to false")
+		assert.Nil(t, saved.CloudServiceModel, "an unset multi-select must stay NULL, not an empty array")
+	})
+
+	t.Run("PartialUpdateLeavesTypedFieldsUntouched", func(t *testing.T) {
+		fs := &FismaSystem{
+			FismaUID:          "ztmf433-partial-uid",
+			FismaAcronym:      "ZT433PU",
+			FismaName:         "partial fixture (ztmf#433)",
+			HVA:               boolPtr(true),
+			CloudServiceModel: []string{"SaaS"},
+		}
+		saved, err := fs.Save(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { hardDeleteFismaSystemByID(saved.FismaSystemID) })
+
+		// Update only the name; HVA and CloudServiceModel are nil (omitted) and
+		// must be left untouched by the nil-guarded UPDATE.
+		upd := &FismaSystem{
+			FismaSystemID: saved.FismaSystemID,
+			FismaUID:      saved.FismaUID,
+			FismaAcronym:  saved.FismaAcronym,
+			FismaName:     "renamed (ztmf#433)",
+		}
+		_, err = upd.Save(ctx)
+		require.NoError(t, err)
+
+		got, err := FindFismaSystem(ctx, FindFismaSystemsInput{FismaSystemID: &saved.FismaSystemID})
+		require.NoError(t, err)
+		if assert.NotNil(t, got.HVA) {
+			assert.True(t, *got.HVA, "omitted boolean must be left untouched")
+		}
+		assert.ElementsMatch(t, []string{"SaaS"}, got.CloudServiceModel, "omitted slice must be left untouched")
+	})
+
+	t.Run("EmptySliceClearsMultiSelect", func(t *testing.T) {
+		fs := &FismaSystem{
+			FismaUID:          "ztmf433-clear-uid",
+			FismaAcronym:      "ZT433CL",
+			FismaName:         "clear fixture (ztmf#433)",
+			CloudServiceModel: []string{"IaaS"},
+		}
+		saved, err := fs.Save(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { hardDeleteFismaSystemByID(saved.FismaSystemID) })
+
+		upd := &FismaSystem{
+			FismaSystemID:     saved.FismaSystemID,
+			FismaUID:          saved.FismaUID,
+			FismaAcronym:      saved.FismaAcronym,
+			FismaName:         saved.FismaName,
+			CloudServiceModel: []string{}, // explicit clear
+		}
+		_, err = upd.Save(ctx)
+		require.NoError(t, err)
+
+		got, err := FindFismaSystem(ctx, FindFismaSystemsInput{FismaSystemID: &saved.FismaSystemID})
+		require.NoError(t, err)
+		assert.Nil(t, got.CloudServiceModel, "an explicit empty slice clears cloud_service_model to NULL")
+	})
+}
+
+// TestFismaSystemRetypeCheckConstraintsIntegration proves the DB CHECK constraints
+// added by migration 0052 reject off-canon values (the value-validation that #433
+// moves into the database). Skipped under `go test -short`.
+func TestFismaSystemRetypeCheckConstraintsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+
+	t.Run("RejectsOffCanonSystemType", func(t *testing.T) {
+		bad := "Nonsense"
+		fs := &FismaSystem{
+			FismaUID:     "ztmf433-badenum-uid",
+			FismaAcronym: "ZT433BE",
+			FismaName:    "bad enum fixture (ztmf#433)",
+			SystemType:   &bad,
+		}
+		saved, err := fs.Save(ctx)
+		if err == nil && saved != nil {
+			hardDeleteFismaSystemByID(saved.FismaSystemID)
+		}
+		require.Error(t, err, "DB CHECK must reject an off-canon system_type")
+	})
+
+	t.Run("RejectsBadCloudServiceModelElement", func(t *testing.T) {
+		fs := &FismaSystem{
+			FismaUID:          "ztmf433-badarr-uid",
+			FismaAcronym:      "ZT433BA",
+			FismaName:         "bad array fixture (ztmf#433)",
+			CloudServiceModel: []string{"IaaS", "Bogus"},
+		}
+		saved, err := fs.Save(ctx)
+		if err == nil && saved != nil {
+			hardDeleteFismaSystemByID(saved.FismaSystemID)
+		}
+		require.Error(t, err, "DB CHECK must reject a non-canonical cloud_service_model element")
+	})
+}
+
+// hardDeleteFismaSystemByID removes a test-created system with a raw DELETE (the
+// app only soft-decommissions), on a fresh connection so it is safe from a
+// t.Cleanup after the test body's conn is released.
+func hardDeleteFismaSystemByID(id int32) {
+	c, err := db.Conn(context.Background())
+	if err != nil {
+		return
+	}
+	defer c.Release()
+	_, _ = c.Exec(context.Background(), `DELETE FROM fismasystems WHERE fismasystemid = $1`, id)
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -389,9 +389,16 @@ components:
     model.FismaSystem:
       properties:
         cloud_service_model:
-          type: string
+          description: |-
+            CloudServiceModel is a decomposed multi-select stored as a text[] column;
+            nil = omitted/NULL, an empty slice clears it, a populated slice is the set
+            of canonical values (IaaS/PaaS/SaaS/Other), enforced by a DB CHECK.
+          items:
+            type: string
+          type: array
+          uniqueItems: false
         cloud_system:
-          type: string
+          type: boolean
         cloud_vendor:
           type: string
         component:
@@ -429,13 +436,16 @@ components:
         groupname:
           type: string
         hva:
-          type: string
+          description: |-
+            HHS metadata typed by ztmf#433. Booleans are *bool so NULL stays "unknown"
+            (the epic rule: never coerce a missing value to false/No).
+          type: boolean
         isso_name:
           type: string
         issoemail:
           type: string
         legacy:
-          type: string
+          type: boolean
         opdiv_id:
           type: integer
         reactivated_by:


### PR DESCRIPTION
## Summary

Sub-issue of the metadata-standardization epic (#431). Retypes the free-text HHS metadata columns on `fismasystems` into typed, self-validating columns. This is the **retype** half of the backend work; the vocabulary endpoint + friendly validation are #395 (stacked on this branch).

## What changed

**Migration `0052fismasystemsretype.go`** — canonicalizes existing values in place, then retypes:
- `hva`, `cloud_system`, `legacy`: `varchar` → `boolean`. **`null` stays "unknown"** and is never coerced to `false` (epic rule).
- `cloud_service_model`: `varchar` → `text[]` (decomposed, per the epic's "store decomposed, not one combined string"), with a CHECK on the elements (`IaaS`/`PaaS`/`SaaS`/`Other`).
- `fips`, `system_type`, `system_operator`, `goco_coco_gogo`: stay `varchar` with NULL-tolerant CHECK constraints (house style, matching `0046`/`0048`).
- Normalization collapses the documented off-canon spellings (`GOVO`→`GOGO`, `Minor Stand-alone`→`Minor Standalone`, etc., case/whitespace-folded); anything unmappable → NULL so the CHECKs can't fail the migration. `down` reverses cleanly.

**Model / `Save()`** — the three booleans become `*bool` and `cloud_service_model` becomes `[]string`; writes preserve the omit/clear/set three-state (`emptyToNil` for the array). Integration tests cover the typed round-trip, unknown-stays-NULL, the partial-update nil-guard, empty-slice clear, and CHECK rejection.

## Contract / coordination

- **API contract change:** these fields now serialize as `boolean` / array instead of strings. The frontend (ztmf-ui#626) consumes the new shapes.
- **SDL/Snowflake:** the varchar→typed change breaks the PG→Snowflake export (`CORE.ZTMF_FISMASYSTEMS`) in the private `ztmf-insights` repo. This is accepted (nothing reads it yet); a follow-up patches the export downstream.

## Verification

`go build`/`vet`/`test -short` green. Migration + typed round-trip need a seeded DB (CI).

## Notes for reviewers

- Data is mostly NULL for these columns today (HHS not yet loaded; CMS rows NULL), so the in-place normalization touches few rows.
- **#395 is stacked on this branch.** Merge this first, or merge #395 directly (it contains these commits).

Refs #431. Closes #433.
