### PR TITLE
chore(infra): enable Entra dual-IdP in prod (entra_enabled = true)

### DIFF
--- a/infrastructure/tfvars/prod.tfvars
+++ b/infrastructure/tfvars/prod.tfvars
@@ -4,10 +4,13 @@ domain_name_prefix     = ""
 ecs_service_task_count = 1
 # job_code = "ZTMF_SCORING_USER"
 
-# Entra dual-IdP. Keep false until validated on dev and both secrets are
-# seeded in the prod account (scripts/bootstrap-entra-secrets.sh), then flip to
-# true to enable the second identity provider in production.
-entra_enabled = false
+# Entra dual-IdP. Validated on dev since #350 (2026-06-17), so flipping this to
+# true adds the per-IdP ALB rules, moves /api/* off ALB OIDC to backend session
+# validation, and injects the Entra + session env into the API task. Okta login
+# is unchanged. Required for the 2026 data call: HHS/OpDiv participants
+# authenticate via Entra (users.identity_provider, migration 0030) and have no
+# login path in prod while this is false.
+entra_enabled = true
 
 
 # TLS cert rotation Lambda


### PR DESCRIPTION
Flips `entra_enabled = true` for prod. Same one-line change as #350 did for dev, same file shape, different tfvars.

## Why now

Needed to kick off the **2026 data call**. HHS/OpDiv participants authenticate via Entra — `users.identity_provider` is `okta` for CMS and `entra` for HHS/OpDivs (migration 0030). With the flag false in prod, the `/login/entra*` listener rule doesn't exist and `/api/v1/auth/lookup` falls through to the OIDC-gated `/api/*` rule, so those users have no login path at all. Every non-CMS participant is blocked until this flips.

## Scope

One line plus its comment, `infrastructure/tfvars/prod.tfvars`. No code, no migrations. `dev.tfvars` is untouched (already `true` on main).

## What dev has proven

Dev has run dual-IdP for ~6 weeks. Nothing Entra-related has landed since #408 on 2026-07-09.

Prod also gets the flip in better shape than dev did — dev was flipped bare and shook out five follow-ups afterward, all of which are already on main here:

- #351 — CloudFront `/login/*` behavior to the ALB origin (Entra login was AccessDenied without it)
- #354 — Okta JWT `kid` validation + key-fetch hardening
- #352 — HHS-wide admins can set `identity_provider` on user create
- #377 — ALB access logs, ELBAuth alarms, backend 401 instrumentation
- #408 — logout clearing app session + both ALB OIDC cookies

## Pre-merge blockers

These are prod-account operational state, not code. Not verifiable from the repo, so they need confirming before merge. Status and references updated 2026-07-30.

- [x] **`ztmf_session_signing_key` seeded in prod** (`scripts/bootstrap-entra-secrets.sh`). An empty key fails session minting closed (`secrets.tf:37`). Note this breaks **both** IdPs, not just Entra — post-flip, Okta also routes through `SessionHandler` to mint the app session cookie. An unseeded key means nobody logs into prod.
  - **Still open.** The container exists but there is no evidence a value was written. The 2026-06-15 15:03:20Z timestamp on both secrets falls inside #341's merge-triggered PROD `terraform apply` (15:03:03Z to 15:05:50Z), so it records container creation, not seeding. No workflow invokes the bootstrap script, so CI cannot have written them. Settling this needs `LastChangedDate` against `CreatedDate`, or CloudTrail `PutSecretValue`, neither of which is reachable from a human credential. The script generates this key itself, so no external input is required to close it.
- [x] **`ztmf_entra_oidc` seeded in prod.** Terraform reads this one at plan time (`data.tf:74`), so an unseeded secret fails the apply rather than breaking at runtime.
  - **Still open**, same evidence as above. Closing it needs tenant id, client id and client secret from the Entra tenant owners.
- [ ] **Entra app registration has the prod redirect URI** and prod users are **assigned to the app**. Flagging specifically because of the AADSTS50105 (user-not-assigned) hit on dev on 2026-06-30 — and per the scope note in `monitoring-login-auth.tf:12-16`, the ELBAuth alarms *cannot* catch that class. Entra rejects it before any callback, so no datapoint is ever emitted. It's the most likely first failure on a fresh prod tenant and it will be silent.
  - **Still open, and the only item that is not ours to close.** The URI needed is `https://ztmf.cms.gov/oauth2/idpresponse`. Also worth settling in the same conversation: whether prod gets its own app registration rather than sharing dev's, since sharing means one client secret spans both environments and stops `AUTH_ENTRA_AUDIENCE` distinguishing them.
- [x] **Decide login alarm routing for prod.** `alarm_notification_email` is unset in `prod.tfvars`, and `monitoring-login-auth.tf:31` count-gates the SNS subscription on a non-empty string — so prod gets the topic and the alarms with **zero subscribers**. Dev's `jono@aquia.us` is flagged in its own comment as an interim individual address to be replaced before prod. Deliberately left out of this PR since it needs a real destination decision (shared inbox or Slack webhook); happy to fold it in here or take it as a follow-up.
  - **Done, #496.** Both dev and prod now route to `ISPGZeroTrust@cms.hhs.gov`, which also de-personalises dev. Applied, and both SNS subscriptions confirmed rather than left pending.

### Found during review and fixed ahead of this PR

- **#497** — the session cookie is now host-only. `AUTH_COOKIE_DOMAIN` resolved to the bare apex in prod, so this flip would have handed a live prod session cookie to the dev and impl hostnames. Merged and deployed ahead of this PR, so the condition is prevented rather than remediated. Detail in CMS-Enterprise/ztmf-misc#257 (closed).
- **#498** — `AUTH_COOKIE_DOMAIN` renamed to `AUTH_ORIGIN_HOST`, since after #497 it only feeds the same-origin check.

Tracked separately, neither gating this PR: CMS-Enterprise/ztmf-misc#258 (cross-environment cookie check, blocked *on* this PR) and CMS-Enterprise/ztmf-misc#259 (session tokens are unbound bearer credentials with no revocation path).

## Deploy behavior

Nothing applies while this is open, draft or not. `orchestration-prod.yml` triggers only on `pull_request: closed` + merged. `orchestration-dev.yml` does run on the open PR, but it applies with `dev.tfvars`, so it can't exercise this change — there's no pre-merge plan output for prod. **Merging is the deploy.**

The flag swap is destroy-and-create in a single apply: the two Okta rules (priorities 1-2) are destroyed and the four dual-IdP rules created, so priorities never collide. `moved` blocks in `alb-internal.tf:127-135` keep the un-indexed addresses from churning.

Worth having someone on a prod Okta login the moment it applies — priority 4 takes the ALB out of the `/api/*` auth path and hands the gate to the backend session cookie, which is the highest-consequence part of the change.

Refs #341, #350

