### PR TITLE
Harden Aurora backups: 35-day PITR, AWS Backup enrollment, and monthly logical dumps

### DIFF
--- a/backend/ops/Dockerfile
+++ b/backend/ops/Dockerfile
@@ -4,10 +4,21 @@ RUN apk add --no-cache \
         aws-cli-v2 \
         bash \
         ca-certificates-bundle \
+        coreutils \
         curl \
         jq \
         postgresql-16-client
 
+# RDS global trust bundle, so psql/pg_dump can run with sslmode=verify-full
+# instead of merely encrypting. Not present in the distro CA bundle.
+ADD --chmod=0444 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+    /etc/ssl/certs/rds-global-bundle.pem
+
+COPY --chmod=0555 dump-db.sh /usr/local/bin/dump-db.sh
+COPY --chmod=0555 check-dump-age.sh /usr/local/bin/check-dump-age.sh
+
 USER nonroot
 
+# Default is the interactive shell target used by scripts/db-tunnel.sh. The
+# scheduled monthly backup task overrides this with dump-db.sh.
 CMD ["sleep", "infinity"]

--- a/backend/ops/check-dump-age.sh
+++ b/backend/ops/check-dump-age.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Daily staleness probe for the monthly database dumps.
+#
+# Publishes ZTMF/Backup DaysSinceLastDump so the freshness of the backups can
+# be alarmed on. This exists as a separate daily job rather than as a heartbeat
+# emitted by the dump itself because CloudWatch caps an alarm's total
+# evaluation range (period x evaluation_periods) at seven days. A monthly
+# success pulse leaves ~29 consecutive days with no datapoint, so no legal
+# alarm can distinguish "between scheduled dumps" from "dumps stopped
+# happening". A daily gauge of the age of the newest object can.
+#
+# It reads the bucket rather than trusting a metric the dump job wrote, so it
+# also catches an upload that was reported as successful but did not land.
+#
+# Required environment (supplied by the task definition):
+#   DUMP_BUCKET   bucket holding the dumps
+#   ENVIRONMENT   dev | prod (key prefix and metric dimension)
+#   AWS_REGION    region for the AWS CLI calls
+
+set -euo pipefail
+
+: "${DUMP_BUCKET:?DUMP_BUCKET is required}"
+: "${ENVIRONMENT:?ENVIRONMENT is required}"
+
+readonly METRIC_NAMESPACE="ZTMF/Backup"
+readonly PREFIX="pgdump/${ENVIRONMENT}/"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+log "listing s3://${DUMP_BUCKET}/${PREFIX}"
+
+# Only the .dump archives count. A stray globals file without its archive is
+# not a usable backup and must not reset the clock.
+newest="$(aws s3api list-objects-v2 \
+  --bucket "${DUMP_BUCKET}" \
+  --prefix "${PREFIX}" \
+  --query 'sort_by(Contents[?ends_with(Key, `.dump`)], &LastModified)[-1].LastModified' \
+  --output text)"
+
+if [[ -z "${newest}" || "${newest}" == "None" ]]; then
+  # An empty bucket is indistinguishable from a bucket whose contents were
+  # deleted. Both are reported as maximally stale rather than as missing data,
+  # so a brand new environment surfaces immediately instead of looking healthy.
+  log "no dumps found under ${PREFIX}; reporting maximum age"
+  age_days=9999
+else
+  # GNU date, from the coreutils package added to the image for this. The
+  # busybox date that wolfi-base ships by default does not parse the
+  # "+00:00" offset S3 returns in LastModified.
+  newest_epoch="$(date -u -d "${newest}" +%s)"
+  now_epoch="$(date -u +%s)"
+  age_days=$(((now_epoch - newest_epoch) / 86400))
+  log "newest dump ${newest}, ${age_days} days old"
+fi
+
+aws cloudwatch put-metric-data \
+  --namespace "${METRIC_NAMESPACE}" \
+  --metric-name DaysSinceLastDump \
+  --value "${age_days}" \
+  --unit Count \
+  --dimensions "Environment=${ENVIRONMENT}"
+
+log "done"

--- a/backend/ops/dump-db.sh
+++ b/backend/ops/dump-db.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Monthly logical backup of the ZTMF Aurora cluster to S3.
+#
+# Run as a scheduled Fargate task off the same ops image used for interactive
+# database access (see infrastructure/backup-dumps.tf). This is deliberately a
+# logical dump rather than another snapshot: recovery for a single bad row is
+# never "restore the cluster", because every Aurora restore path produces a new
+# cluster and rolling production back weeks to fix one row would discard
+# everything else. The real procedure is to stand up a reference copy, diff the
+# affected rows, and apply a targeted UPDATE, so the artifact's readability
+# matters more than its restorability. A pg_dump restores into local docker in
+# minutes; a snapshot needs a new cluster.
+#
+# It is also the only copy with no expiry, which matters given the usage
+# pattern: an unnoticed edit can plausibly sit for a year.
+#
+# Required environment (supplied by the task definition):
+#   DB_SECRET_ID  Secrets Manager ARN of the RDS-managed master credential
+#   DB_ENDPOINT   cluster writer endpoint
+#   DB_PORT       postgres port
+#   DB_NAME       database to dump
+#   DUMP_BUCKET   destination S3 bucket
+#   ENVIRONMENT   dev | prod (key prefix and metric dimension)
+#   AWS_REGION    region for the AWS CLI calls
+
+set -euo pipefail
+
+: "${DB_SECRET_ID:?DB_SECRET_ID is required}"
+: "${DB_ENDPOINT:?DB_ENDPOINT is required}"
+: "${DB_PORT:?DB_PORT is required}"
+: "${DB_NAME:?DB_NAME is required}"
+: "${DUMP_BUCKET:?DUMP_BUCKET is required}"
+: "${ENVIRONMENT:?ENVIRONMENT is required}"
+
+readonly METRIC_NAMESPACE="ZTMF/Backup"
+
+# Assigned then marked readonly separately: `readonly X="$(cmd)"` makes the
+# builtin's exit status the one `set -e` sees, so a failing mktemp would leave
+# WORKDIR empty and hand `rm -rf ""` to the trap.
+WORKDIR="$(mktemp -d)"
+readonly WORKDIR
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+year="$(date -u +%Y)"
+prefix="pgdump/${ENVIRONMENT}/${year}"
+dump_file="${WORKDIR}/ztmf-${ENVIRONMENT}-${timestamp}.dump"
+globals_file="${WORKDIR}/ztmf-${ENVIRONMENT}-${timestamp}.globals.sql"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+log "fetching database credentials"
+secret_json="$(aws secretsmanager get-secret-value \
+  --secret-id "${DB_SECRET_ID}" \
+  --query SecretString \
+  --output text)"
+
+PGUSER="$(jq -r '.username' <<<"${secret_json}")"
+PGPASSWORD="$(jq -r '.password' <<<"${secret_json}")"
+export PGUSER PGPASSWORD
+unset secret_json
+
+export PGHOST="${DB_ENDPOINT}"
+export PGPORT="${DB_PORT}"
+# verify-full, not require. `require` encrypts but performs no certificate or
+# hostname validation, so it defeats passive sniffing while leaving an in-path
+# substitution undetected. The RDS global trust bundle is baked into the image
+# and the cluster pins ca_cert_identifier, so full verification costs nothing.
+export PGSSLMODE="verify-full"
+export PGSSLROOTCERT="/etc/ssl/certs/rds-global-bundle.pem"
+
+log "dumping ${DB_NAME} in custom format"
+pg_dump --format=custom --compress=9 --no-owner --no-privileges \
+  --file="${dump_file}" "${DB_NAME}"
+
+# Roles and other cluster-wide objects live outside any single database, so a
+# database-only dump is not enough to reconstruct a working reference copy.
+# --database pins the connection database: pg_dumpall otherwise defaults to
+# `postgres`, which is not guaranteed to exist or be reachable by this role.
+log "dumping globals"
+pg_dumpall --globals-only --no-role-passwords \
+  --database="${DB_NAME}" --file="${globals_file}"
+
+# Verify the archive parses before it is uploaded and the local copy is
+# discarded. A dump that cannot be listed cannot be restored, and finding that
+# out at recovery time defeats the point of having it.
+log "verifying archive integrity"
+pg_restore --list "${dump_file}" >/dev/null
+
+dump_bytes="$(wc -c <"${dump_file}")"
+if [[ "${dump_bytes}" -lt 1024 ]]; then
+  log "ERROR: dump is only ${dump_bytes} bytes, refusing to upload"
+  exit 1
+fi
+log "dump is ${dump_bytes} bytes"
+
+log "uploading to s3://${DUMP_BUCKET}/${prefix}/"
+aws s3 cp "${dump_file}" "s3://${DUMP_BUCKET}/${prefix}/$(basename "${dump_file}")"
+aws s3 cp "${globals_file}" "s3://${DUMP_BUCKET}/${prefix}/$(basename "${globals_file}")"
+
+# Informational only. Staleness is detected by check-dump-age.sh reading the
+# bucket daily, not by this pulse, because CloudWatch caps an alarm's total
+# evaluation range at seven days and a monthly heartbeat cannot be alarmed on
+# across a 40-day window.
+#
+# Deliberately non-fatal: both objects are already durably in S3 by this point,
+# so failing the task over a CloudWatch hiccup would report a backup as missing
+# when it is sitting in the bucket.
+log "publishing success metric"
+aws cloudwatch put-metric-data \
+  --namespace "${METRIC_NAMESPACE}" \
+  --metric-name DumpSucceeded \
+  --value 1 \
+  --unit Count \
+  --dimensions "Environment=${ENVIRONMENT}" ||
+  log "WARN: could not publish DumpSucceeded; the dump itself succeeded"
+
+log "done"

--- a/infrastructure/backup-dumps.tf
+++ b/infrastructure/backup-dumps.tf
@@ -1,0 +1,536 @@
+# Monthly logical backup of the Aurora cluster to S3.
+#
+# Third leg of the backup strategy, alongside 35-day PITR and the AWS Backup
+# `d15_w90` enrollment in rds.tf. Each leg covers a different discovery lag:
+#
+#   lag           PITR @ 35d   d15_w90 chain   monthly dump
+#   <= 35 days    yes          yes             yes
+#   36-95 days    no           yes             yes
+#   96d - 1 year  no           no              yes
+#   > 1 year      no           no              yes
+#
+# The incident that prompted this surfaced 35 days after the edit, which is
+# exactly the Aurora PITR ceiling. Designing to the worst case already observed
+# leaves no margin, which is what the two longer-lived legs are for.
+#
+# Snapshot export to Parquet was considered and rejected: it needs a bucket, an
+# IAM role, a customer-managed KMS key with specific grants, and orchestration,
+# and produces an artifact you cannot restore from. Aurora cloning is not a
+# backup either - a clone holds today's data and costs ~$43/month if left
+# running. A pg_dump is strictly better for the same money.
+
+resource "aws_s3_bucket" "ztmf_db_dumps" {
+  bucket = "ztmf-db-dumps-${var.environment}"
+
+  # Must be set at creation; enabling Object Lock later requires AWS support.
+  object_lock_enabled = true
+
+  tags = {
+    Name        = "ZTMF Database Dumps"
+    Environment = var.environment
+    Purpose     = "Long-horizon logical backups of the Aurora cluster"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "ztmf_db_dumps" {
+  bucket = aws_s3_bucket.ztmf_db_dumps.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Required by Object Lock, and independently useful: a same-key overwrite
+# cannot destroy the prior dump.
+resource "aws_s3_bucket_versioning" "ztmf_db_dumps" {
+  bucket = aws_s3_bucket.ztmf_db_dumps.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ztmf_db_dumps" {
+  bucket = aws_s3_bucket.ztmf_db_dumps.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# GOVERNANCE rather than COMPLIANCE. GOVERNANCE stops routine and accidental
+# deletion while leaving a documented break-glass path for a principal holding
+# s3:BypassGovernanceRetention. COMPLIANCE cannot be overridden by anyone
+# including the account root for the full retention period, which is a large
+# commitment to make on behalf of an account we do not solely control.
+resource "aws_s3_bucket_object_lock_configuration" "ztmf_db_dumps" {
+  bucket = aws_s3_bucket.ztmf_db_dumps.id
+
+  rule {
+    default_retention {
+      mode = "GOVERNANCE"
+      days = 365
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.ztmf_db_dumps]
+}
+
+# No expiration rule: these are the only copies with no expiry, which is the
+# entire reason they exist. Storage class steps down instead. Glacier IR keeps
+# millisecond retrieval, so a dump stays as easy to diff at two years as at two
+# months - important because the recovery procedure is "read it", not "restore
+# the cluster".
+resource "aws_s3_bucket_lifecycle_configuration" "ztmf_db_dumps" {
+  bucket = aws_s3_bucket.ztmf_db_dumps.id
+
+  rule {
+    id     = "dumps-to-glacier-ir"
+    status = "Enabled"
+
+    filter {
+      prefix = "pgdump/"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER_IR"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 90
+      storage_class   = "GLACIER_IR"
+    }
+  }
+
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.ztmf_db_dumps]
+}
+
+# Dedicated task role rather than reusing module.ops_task. The interactive ops
+# role exists so an operator can reach the database; this one additionally
+# writes backups, and the two should not grow into each other.
+module "db_dump_task" {
+  name      = "ztmf_db_dump_task${local.underscore_sfx}"
+  source    = "./modules/role"
+  principal = { Service = "ecs-tasks.amazonaws.com" }
+}
+
+resource "aws_iam_role_policy" "ztmf_db_dump_task" {
+  name = "dbDumpTaskPermissions"
+  role = module.db_dump_task.role_id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+        ]
+        Effect   = "Allow"
+        Resource = [local.db_cred_secret]
+      },
+      {
+        # Write-only. The task never needs to read a dump back, and no
+        # s3:DeleteObject means a compromised task cannot erase history even
+        # before Object Lock is considered. AbortMultipartUpload only lets it
+        # clean up its own failed upload; the lifecycle rule sweeps whatever it
+        # misses after 7 days.
+        Action = [
+          "s3:PutObject",
+          "s3:AbortMultipartUpload",
+        ]
+        Effect   = "Allow"
+        Resource = ["${aws_s3_bucket.ztmf_db_dumps.arn}/*"]
+      },
+      {
+        # PutMetricData cannot be scoped to a resource; the namespace
+        # condition is the supported way to constrain it.
+        Action   = ["cloudwatch:PutMetricData"]
+        Effect   = "Allow"
+        Resource = ["*"]
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "ZTMF/Backup"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "ztmf_db_dump" {
+  name              = "ztmf_db_dump${local.underscore_sfx}"
+  retention_in_days = 90
+
+  tags = {
+    Name        = "ZTMF DB Dump"
+    Environment = var.environment
+  }
+}
+
+# Same image as the interactive ops task, different entrypoint. Memory is
+# raised over the 512 MB interactive task to give pg_dump's compression buffers
+# headroom; the dump itself lands in the task's ephemeral storage before upload.
+resource "aws_ecs_task_definition" "ztmf_db_dump" {
+  execution_role_arn       = module.ops_task_execution.role_arn
+  task_role_arn            = module.db_dump_task.role_arn
+  family                   = "db-dump${local.name_suffix}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 512
+  memory                   = 1024
+  container_definitions = jsonencode([
+    {
+      name      = "ztmfdbdump"
+      image     = "${local.ecr_ops_repo_url}:${data.aws_ssm_parameter.ztmf_ops_tag.insecure_value}"
+      essential = true
+      command   = ["/usr/local/bin/dump-db.sh"]
+
+      environment = [
+        { name = "ENVIRONMENT", value = var.environment },
+        { name = "AWS_REGION", value = "us-east-1" },
+        { name = "DB_NAME", value = "ztmf" },
+        { name = "DB_ENDPOINT", value = aws_rds_cluster.ztmf.endpoint },
+        { name = "DB_PORT", value = "5432" },
+        { name = "DB_SECRET_ID", value = local.db_cred_secret },
+        { name = "DUMP_BUCKET", value = aws_s3_bucket.ztmf_db_dumps.bucket },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ztmf_db_dump.name
+          "awslogs-region"        = "us-east-1"
+          "awslogs-stream-prefix" = "dump"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_security_group" "ztmf_db_dump_task" {
+  name        = "ztmf_db_dump_task${local.underscore_sfx}"
+  description = "scheduled db dump task: Aurora, VPC endpoints, CloudWatch via NAT"
+  vpc_id      = data.aws_vpc.ztmf.id
+
+  egress {
+    description = "HTTPS to VPC endpoints (ECR, Secrets Manager, S3, CloudWatch Logs)"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    security_groups = [
+      local.manage_vpc_endpoints
+      ? aws_security_group.ztmf_vpc_endpoints[0].id
+      : data.aws_security_group.ztmf_vpc_endpoints[0].id
+    ]
+  }
+
+  egress {
+    description     = "PostgreSQL to Aurora"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ztmf_db.id]
+  }
+
+  # The VPC has interface endpoints for ecr, logs, s3, secretsmanager, ssm and
+  # friends, but none for `monitoring`, so the PutMetricData calls egress
+  # through the CMS-provided NAT gateway rather than adding an endpoint. This
+  # rule is also what carries any AWS API call whose endpoint resolves
+  # publicly, which in practice includes some of the S3 traffic.
+  egress {
+    description = "HTTPS to CloudWatch and other AWS APIs via the CMS-provided NAT gateway"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# EventBridge Scheduler rather than an EventBridge rule: it is the current AWS
+# recommendation for scheduled invocations, supports a native ECS RunTask
+# target without a rule/target pair, and matches the direction of the pending
+# migration of the existing Lambda schedules.
+module "db_dump_scheduler" {
+  name      = "ztmf_db_dump_scheduler${local.underscore_sfx}"
+  source    = "./modules/role"
+  principal = { Service = "scheduler.amazonaws.com" }
+}
+
+resource "aws_iam_role_policy" "ztmf_db_dump_scheduler" {
+  name = "dbDumpSchedulerPermissions"
+  role = module.db_dump_scheduler.role_id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = ["ecs:RunTask"]
+        Effect = "Allow"
+        # RunTask is authorized against the revision-less family ARN so a new
+        # task definition revision does not require a policy update.
+        Resource = ["${aws_ecs_task_definition.ztmf_db_dump.arn_without_revision}:*"]
+        Condition = {
+          ArnLike = {
+            "ecs:cluster" = aws_ecs_cluster.ztmf.arn
+          }
+        }
+      },
+      {
+        Action = ["iam:PassRole"]
+        Effect = "Allow"
+        Resource = [
+          module.db_dump_task.role_arn,
+          module.ops_task_execution.role_arn,
+        ]
+        Condition = {
+          StringLike = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
+# 06:30 UTC on the 1st. Deliberately outside the 06:00-06:30 Aurora backup
+# window so the two do not contend, and well clear of the Sunday maintenance
+# window.
+resource "aws_scheduler_schedule" "ztmf_db_dump" {
+  name        = "ztmf-db-dump-${var.environment}"
+  description = "Monthly pg_dump of the ZTMF Aurora cluster to S3"
+  state       = var.db_dump_enabled ? "ENABLED" : "DISABLED"
+
+  schedule_expression          = "cron(30 6 1 * ? *)"
+  schedule_expression_timezone = "UTC"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = aws_ecs_cluster.ztmf.arn
+    role_arn = module.db_dump_scheduler.role_arn
+
+    ecs_parameters {
+      task_definition_arn = aws_ecs_task_definition.ztmf_db_dump.arn
+      launch_type         = "FARGATE"
+      task_count          = 1
+
+      network_configuration {
+        assign_public_ip = false
+        subnets          = data.aws_subnets.private.ids
+        security_groups  = [aws_security_group.ztmf_db_dump_task.id]
+      }
+    }
+
+    # Covers failure to *invoke* RunTask (throttling, a transient ECS API
+    # error) only. Once ECS accepts the task the delivery is successful as far
+    # as Scheduler is concerned, so a container that starts and then fails is
+    # not retried here - that case is caught by DaysSinceLastDump staying high
+    # into the next day.
+    retry_policy {
+      maximum_event_age_in_seconds = 3600
+      maximum_retry_attempts       = 3
+    }
+  }
+}
+
+# Daily staleness probe.
+#
+# The obvious design - have the dump publish a success pulse and alarm on
+# missing data over 40 days - is not expressible. CloudWatch caps an alarm's
+# total evaluation range (period x evaluation_periods) at 604800 seconds, so
+# the longest possible lookback is 7 days. A monthly pulse leaves ~29
+# consecutive days with no datapoint, which any legal alarm reads as breaching.
+#
+# So freshness is measured instead of inferred: this task lists the bucket once
+# a day and publishes the age of the newest dump, which the alarm below reads
+# over a single 1-day period. It also catches an upload that the dump job
+# believed succeeded but which never landed, since it trusts the bucket rather
+# than the previous job's own report.
+resource "aws_ecs_task_definition" "ztmf_db_dump_check" {
+  execution_role_arn       = module.ops_task_execution.role_arn
+  task_role_arn            = module.db_dump_check.role_arn
+  family                   = "db-dump-check${local.name_suffix}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  container_definitions = jsonencode([
+    {
+      name      = "ztmfdbdumpcheck"
+      image     = "${local.ecr_ops_repo_url}:${data.aws_ssm_parameter.ztmf_ops_tag.insecure_value}"
+      essential = true
+      command   = ["/usr/local/bin/check-dump-age.sh"]
+
+      environment = [
+        { name = "ENVIRONMENT", value = var.environment },
+        { name = "AWS_REGION", value = "us-east-1" },
+        { name = "DUMP_BUCKET", value = aws_s3_bucket.ztmf_db_dumps.bucket },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ztmf_db_dump.name
+          "awslogs-region"        = "us-east-1"
+          "awslogs-stream-prefix" = "check"
+        }
+      }
+    }
+  ])
+}
+
+# Read-only against the bucket. It never needs the database credentials, so it
+# does not get them.
+module "db_dump_check" {
+  name      = "ztmf_db_dump_check${local.underscore_sfx}"
+  source    = "./modules/role"
+  principal = { Service = "ecs-tasks.amazonaws.com" }
+}
+
+resource "aws_iam_role_policy" "ztmf_db_dump_check" {
+  name = "dbDumpCheckPermissions"
+  role = module.db_dump_check.role_id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["s3:ListBucket"]
+        Effect   = "Allow"
+        Resource = [aws_s3_bucket.ztmf_db_dumps.arn]
+      },
+      {
+        Action   = ["cloudwatch:PutMetricData"]
+        Effect   = "Allow"
+        Resource = ["*"]
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "ZTMF/Backup"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ztmf_db_dump_check_scheduler" {
+  name = "dbDumpCheckSchedulerPermissions"
+  role = module.db_dump_scheduler.role_id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["ecs:RunTask"]
+        Effect   = "Allow"
+        Resource = ["${aws_ecs_task_definition.ztmf_db_dump_check.arn_without_revision}:*"]
+        Condition = {
+          ArnLike = {
+            "ecs:cluster" = aws_ecs_cluster.ztmf.arn
+          }
+        }
+      },
+      {
+        Action   = ["iam:PassRole"]
+        Effect   = "Allow"
+        Resource = [module.db_dump_check.role_arn]
+        Condition = {
+          StringLike = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
+# 07:45 UTC daily, clear of both the Aurora backup window and the monthly dump
+# so a same-day dump is already in the bucket when the age is measured.
+resource "aws_scheduler_schedule" "ztmf_db_dump_check" {
+  name        = "ztmf-db-dump-check-${var.environment}"
+  description = "Daily freshness probe for the ZTMF database dumps"
+  state       = var.db_dump_enabled ? "ENABLED" : "DISABLED"
+
+  schedule_expression          = "cron(45 7 * * ? *)"
+  schedule_expression_timezone = "UTC"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = aws_ecs_cluster.ztmf.arn
+    role_arn = module.db_dump_scheduler.role_arn
+
+    ecs_parameters {
+      task_definition_arn = aws_ecs_task_definition.ztmf_db_dump_check.arn
+      launch_type         = "FARGATE"
+      task_count          = 1
+
+      network_configuration {
+        assign_public_ip = false
+        subnets          = data.aws_subnets.private.ids
+        security_groups  = [aws_security_group.ztmf_db_dump_task.id]
+      }
+    }
+
+    retry_policy {
+      maximum_event_age_in_seconds = 3600
+      maximum_retry_attempts       = 3
+    }
+  }
+}
+
+# Fires when the newest dump is older than 40 days - a month plus margin for a
+# missed run - or when the probe itself stops reporting.
+#
+# Total evaluation range is 86400s, inside the CloudWatch 604800s ceiling.
+# treat_missing_data stays "breaching" because the failure worth catching is
+# the silent one: a disabled schedule, a broken image, a revoked role. Those
+# produce no datapoint at all, and an alarm keyed on task exit status would
+# stay green forever while backups quietly stopped.
+#
+# Counted off var.db_dump_enabled so environments that deliberately run without
+# dumps (impl) do not sit permanently in ALARM against a live SNS subscription.
+# Note that in an environment where it IS enabled, the alarm goes ALARM on
+# first apply and clears once the probe has run - it does not wait 40 days to
+# tell you it has no data.
+resource "aws_cloudwatch_metric_alarm" "ztmf_db_dump_stale" {
+  count               = var.db_dump_enabled ? 1 : 0
+  alarm_name          = "ztmf-db-dump-stale-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  datapoints_to_alarm = "1"
+  metric_name         = "DaysSinceLastDump"
+  namespace           = "ZTMF/Backup"
+  period              = "86400"
+  statistic           = "Maximum"
+  threshold           = "40"
+  treat_missing_data  = "breaching"
+  alarm_description   = "The newest ZTMF database dump is more than 40 days old, or the daily freshness probe has stopped reporting. Check the ztmf-db-dump and ztmf-db-dump-check schedules and the ztmf_db_dump log group."
+  alarm_actions       = [aws_sns_topic.ztmf_alarms.arn]
+  ok_actions          = [aws_sns_topic.ztmf_alarms.arn]
+
+  dimensions = {
+    Environment = var.environment
+  }
+
+  tags = {
+    Name        = "ZTMF DB Dump Stale Alarm"
+    Environment = var.environment
+  }
+}

--- a/infrastructure/rds.tf
+++ b/infrastructure/rds.tf
@@ -28,11 +28,76 @@ resource "aws_rds_cluster" "ztmf" {
   manage_master_user_password = true
   storage_encrypted           = true
 
+  # Point-in-time recovery. Prod runs at the Aurora maximum of 35 days; dev
+  # stays at 1 because it holds no data worth recovering at that horizon. See
+  # var.db_backup_retention_days.
+  #
+  # In prod this is deliberately NOT lowered between data calls. Aurora meters
+  # backup storage on change volume rather than volume size, so a quiet month
+  # costs near nothing anyway, and the quiet months are exactly when an
+  # unnoticed edit is most likely to be sitting inside the PITR window.
+  #
+  # 35 days is the Aurora ceiling, not a sufficient answer on its own. The
+  # incident that prompted this surfaced 35 days after the edit, so PITR alone
+  # would have covered it with zero margin. Late-discovery coverage comes from
+  # the AWS Backup enrollment below and the monthly dumps in backup-dumps.tf.
+  backup_retention_period = var.db_backup_retention_days
+
+  # Pinned rather than left to the AWS-assigned random windows (prod was
+  # 06:19-06:49 / sun:07:05-sun:07:35, dev 08:37-09:07 / tue:10:22-tue:10:52).
+  # Pinning keeps the two envs identical and stops a silent out-of-band change
+  # from going unnoticed. Both are UTC; the backup window must not overlap the
+  # maintenance window.
+  preferred_backup_window      = "06:00-06:30"
+  preferred_maintenance_window = "sun:07:00-sun:07:30"
+
+  # Snapshots inherit cluster tags, so a restored cluster keeps its provenance.
+  copy_tags_to_snapshot = true
+
+  # This cluster is the system of record for every data call response. An
+  # accidental destroy is not recoverable from anything short of a snapshot
+  # restore, so require an explicit console/CLI removal of the flag first.
+  deletion_protection = true
+
+  # Pinned to the value already in use so a manual parameter-group swap shows
+  # up as drift instead of silently persisting.
+  db_cluster_parameter_group_name = "default.aurora-postgresql16"
+
+  # AWS_Backup enrolls the cluster in the CMS OIT `Daily15_Weekly90` plan,
+  # which selects purely on this tag (StringEquals aws:ResourceTag/AWS_Backup
+  # = d15_w90) and holds 15 daily plus weekly recovery points for 95 days. The
+  # plans already run daily in this account against zero tagged resources, so
+  # enrollment is one tag rather than a new backup stack.
+  #
+  # Do NOT use the d15_w90_m365_y730 plan: its yearly rule requests 730-day
+  # retention against a vault capped at MaxRetentionDays 720, so those jobs
+  # fail. Use d15_w90 or d15_w90_m365.
+  #
+  # Do NOT copy this tag onto aws_rds_cluster_instance below. AWS Backup
+  # protects Aurora at the cluster level; a tagged serverless instance is
+  # selected as a separate RDS resource and its jobs fail.
+  tags = {
+    Name        = local.ztmf_name
+    Environment = var.environment
+    AWS_Backup  = "d15_w90"
+  }
+
   serverlessv2_scaling_configuration {
     max_capacity = 1.0
     min_capacity = 0.5
   }
   vpc_security_group_ids = [aws_security_group.ztmf_db.id]
+
+  # auto_minor_version_upgrade is on for the instance, so AWS applies minor
+  # patches on its own schedule and the live version drifts ahead of the
+  # literal above (16.11 today). Without this, the next AWS-applied patch makes
+  # every subsequent plan propose a downgrade back to the pinned value. Refresh
+  # still records the real version in state, so the instance reference below
+  # continues to resolve correctly. Remove this block temporarily to perform a
+  # deliberate, reviewed version change.
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }
 
 resource "aws_rds_cluster_instance" "ztmf" {
@@ -42,4 +107,17 @@ resource "aws_rds_cluster_instance" "ztmf" {
   instance_class       = "db.serverless"
   engine               = aws_rds_cluster.ztmf.engine
   engine_version       = aws_rds_cluster.ztmf.engine_version
+
+  # Explicit rather than relying on the provider default, since it is the
+  # reason engine_version is ignored above.
+  auto_minor_version_upgrade = true
+
+  tags = {
+    Name        = local.ztmf_name
+    Environment = var.environment
+  }
+
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }

--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -25,3 +25,15 @@ alarm_notification_email = "jono@aquia.us"
 enable_cert_rotation_lambda = true
 cert_rotation_prefix        = "dev"
 cert_rotation_domain        = "dev.ztmf.cms.gov"
+
+# Aurora PITR. Dev keeps the 1-day default it already runs at: nothing here is
+# a system of record, and the long-horizon protection prod needs would be paid
+# for on data we would never restore.
+db_backup_retention_days = 1
+
+# Monthly logical backup to S3. Enabled in dev first so the schedule, task and
+# staleness alarm are exercised on real data before prod depends on them. Dev
+# also stays enrolled in the AWS Backup d15_w90 plan (~$0.02/month) on purpose:
+# the tag-selection path has never executed in this account, so dev is where we
+# confirm the CMS-managed selection role can actually back up Aurora.
+db_dump_enabled = true

--- a/infrastructure/tfvars/impl.tfvars
+++ b/infrastructure/tfvars/impl.tfvars
@@ -23,3 +23,10 @@ kion_rotate_schedule_enabled = false
 enable_cert_rotation_lambda = true
 cert_rotation_prefix        = "impl"
 cert_rotation_domain        = "impl.ztmf.cms.gov"
+
+# Backups: impl is a throwaway experiment environment sharing the dev account.
+# Keep PITR at the 1-day minimum and leave the monthly dump schedule off (the
+# bucket and task definition are still created, so it can be switched on for a
+# single experiment without an infrastructure change).
+db_backup_retention_days = 1
+db_dump_enabled          = false

--- a/infrastructure/tfvars/prod.tfvars
+++ b/infrastructure/tfvars/prod.tfvars
@@ -15,3 +15,12 @@ entra_enabled = false
 enable_cert_rotation_lambda = true
 cert_rotation_prefix        = "prod"
 cert_rotation_domain        = "ztmf.cms.gov"
+
+# Aurora PITR at the Aurora maximum. Set explicitly rather than relying on the
+# default so the prod value is visible next to the environment it protects.
+db_backup_retention_days = 35
+
+# Monthly logical backup to S3. This is the environment the strategy exists for
+# - prod holds the submitted data call responses that the training-session edit
+# incident put at risk.
+db_dump_enabled = true

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -24,6 +24,23 @@ variable "alarm_notification_email" {
   default     = ""
 }
 
+variable "db_backup_retention_days" {
+  description = "Aurora point-in-time-recovery retention window, in days. Prod runs at the Aurora maximum of 35 because the incident this addresses surfaced 35 days after the edit. Dev holds no data worth recovering at that horizon, so it runs shorter. Valid range is 1-35."
+  type        = number
+  default     = 35
+
+  validation {
+    condition     = var.db_backup_retention_days >= 1 && var.db_backup_retention_days <= 35
+    error_message = "db_backup_retention_days must be between 1 and 35 (the Aurora maximum)."
+  }
+}
+
+variable "db_dump_enabled" {
+  description = "Enable the monthly EventBridge schedule that dumps the Aurora cluster to the ztmf-db-dumps bucket. The bucket, task definition and alarm are always created so the schedule can be flipped on without an infrastructure change; only the schedule itself is gated. Defaults to false so a new environment does not start writing backups before its ops image has been pushed."
+  type        = bool
+  default     = false
+}
+
 variable "kion_rotate_schedule_enabled" {
   description = "Enable the daily EventBridge schedule for ztmf-kion-key-rotate. Kion NAT allowlist is in place (CMS-Enterprise/ztmf-misc#174) and real rotation was validated end to end on 2026-04-22, so this defaults to true. Set to false only for temporary maintenance windows when rotation must be paused."
   type        = bool


### PR DESCRIPTION
## Why

An unintended survey response edit was discovered five weeks after it happened, and there was no backup old enough to recover from. This is the infrastructure side of making that recoverable.

The cluster is about 105 MB and Aurora meters backup storage on change volume rather than volume size, so cost is not a decision input here - the whole thing lands under $0.15/month worst case. Simplicity and late-discovery coverage are what drove the choices.

## What

Three legs, because no single one covers the observed failure:

**1. Point-in-time recovery raised to 35 days in prod.** Dev and impl stay at 1 day; neither holds data worth recovering at that horizon. 35 is the Aurora ceiling and deliberately not enough on its own - the incident surfaced at exactly 35 days, so PITR alone would have covered it with zero margin and missed it entirely at six weeks. That is what justifies the other two legs.

**2. Enrollment in the existing CMS OIT `Daily15_Weekly90` plan.** This account already has seven backup plans executing daily against a locked vault. Every one selects purely on an `AWS_Backup` tag, and nothing in the account carries it, so no backup job has ever run. Enrollment turned out to be one tag rather than a new backup stack. That buys 15 daily plus weekly recovery points held 95 days.

**3. A monthly `pg_dump` to a new Object Lock bucket**, driven by EventBridge Scheduler running the existing ops image with a different entrypoint. This is the only copy with no expiry, which matters given the usage pattern - fourteen months elapsed with two writes, so an edit can plausibly sit unnoticed for a year. It is also the only artifact you can read without standing up a cluster, which is the point: recovery for a single bad row is never "restore the cluster", since every Aurora restore path produces a new cluster and rolling prod back weeks would discard everything else. The real procedure is to stand up a reference copy, diff the rows, and apply a targeted UPDATE.

Coverage by discovery lag:

| lag | PITR @ 35d | `d15_w90` chain | monthly dump |
| --- | --- | --- | --- |
| <= 35 days | yes | yes | yes |
| 36-95 days | no | yes | yes |
| 96 days - 1 year | no | no | yes |
| > 1 year | no | no | yes |

## Drift closed on the cluster

Separate from the backups, and the reason `rds.tf` has more diff than you might expect:

- Backup and maintenance windows are pinned. Both environments were running AWS-assigned random windows that differed from each other (prod `06:19-06:49` / `sun:07:05`, dev `08:37-09:07` / `tue:10:22`).
- The cluster parameter group is pinned to the value already in use, so a manual swap shows as drift instead of persisting silently.
- `engine_version` is now ignored via `lifecycle`. With `auto_minor_version_upgrade` on, AWS applies minor patches on its own schedule, and the pinned `16.11` literal meant the next patch would make every subsequent plan propose a downgrade. Refresh still records the real version, so the instance's reference to it continues to resolve.
- `deletion_protection` is on, which does mean `terraform destroy` on the cluster now requires clearing the flag by hand first.

## One design note worth flagging

The obvious staleness alarm - have the dump publish a success pulse, alarm on missing data over 40 days - is not expressible in CloudWatch. An alarm's total evaluation range (`period` x `evaluation_periods`) is capped at 604800 seconds, so the longest possible lookback is 7 days, and a monthly pulse leaves about 29 consecutive days with no datapoint that any legal alarm reads as breaching. `terraform validate` does not catch this because it never calls the API; it fails at apply.

So freshness is measured rather than inferred. A small daily probe task lists the bucket and publishes the age of the newest dump, and the alarm reads that over a single 1-day period. Side benefit: it trusts the bucket rather than the previous job's own report, so an upload that was reported successful but never landed still trips it.

## Verification

- `terraform fmt`, `terraform validate`, `tflint` clean.
- `terraform plan` against **dev**: 20 to add, 2 to change, 0 to destroy. Both changes in-place on the cluster and its instance, no replacement. `backup_retention_period` correctly shows no change in dev, and `engine_version` shows no change, confirming the `ignore_changes` behaves.
- The ops image was built and run locally to confirm both scripts are present and executable, the RDS trust bundle is in place, and `date -u -d` parses the timestamp format S3 returns.

**The dev image is preloaded.** `ztmf/ops:c61f01a` is pushed to dev ECR and SSM `ztmf_ops_tag` points at it, because `ops-image.yml` only publishes on push to `main` while the infra applies on PR - without preloading, the task definitions would have registered against an image with no scripts in it. Re-planning after the preload shows 21 to add, 2 to change, 1 to destroy, where the destroy is `aws_ecs_task_definition.ztmf_ops` rolling to a new revision. The next `ops-image.yml` run on `main` will overwrite that SSM value with its own build, which is fine.

Prod has not been planned yet.

## On the `needs-refinement` label

@jsos3-cms - you are the Terraform expert here and I would rather you shape this than rubber-stamp it. The label is not "this is half-finished" - the functionality is complete and verified against dev. It is that this is bootstrap: I picked defaults where the strategy left room, and those are the parts worth your eye rather than the plumbing.

Specifically, the judgment calls I would like you to push back on:

- **Object Lock is GOVERNANCE, not COMPLIANCE**, at 365 days. COMPLIANCE cannot be overridden by anyone including account root for the full retention period, which felt like a large commitment to make on an account we do not solely control. If you disagree, that is a one-line change.
- **Dev stays enrolled in `d15_w90`** (about two cents a month) on purpose, because the tag-selection path has never executed in this account and dev is where we find out whether the CMS-managed selection role can actually back up Aurora. Drop it if you would rather not pay for that signal.
- **Pinning the backup and maintenance windows** changes them in both environments on first apply. Non-disruptive, but it is a real change and the specific times are arbitrary.
- **`ignore_changes = [engine_version]`** versus disabling `auto_minor_version_upgrade` and managing the version explicitly. I chose to keep patching automatic and stop Terraform fighting it, but the other direction is more auditable for a FISMA system and I would defer to you.
- **A second task definition for the daily probe.** EventBridge Scheduler's ECS target has no container override, so a different command means a different task definition. If there is a cleaner idiom, I would rather use it.

Worth knowing before it applies: an unmerged PR's Terraform in shared dev gets reverted by the next PR's apply, since those run from `main`.

Do not hold back on restructuring. Refine further if you want to.
