### PR TITLE
fix(infra): route alarm notifications to the shared ISPG inbox

### DIFF
--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -18,7 +18,7 @@ entra_enabled = true
 # the dev Entra pilot. Replace it with a shared team inbox or a Slack webhook
 # before this routing is relied on beyond dev / before prod, so paging never
 # depends on one person being reachable.
-alarm_notification_email = "jono@aquia.us"
+alarm_notification_email = "ISPGZeroTrust@cms.hhs.gov"
 
 # TLS cert rotation Lambda
 # ACM ARN sourced from SSM Parameter Store /ztmf/dev/cert-rotation/acm-arn

--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -12,12 +12,11 @@ ecs_service_task_count = 1
 entra_enabled = true
 
 
-# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS topic
-# (confirm the AWS subscription email once after first apply).
-# INTERIM destination only — an individual address used to stand up alerting for
-# the dev Entra pilot. Replace it with a shared team inbox or a Slack webhook
-# before this routing is relied on beyond dev / before prod, so paging never
-# depends on one person being reachable.
+# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS topic.
+# A shared inbox rather than an individual, so paging never depends on one
+# person being reachable. AWS sends a subscription confirmation email that has
+# to be clicked once before anything is delivered, and changing this address
+# replaces the subscription, so an edit here means confirming again.
 alarm_notification_email = "ISPGZeroTrust@cms.hhs.gov"
 
 # TLS cert rotation Lambda

--- a/infrastructure/tfvars/prod.tfvars
+++ b/infrastructure/tfvars/prod.tfvars
@@ -10,6 +10,8 @@ ecs_service_task_count = 1
 entra_enabled = false
 
 
+alarm_notification_email = "ISPGZeroTrust@cms.hhs.gov"
+
 # TLS cert rotation Lambda
 # ACM ARN sourced from SSM Parameter Store /ztmf/prod/cert-rotation/acm-arn
 enable_cert_rotation_lambda = true

--- a/infrastructure/tfvars/prod.tfvars
+++ b/infrastructure/tfvars/prod.tfvars
@@ -9,7 +9,11 @@ ecs_service_task_count = 1
 # true to enable the second identity provider in production.
 entra_enabled = false
 
-
+# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS topic.
+# A shared inbox rather than an individual, so paging never depends on one
+# person being reachable. AWS sends a subscription confirmation email that has
+# to be clicked once before anything is delivered; until then the alarms exist
+# but have no destination, which is the state prod was in with this unset.
 alarm_notification_email = "ISPGZeroTrust@cms.hhs.gov"
 
 # TLS cert rotation Lambda


### PR DESCRIPTION
This sets the login/OIDC alarm destination to the shared ISPG Zero Trust inbox in both dev and prod. Prod had no destination at all, so the SNS subscription was count-gated to zero subscribers and the login auth alarms had nowhere to go. Dev was pointed at a personal address that was only ever meant to stand up alerting during the Entra pilot.

An email subscription requires a one-time manual confirmation click after apply. Because dev's address is changing, Terraform will replace that subscription too, so both dev and prod will send a fresh confirmation email that someone monitoring the shared inbox needs to click.

## Test plan

- [ ] `terraform fmt -check` passes in `infrastructure/`
- [ ] After apply, `aws sns list-subscriptions-by-topic` for the dev topic shows the `ISPGZeroTrust@cms.hhs.gov` endpoint with a `SubscriptionArn` that is not `PendingConfirmation`
- [ ] After apply, `aws sns list-subscriptions-by-topic` for the prod topic shows the same endpoint with a confirmed `SubscriptionArn`

## Blockers

This is one of two prerequisites for merging #495 (enable Entra dual-IdP in prod), so that monitoring exists and is confirmed before the flag flips. Refs #495
