### PR TITLE
chore(auth): rename AUTH_COOKIE_DOMAIN to reflect its only use

### DIFF
--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -205,12 +205,12 @@ func isSafeMethod(method string) bool {
 }
 
 // sameOrigin checks that a state-changing request originated from our own site.
-// It compares the Origin (then Referer) host against the configured cookie
-// domain, falling back to the request Host. A request with neither header is
+// It compares the Origin (then Referer) host against the configured origin
+// host, falling back to the request Host. A request with neither header is
 // allowed: SameSite=Strict already prevents a cross-site context from sending
 // the session cookie, so this header check is additive, not the sole gate.
 func sameOrigin(r *http.Request) bool {
-	expected := config.GetInstance().Auth.CookieDomain
+	expected := config.GetInstance().Auth.OriginHost
 	if expected == "" {
 		expected = hostOnly(r.Host)
 	}

--- a/backend/cmd/api/internal/auth/middleware_test.go
+++ b/backend/cmd/api/internal/auth/middleware_test.go
@@ -303,7 +303,7 @@ func TestMiddleware(t *testing.T) {
 }
 
 func TestSameOrigin(t *testing.T) {
-	// CookieDomain is unset in the test env, so sameOrigin falls back to the
+	// OriginHost is unset in the test env, so sameOrigin falls back to the
 	// request Host.
 	tests := []struct {
 		name    string

--- a/backend/cmd/api/internal/auth/session_test.go
+++ b/backend/cmd/api/internal/auth/session_test.go
@@ -69,14 +69,8 @@ func TestParseSession_RejectsForeignTokens(t *testing.T) {
 }
 
 func TestSetSessionCookie_Attributes(t *testing.T) {
-	// A configured cookie domain must not reach the cookie. The domain is set
-	// here because it is empty in the test environment, so without it the
-	// host-only assertion below would pass no matter what the setter does.
-	cfg := config.GetInstance()
-	orig := cfg.Auth.CookieDomain
-	cfg.Auth.CookieDomain = "ztmf.cms.gov"
-	defer func() { cfg.Auth.CookieDomain = orig }()
-
+	// No configuration feeds the cookie's Domain any more, so the host-only
+	// assertion below is the guard against reintroducing one.
 	w := httptest.NewRecorder()
 	SetSessionCookie(w, "tok123")
 
@@ -99,9 +93,6 @@ func TestClearSessionCookie_Attributes(t *testing.T) {
 	// issued; a Domain here would create a separate domain-scoped cookie and
 	// leave the session in place.
 	cfg := config.GetInstance()
-	orig := cfg.Auth.CookieDomain
-	cfg.Auth.CookieDomain = "ztmf.cms.gov"
-	defer func() { cfg.Auth.CookieDomain = orig }()
 
 	w := httptest.NewRecorder()
 	ClearSessionCookie(w)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -72,9 +72,12 @@ type config struct {
 		SessionCookieName string `env:"AUTH_SESSION_COOKIE_NAME" envDefault:"ztmf_session"`
 		// SessionTTL is the app session lifetime in seconds.
 		SessionTTL int `env:"AUTH_SESSION_TTL" envDefault:"10800"`
-		// CookieDomain scopes the session cookie (e.g. dev.ztmf.cms.gov). Empty
-		// scopes the cookie to the exact request host, which is correct locally.
-		CookieDomain string `env:"AUTH_COOKIE_DOMAIN"`
+		// OriginHost is the host the same-origin check expects in the Origin
+		// (then Referer) header of a state-changing request, e.g.
+		// dev.ztmf.cms.gov. Empty compares against the request Host instead,
+		// which is what local dev and the test suite rely on. This does not
+		// affect cookie scope: the session cookie is always host-only.
+		OriginHost string `env:"AUTH_ORIGIN_HOST"`
 	}
 	Db struct {
 		Host        string  `env:"DB_ENDPOINT"`

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -38,7 +38,11 @@ locals {
     # Pin the accepted audience to the ZTMF Entra app's client id so a validly
     # signed token minted for a different app in the same tenant is rejected.
     { name = "AUTH_ENTRA_AUDIENCE", value = local.entra_oidc_options["client_id"] },
-    { name = "AUTH_COOKIE_DOMAIN", value = local.domain_name },
+    # Expected Origin/Referer host for the same-origin check on state-changing
+    # requests. The public hostname is what browsers send, and it is not always
+    # the request Host the task sees, so name it explicitly rather than relying
+    # on the fallback.
+    { name = "AUTH_ORIGIN_HOST", value = local.domain_name },
   ] : []
 
   entra_api_secrets = var.entra_enabled ? [


### PR DESCRIPTION
`config.Auth.CookieDomain`, bound to `AUTH_COOKIE_DOMAIN`, used to do two unrelated jobs. It supplied the session cookie's `Domain` attribute, and it is the host `sameOrigin` expects to see in the `Origin` (then `Referer`) header of a state-changing request. #497 removed `Domain` from both `SetSessionCookie` and `ClearSessionCookie`, so no code path sets a cookie domain any more and the same-origin check is the field's only remaining consumer.

That leaves the name describing a job the value no longer does, which is a trap of its own. Someone setting a variable called `AUTH_COOKIE_DOMAIN` would reasonably expect it to scope the session cookie, and it does not. This renames the field to `OriginHost` and the environment variable to `AUTH_ORIGIN_HOST`, and rewrites the doc comment to describe the same-origin check it actually feeds, including the fallback to the request `Host` when the value is empty.

This is a pure rename. `sameOrigin` reads the same value, compares it the same way, and falls back the same way. Terraform still injects `local.domain_name`, only under the new name, because the public hostname is exactly what a browser puts in `Origin` and therefore exactly what the check should expect.

#497 described the follow-up as splitting the field into a cookie-domain setting plus an Origin-check setting named for its purpose. This does the rename half and deliberately skips the other half. After #497 there is no code path that reads a cookie domain, so a new `AUTH_SESSION_COOKIE_DOMAIN` would be either dead configuration or, the moment something started reading it, a re-armed version of the over-scoping #497 removed. Host-only scoping is the behaviour we want in every environment, and the way to get it is to have no field for it at all. Renaming the surviving field is what actually closes the root cause, since the root cause was one name standing for two things.

#497 left the field alone specifically because clearing or renaming it could start failing the Origin check behind CloudFront, and that is the part of this change worth checking rather than the rename itself. It is settled below.

## Deploy atomicity

An environment variable rename couples the task-definition change to the image rollout. If Terraform injected `AUTH_ORIGIN_HOST` while the running image still read `AUTH_COOKIE_DOMAIN`, `sameOrigin` would silently fall back to `r.Host` for the duration of the gap, and behind CloudFront that is not guaranteed to be the public hostname. The two land together, in the same ECS task definition revision, so no such gap exists.

`.github/workflows/orchestration-prod.yml` runs `analysis`, then `backend`, then `infrastructure`, and the `infrastructure` job declares `needs: [analysis, backend]`, so `terraform apply` cannot start until the backend job has succeeded. `.github/workflows/backend.yml` pushes the image tagged with the short commit SHA, then writes that same SHA to the image-pointer SSM parameter with `aws ssm put-parameter --overwrite`, and closes with the comment "Deployment of the latest image will happen with terraform apply during infrastructure deploy". `.github/workflows/infrastructure.yml` then checks out the merge commit and runs `terraform apply`, which reads that pointer through `data "aws_ssm_parameter" "ztmf_api_tag"` in `infrastructure/data.tf` and so sees the tag the backend job just wrote.

The two changes are attributes of one resource. `infrastructure/ecs.tf` sets `aws_ecs_task_definition.ztmf_api`'s `image` from that data source, and builds the container's `environment` as `concat([...], local.entra_api_env)`, which is where the renamed variable lives. A single apply produces a single new revision carrying both the new image and the new variable name, so there is no revision in which the new variable name meets an image that reads the old one, and none in which the new image meets the old variable name. `orchestration-dev.yml` gates its backend job on a backend diff and this PR changes Go files, so the dev deploy builds and rolls out a new image the same way.

A bare rename is therefore safe and no back-compat fallback is needed. As a secondary point, the `/api/*` CloudFront behaviour forwards `headers = ["*"]`, so even the fallback path would most likely resolve to the viewer's host, but naming the expected host explicitly is still right, because the check should not depend on header-forwarding configuration staying as it is.

## Note on the test setup that goes away

Two call sites in `session_test.go` set `CookieDomain` to a non-empty value before asserting the cookie stayed host-only, because the field used to be the one thing that could have leaked a `Domain`, and #497 needed that setup to keep the assertion from passing vacuously. No configuration can feed the cookie's `Domain` now, so the setup has nothing to prove and it is removed. The host-only assertions stay as the guard against reintroducing a `Domain`. They are weaker than they were, in that they can no longer be driven by a config value, and there is no way to keep that strength without keeping a cookie-domain field, which is the thing this change is removing the last trace of.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` green, 577 tests across 19 packages
- [x] `TestSameOrigin` passes all six subtests unchanged, confirming the fallback-to-`Host` path behaves the same
- [x] `TestSetSessionCookie_Attributes` and `TestClearSessionCookie_Attributes` still assert the cookie is issued host-only
- [x] `terraform fmt -check -recursive` clean in `infrastructure/`
- [x] `gofmt` clean on the lines this change touches. `middleware.go` carries one pre-existing alignment nit on an unrelated const block that `gofmt` also reports against `main`, left alone to keep this diff to the rename
- [x] `git grep -n 'CookieDomain\|AUTH_COOKIE_DOMAIN'` returns nothing
- [ ] After the rollout, confirm a state-changing request from the browser still succeeds, which is what exercises `sameOrigin` against the injected `AUTH_ORIGIN_HOST`

Refs CMS-Enterprise/ztmf-misc#257. This completes that ticket's code cleanup. Its remaining post-rollout verification stays open.
