### PR TITLE
fix(auth): scope the session cookie to the issuing host

### DIFF
--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -186,10 +186,15 @@ func SessionHandler(w http.ResponseWriter, r *http.Request) {
 func SetSessionCookie(w http.ResponseWriter, token string) {
 	cfg := config.GetInstance()
 	http.SetCookie(w, &http.Cookie{
-		Name:     cfg.Auth.SessionCookieName,
-		Value:    token,
-		Path:     "/",
-		Domain:   cfg.Auth.CookieDomain,
+		Name:  cfg.Auth.SessionCookieName,
+		Value: token,
+		Path:  "/",
+		// No Domain: omitting the attribute makes this a host-only cookie, so
+		// the browser returns it only to the exact host that issued it. An
+		// explicit Domain scopes a cookie to that domain and every subdomain
+		// beneath it, and in prod the deployed hostname is the bare apex, so
+		// naming it here would attach a prod session to requests for the dev
+		// and impl hostnames underneath it.
 		MaxAge:   cfg.Auth.SessionTTL,
 		HttpOnly: true,
 		Secure:   true,
@@ -202,10 +207,13 @@ func SetSessionCookie(w http.ResponseWriter, token string) {
 func ClearSessionCookie(w http.ResponseWriter) {
 	cfg := config.GetInstance()
 	http.SetCookie(w, &http.Cookie{
-		Name:     cfg.Auth.SessionCookieName,
-		Value:    "",
-		Path:     "/",
-		Domain:   cfg.Auth.CookieDomain,
+		Name:  cfg.Auth.SessionCookieName,
+		Value: "",
+		Path:  "/",
+		// No Domain, matching SetSessionCookie. A browser only removes a cookie
+		// when the expiring cookie's Domain matches the one it was stored with,
+		// so a Domain here would create a separate domain-scoped cookie and
+		// leave the host-only session in place.
 		MaxAge:   -1,
 		HttpOnly: true,
 		Secure:   true,

--- a/backend/cmd/api/internal/auth/session_test.go
+++ b/backend/cmd/api/internal/auth/session_test.go
@@ -69,6 +69,14 @@ func TestParseSession_RejectsForeignTokens(t *testing.T) {
 }
 
 func TestSetSessionCookie_Attributes(t *testing.T) {
+	// A configured cookie domain must not reach the cookie. The domain is set
+	// here because it is empty in the test environment, so without it the
+	// host-only assertion below would pass no matter what the setter does.
+	cfg := config.GetInstance()
+	orig := cfg.Auth.CookieDomain
+	cfg.Auth.CookieDomain = "ztmf.cms.gov"
+	defer func() { cfg.Auth.CookieDomain = orig }()
+
 	w := httptest.NewRecorder()
 	SetSessionCookie(w, "tok123")
 
@@ -81,6 +89,31 @@ func TestSetSessionCookie_Attributes(t *testing.T) {
 	assert.True(t, c.Secure, "must be Secure")
 	assert.Equal(t, http.SameSiteStrictMode, c.SameSite, "must be SameSite=Strict")
 	assert.Equal(t, "/", c.Path)
+	// Host-only: an explicit Domain covers that domain and every subdomain, so
+	// naming the apex would deliver a prod session to the dev and impl hosts.
+	assert.Empty(t, c.Domain, "must stay host-only")
+}
+
+func TestClearSessionCookie_Attributes(t *testing.T) {
+	// The expiring cookie has to match the host-only cookie SetSessionCookie
+	// issued; a Domain here would create a separate domain-scoped cookie and
+	// leave the session in place.
+	cfg := config.GetInstance()
+	orig := cfg.Auth.CookieDomain
+	cfg.Auth.CookieDomain = "ztmf.cms.gov"
+	defer func() { cfg.Auth.CookieDomain = orig }()
+
+	w := httptest.NewRecorder()
+	ClearSessionCookie(w)
+
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+	c := cookies[0]
+	assert.Equal(t, cfg.Auth.SessionCookieName, c.Name)
+	assert.Empty(t, c.Value, "must be emptied")
+	assert.True(t, c.MaxAge < 0, "must be expired")
+	assert.Equal(t, "/", c.Path)
+	assert.Empty(t, c.Domain, "must stay host-only")
 }
 
 func TestSessionHandler_Unauthorized(t *testing.T) {


### PR DESCRIPTION
The session cookie now omits the `Domain` attribute, so the browser scopes it to the exact host that issued it. Both cookie setters previously copied the configured cookie domain onto `Domain`, and per RFC 6265 an explicit `Domain` scopes a cookie to that domain and to every subdomain beneath it. The prod hostname is the bare apex, so a prod session would be delivered to the dev and impl hostnames as well, and to any subdomain added later. Omitting the attribute is what produces host-only scoping, which keeps the credential confined to the environment that minted it.

Go's `net/http` gives us exactly that with no extra work: `Cookie.String()`, which `http.SetCookie` calls, writes `; Domain=` only when the field is non-empty, so an unset `Domain` is absent from the serialized `Set-Cookie` header rather than emitted empty.

`sameOrigin` in `backend/cmd/api/internal/auth/middleware.go` is deliberately untouched, and that is the part worth checking. It reads the same `Auth.CookieDomain` value as the expected `Origin` host and falls back to the request `Host` when the field is empty. Behind CloudFront with a VPC origin to the internal ALB, the `Host` the container observes is not necessarily the public hostname, so clearing or renaming the field could start failing the Origin check on every state-changing request. This change therefore leaves the config field, its env binding and the Origin-check path exactly as they were, and only stops putting the value on the cookie. Splitting the overloaded field into a separate cookie-domain setting plus an Origin-check setting named for its actual purpose is a deliberate follow-up, still outstanding.

Both setters change in the same commit because they are coupled. A browser only removes a cookie when the expiring cookie's `Domain` matches the one it was stored with, so dropping `Domain` from `SetSessionCookie` alone would leave `ClearSessionCookie` unable to clear the session. That failure mode passes a casual test, since login and normal browsing look fine and only logout silently stops working.

## Test plan

- [x] `TestSetSessionCookie_Attributes` asserts the issued cookie carries no `Domain`, so a future change cannot silently re-widen it. The test sets `Auth.CookieDomain` to a non-empty value first, because it is empty in the test environment and the assertion would otherwise pass no matter what the setter does.
- [x] `TestClearSessionCookie_Attributes` asserts the logout cookie is emptied, expired, and also carries no `Domain`, covering the coupled-setter trap.
- [x] Both new assertions were confirmed to fail when `Domain` is reintroduced, so they are load-bearing rather than vacuous.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test -short ./...` fully green across all 19 packages.
- [x] `go test ./...` green except the pre-existing integration tests, which need a live database and fail the same way on `main` without one. `cmd/api/internal/auth` passes.
- [x] `gofmt` clean on both changed files. The repo carries no golangci-lint config; the only lint gates are terraform fmt and tflint for infrastructure and the Redocly OpenAPI lint, none of which this change touches.
- [ ] Manual check that no unit test can cover: sign in to prod first, then to a lower environment, in one browser profile, and confirm the lower environment works. That ordering is the one that breaks while the cookie is apex-scoped.

## Deploy note

A session issued before this change is a distinct cookie from the host-only one, so the new expiry does not delete it. Only dev is in that state, because `entra_enabled` gates the variable and it is true only in dev, where the configured value is dev's own leaf hostname. The effect there is bounded: `r.Cookie` returns the older of two same-named cookies, so a dev browser holding a pre-deploy cookie keeps presenting it and logout does not end that session until the 3 hour `MaxAge` elapses. It self-heals, and clearing site cookies ends it immediately. No prod session is involved, since prod sets no cookie domain today and so holds nothing domain-scoped. Emitting an extra legacy domain-scoped expiry would close that window, but it would put an apex `Domain` back on the wire for every prod logout once #495 lands, and leave a dead dependency on a field the planned split is going to rename, so this leaves it out. Worth a cookie clear if a dev logout looks sticky just after this deploys.

## Blockers

This is one of two prerequisites for merging #495, which enables Entra dual-IdP in prod. Merging #495 is the deploy that applies the flag and injects the cookie domain into the API task, so merging it is what turns the over-scoping on. Please do not apply `entra_enabled = true` in prod until this is in.

The second prerequisite is the config-field split described above. That work is outstanding, so this PR does not close the tracking ticket.

Refs #495
Refs CMS-Enterprise/ztmf-misc#257
