### PR TITLE
Nightly sync: main -> impl (2026-07-31)

### DIFF
--- a/backend/cmd/api/internal/auth/middleware.go
+++ b/backend/cmd/api/internal/auth/middleware.go
@@ -205,12 +205,12 @@ func isSafeMethod(method string) bool {
 }
 
 // sameOrigin checks that a state-changing request originated from our own site.
-// It compares the Origin (then Referer) host against the configured cookie
-// domain, falling back to the request Host. A request with neither header is
+// It compares the Origin (then Referer) host against the configured origin
+// host, falling back to the request Host. A request with neither header is
 // allowed: SameSite=Strict already prevents a cross-site context from sending
 // the session cookie, so this header check is additive, not the sole gate.
 func sameOrigin(r *http.Request) bool {
-	expected := config.GetInstance().Auth.CookieDomain
+	expected := config.GetInstance().Auth.OriginHost
 	if expected == "" {
 		expected = hostOnly(r.Host)
 	}

--- a/backend/cmd/api/internal/auth/middleware_test.go
+++ b/backend/cmd/api/internal/auth/middleware_test.go
@@ -303,7 +303,7 @@ func TestMiddleware(t *testing.T) {
 }
 
 func TestSameOrigin(t *testing.T) {
-	// CookieDomain is unset in the test env, so sameOrigin falls back to the
+	// OriginHost is unset in the test env, so sameOrigin falls back to the
 	// request Host.
 	tests := []struct {
 		name    string

--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -186,10 +186,15 @@ func SessionHandler(w http.ResponseWriter, r *http.Request) {
 func SetSessionCookie(w http.ResponseWriter, token string) {
 	cfg := config.GetInstance()
 	http.SetCookie(w, &http.Cookie{
-		Name:     cfg.Auth.SessionCookieName,
-		Value:    token,
-		Path:     "/",
-		Domain:   cfg.Auth.CookieDomain,
+		Name:  cfg.Auth.SessionCookieName,
+		Value: token,
+		Path:  "/",
+		// No Domain: omitting the attribute makes this a host-only cookie, so
+		// the browser returns it only to the exact host that issued it. An
+		// explicit Domain scopes a cookie to that domain and every subdomain
+		// beneath it, and in prod the deployed hostname is the bare apex, so
+		// naming it here would attach a prod session to requests for the dev
+		// and impl hostnames underneath it.
 		MaxAge:   cfg.Auth.SessionTTL,
 		HttpOnly: true,
 		Secure:   true,
@@ -202,10 +207,13 @@ func SetSessionCookie(w http.ResponseWriter, token string) {
 func ClearSessionCookie(w http.ResponseWriter) {
 	cfg := config.GetInstance()
 	http.SetCookie(w, &http.Cookie{
-		Name:     cfg.Auth.SessionCookieName,
-		Value:    "",
-		Path:     "/",
-		Domain:   cfg.Auth.CookieDomain,
+		Name:  cfg.Auth.SessionCookieName,
+		Value: "",
+		Path:  "/",
+		// No Domain, matching SetSessionCookie. A browser only removes a cookie
+		// when the expiring cookie's Domain matches the one it was stored with,
+		// so a Domain here would create a separate domain-scoped cookie and
+		// leave the host-only session in place.
 		MaxAge:   -1,
 		HttpOnly: true,
 		Secure:   true,

--- a/backend/cmd/api/internal/auth/session_test.go
+++ b/backend/cmd/api/internal/auth/session_test.go
@@ -69,6 +69,14 @@ func TestParseSession_RejectsForeignTokens(t *testing.T) {
 }
 
 func TestSetSessionCookie_Attributes(t *testing.T) {
+	// A configured cookie domain must not reach the cookie. The domain is set
+	// here because it is empty in the test environment, so without it the
+	// host-only assertion below would pass no matter what the setter does.
+	cfg := config.GetInstance()
+	orig := cfg.Auth.CookieDomain
+	cfg.Auth.CookieDomain = "ztmf.cms.gov"
+	defer func() { cfg.Auth.CookieDomain = orig }()
+
 	w := httptest.NewRecorder()
 	SetSessionCookie(w, "tok123")
 
@@ -81,6 +89,31 @@ func TestSetSessionCookie_Attributes(t *testing.T) {
 	assert.True(t, c.Secure, "must be Secure")
 	assert.Equal(t, http.SameSiteStrictMode, c.SameSite, "must be SameSite=Strict")
 	assert.Equal(t, "/", c.Path)
+	// Host-only: an explicit Domain covers that domain and every subdomain, so
+	// naming the apex would deliver a prod session to the dev and impl hosts.
+	assert.Empty(t, c.Domain, "must stay host-only")
+}
+
+func TestClearSessionCookie_Attributes(t *testing.T) {
+	// The expiring cookie has to match the host-only cookie SetSessionCookie
+	// issued; a Domain here would create a separate domain-scoped cookie and
+	// leave the session in place.
+	cfg := config.GetInstance()
+	orig := cfg.Auth.CookieDomain
+	cfg.Auth.CookieDomain = "ztmf.cms.gov"
+	defer func() { cfg.Auth.CookieDomain = orig }()
+
+	w := httptest.NewRecorder()
+	ClearSessionCookie(w)
+
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+	c := cookies[0]
+	assert.Equal(t, cfg.Auth.SessionCookieName, c.Name)
+	assert.Empty(t, c.Value, "must be emptied")
+	assert.True(t, c.MaxAge < 0, "must be expired")
+	assert.Equal(t, "/", c.Path)
+	assert.Empty(t, c.Domain, "must stay host-only")
 }
 
 func TestSessionHandler_Unauthorized(t *testing.T) {

--- a/backend/cmd/api/internal/auth/session_test.go
+++ b/backend/cmd/api/internal/auth/session_test.go
@@ -69,14 +69,8 @@ func TestParseSession_RejectsForeignTokens(t *testing.T) {
 }
 
 func TestSetSessionCookie_Attributes(t *testing.T) {
-	// A configured cookie domain must not reach the cookie. The domain is set
-	// here because it is empty in the test environment, so without it the
-	// host-only assertion below would pass no matter what the setter does.
-	cfg := config.GetInstance()
-	orig := cfg.Auth.CookieDomain
-	cfg.Auth.CookieDomain = "ztmf.cms.gov"
-	defer func() { cfg.Auth.CookieDomain = orig }()
-
+	// No configuration feeds the cookie's Domain any more, so the host-only
+	// assertion below is the guard against reintroducing one.
 	w := httptest.NewRecorder()
 	SetSessionCookie(w, "tok123")
 
@@ -99,9 +93,6 @@ func TestClearSessionCookie_Attributes(t *testing.T) {
 	// issued; a Domain here would create a separate domain-scoped cookie and
 	// leave the session in place.
 	cfg := config.GetInstance()
-	orig := cfg.Auth.CookieDomain
-	cfg.Auth.CookieDomain = "ztmf.cms.gov"
-	defer func() { cfg.Auth.CookieDomain = orig }()
 
 	w := httptest.NewRecorder()
 	ClearSessionCookie(w)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -72,9 +72,12 @@ type config struct {
 		SessionCookieName string `env:"AUTH_SESSION_COOKIE_NAME" envDefault:"ztmf_session"`
 		// SessionTTL is the app session lifetime in seconds.
 		SessionTTL int `env:"AUTH_SESSION_TTL" envDefault:"10800"`
-		// CookieDomain scopes the session cookie (e.g. dev.ztmf.cms.gov). Empty
-		// scopes the cookie to the exact request host, which is correct locally.
-		CookieDomain string `env:"AUTH_COOKIE_DOMAIN"`
+		// OriginHost is the host the same-origin check expects in the Origin
+		// (then Referer) header of a state-changing request, e.g.
+		// dev.ztmf.cms.gov. Empty compares against the request Host instead,
+		// which is what local dev and the test suite rely on. This does not
+		// affect cookie scope: the session cookie is always host-only.
+		OriginHost string `env:"AUTH_ORIGIN_HOST"`
 	}
 	Db struct {
 		Host        string  `env:"DB_ENDPOINT"`

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -38,7 +38,11 @@ locals {
     # Pin the accepted audience to the ZTMF Entra app's client id so a validly
     # signed token minted for a different app in the same tenant is rejected.
     { name = "AUTH_ENTRA_AUDIENCE", value = local.entra_oidc_options["client_id"] },
-    { name = "AUTH_COOKIE_DOMAIN", value = local.domain_name },
+    # Expected Origin/Referer host for the same-origin check on state-changing
+    # requests. The public hostname is what browsers send, and it is not always
+    # the request Host the task sees, so name it explicitly rather than relying
+    # on the fallback.
+    { name = "AUTH_ORIGIN_HOST", value = local.domain_name },
   ] : []
 
   entra_api_secrets = var.entra_enabled ? [

--- a/infrastructure/tfvars/dev.tfvars
+++ b/infrastructure/tfvars/dev.tfvars
@@ -12,13 +12,12 @@ ecs_service_task_count = 1
 entra_enabled = true
 
 
-# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS topic
-# (confirm the AWS subscription email once after first apply).
-# INTERIM destination only — an individual address used to stand up alerting for
-# the dev Entra pilot. Replace it with a shared team inbox or a Slack webhook
-# before this routing is relied on beyond dev / before prod, so paging never
-# depends on one person being reachable.
-alarm_notification_email = "jono@aquia.us"
+# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS topic.
+# A shared inbox rather than an individual, so paging never depends on one
+# person being reachable. AWS sends a subscription confirmation email that has
+# to be clicked once before anything is delivered, and changing this address
+# replaces the subscription, so an edit here means confirming again.
+alarm_notification_email = "ISPGZeroTrust@cms.hhs.gov"
 
 # TLS cert rotation Lambda
 # ACM ARN sourced from SSM Parameter Store /ztmf/dev/cert-rotation/acm-arn

--- a/infrastructure/tfvars/prod.tfvars
+++ b/infrastructure/tfvars/prod.tfvars
@@ -4,10 +4,13 @@ domain_name_prefix     = ""
 ecs_service_task_count = 1
 # job_code = "ZTMF_SCORING_USER"
 
-# Entra dual-IdP. Keep false until validated on dev and both secrets are
-# seeded in the prod account (scripts/bootstrap-entra-secrets.sh), then flip to
-# true to enable the second identity provider in production.
-entra_enabled = false
+# Entra dual-IdP. Validated on dev since #350 (2026-06-17), so flipping this to
+# true adds the per-IdP ALB rules, moves /api/* off ALB OIDC to backend session
+# validation, and injects the Entra + session env into the API task. Okta login
+# is unchanged. Required for the 2026 data call: HHS/OpDiv participants
+# authenticate via Entra (users.identity_provider, migration 0030) and have no
+# login path in prod while this is false.
+entra_enabled = true
 
 # Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS topic.
 # A shared inbox rather than an individual, so paging never depends on one

--- a/infrastructure/tfvars/prod.tfvars
+++ b/infrastructure/tfvars/prod.tfvars
@@ -9,6 +9,12 @@ ecs_service_task_count = 1
 # true to enable the second identity provider in production.
 entra_enabled = false
 
+# Login/OIDC alarm routing. Subscribes this address to the ztmf-alarms SNS topic.
+# A shared inbox rather than an individual, so paging never depends on one
+# person being reachable. AWS sends a subscription confirmation email that has
+# to be clicked once before anything is delivered; until then the alarms exist
+# but have no destination, which is the state prod was in with this unset.
+alarm_notification_email = "ISPGZeroTrust@cms.hhs.gov"
 
 # TLS cert rotation Lambda
 # ACM ARN sourced from SSM Parameter Store /ztmf/prod/cert-rotation/acm-arn


### PR DESCRIPTION
Automated nightly sync of `main` into `impl` — **main wins every overlap**.

This branch is `impl` with `main` merged in using `-X theirs`, so the result is deterministic: main's version wins any conflict, and impl-only files that don't conflict are preserved. There should be nothing to hand-resolve.

**Squash-merge this PR** — `impl` is squash-only by policy (linear history). Because `main` and `impl` share no squash ancestry the diff is computed against a stale base, but `-X theirs` makes it deterministic and the content settles (a no-change night opens no PR). Unlike ztmf-ui (which merges as a merge commit), this stays in content-sync rather than closing the ancestry gap.

- Review the net change, then **squash-merge**. Merging pushes to `impl` and triggers the impl deploy (orchestration-impl: backend image build + terraform apply).
- To smoke-test in the impl environment first, run **Manual Deploy to IMPL** with `--ref automation/sync-main-to-impl`.

_Opened by the nightly-impl-sync workflow._
