### PR TITLE
fix(rollover): key the FY2026 predecessor by OpDiv (ztmf#500)

### DIFF
--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -742,107 +742,32 @@ ORDER BY ps.datacallid, ps.fismasystemid, ps.pillarid
 // TEMPORARY HARD-CODE - ztmf#500. DELETE THIS ENTIRE BLOCK after the FY2026
 // data call has been created, along with the call site in copyPreviousScores.
 //
-// Rule: CMS systems roll forward from CMS's own hand-entered ZTMF cycle; every
-// other OpDiv rolls forward from the HHS import cycle. This replaces the single
-// global predecessor (findPreviousDataCall) for one cycle only.
+// Rule: CMS systems roll forward from CMS's own hand-entered cycle; every other
+// OpDiv rolls forward from the HHS import cycle. Replaces the single global
+// predecessor (findPreviousDataCall) for the FY2026 cycle only.
 //
-// OpDiv is an EXCLUSION, not a preference. A system's OpDiv selects exactly one
-// source cycle and the other is not read at all: a CMS system never inherits an
-// HHS-import answer, even for a question it has no CMS-cycle answer for. Danny
-// Bowne confirmed there is no case where a CMS system should pull from the HHS
-// cycle - any such gap was already resolved in the data cleanup - so a CMS
-// system missing from FY2025 Q3 is a data problem to fix at the source, not one
-// to paper over at rollover time.
+// EXCLUSION, not preference: a system's OpDiv selects exactly one source cycle
+// and the other is not read at all. The two cycles are separate lineages, and
+// where they overlap the CMS entry is the record. A system with no rows in its
+// assigned cycle therefore rolls forward EMPTY - see cms_stranded below.
 //
-// This is safe because the assigned cycle IS each side's source of truth: a CMS
-// system's answers live in the CMS cycle, so reading only that cycle reads
-// everything it has. Exclusion is not discarding a fallback, it is declining to
-// overlay a second, non-authoritative copy of the same systems.
-//
-// The two cycles are separate lineages, not one record with gaps. CMS ran its
-// own hand-entered call; the HHS ZTM cycles were loaded independently and their
-// systems only arrived in ZTMF recently. Where they overlap - the HHS import
-// carries its own view of some CMS systems - the CMS entry is the record and the
-// imported view is not. That overlap is precisely what made the global
-// predecessor wrong: it handed CMS systems the imported view because that cycle
-// happened to have the later deadline. So a CMS system appearing in FY25 ZTM is
-// expected and is not evidence that it needs to read from there.
-//
-// Consequence, intended: FY25 ZTM's rows for CMS systems do not carry into FY26
-// at all. They remain queryable as history under their own datacallid, but the
-// forward line for a CMS system is its CMS-cycle answer only.
-//
-// The mechanical risk that remains is a system with no rows at all in its
-// assigned cycle - it rolls forward EMPTY, and this copy runs once with no
-// re-run path (ztmf#411). Under the rule above that count should be zero on both
-// sides. It is measured rather than assumed ("stranded" in the diagnostics
-// below), because zero is the premise the design rests on and a one-shot,
-// unrecoverable copy is a bad place to find out otherwise. Confirming it against
-// the target database before creating the real cycle costs one query:
-//
-//	SELECT o.code, COUNT(*) FROM fismasystems fs
-//	  JOIN opdivs o ON o.opdiv_id = fs.opdiv_id
-//	 WHERE fs.fismasystemid IN (SELECT fismasystemid FROM scores
-//	                             WHERE datacallid IN (<cms>, <other>))
-//	   AND NOT EXISTS (
-//	         SELECT 1 FROM scores sc
-//	           JOIN functionoptions fo ON fo.functionoptionid = sc.functionoptionid
-//	          WHERE sc.fismasystemid = fs.fismasystemid
-//	            AND sc.datacallid = CASE WHEN o.code = 'CMS' THEN <cms> ELSE <other> END)
-//	 GROUP BY o.code;
-//
-// The JOIN to functionoptions is load-bearing: "has rows in the assigned cycle"
-// is not the same question as "has rows the copy can carry". A system whose only
-// answers are functionoptionid = -1 sentinels passes the first test and still
-// rolls forward empty. Omitting the join under-reports - it predicted 8 against
-// an actual 9 on the prod-like snapshot, and the one it missed was exactly that
-// case.
-//
-// A second accepted consequence: exclusion carries mis-filed rows
-// (ztmf-misc#256) forward with no escape hatch. A system whose assigned cycle
-// holds a functionoptionid pointing outside its own scoring environment keeps
-// that row and scores exactly 1.00; the other cycle's correct answer is not
-// consulted. misfiled_carried below counts these.
-//
-// fismasystems.opdiv_id is NOT NULL with an FK to opdivs (migrations 0029,
-// 0027), so the OpDiv always resolves and no system can be routed by accident.
-// Migration 0028 backfilled every pre-existing row to CMS, so the CMS branch is
-// the overwhelmingly common one.
-//
-// Sources are resolved by NAME, not by hard-coded IDs: datacalls.datacall is
-// UNIQUE (migration 0013) and the IDs differ between dev and prod, so names are
-// the only portable handle. If either name is missing the override does nothing
-// and the caller falls through to the existing global path unchanged - so this
-// is inert on any environment that lacks both 2025 cycles.
+// Sources resolve by NAME, not id: datacalls.datacall is UNIQUE (migration 0013)
+// and ids differ per environment. If either name is missing the override is inert
+// and the caller falls through to the global path unchanged.
 const (
 	rolloverHardcodeCMSSource   = "FY2025 Q3" // CMS's own hand-entered cycle
 	rolloverHardcodeOtherSource = "FY25 ZTM"  // HHS import
 	rolloverHardcodeCMSOpDiv    = "CMS"       // opdivs.code seeded by migration 0026
 )
 
-// The override is gated to the FY2026 cycle on TWO independent conditions, so it
-// cannot leak onto any other data call while this block is still deployed:
-//
-//  1. The target's name starts with one of rolloverHardcodeTargetPrefixes.
-//     Excludes FY2027 and anything else created before the removal ticket lands,
-//     which is what makes "delete this after FY26 kicks off" safe rather than a
-//     deadline. Both prefixes are accepted because the two source cycles
-//     themselves disagree on the convention ("FY2025 Q3" vs "FY25 ZTM") and the
-//     FY26 name is chosen by the operator at creation time.
-//  2. The target's deadline is later than BOTH sources' deadlines. This is the
-//     ztmf#448 invariant restated: a backfill call with an earlier deadline must
-//     not pull a 2025 cycle forward, no matter what it is named. The override
-//     replaces findPreviousDataCall entirely, so it has to carry #448's guarantee
-//     itself rather than inherit it.
-//
-// A declined target is logged with the specific reason and the actual name, so a
-// gate that rejects the real FY26 call is diagnosable from the log line alone
-// rather than looking like a normal rollover. That failure mode matters: the copy
-// runs once, at creation, with no re-run path (ztmf#411).
+// Gated to FY2026 on two independent conditions so it cannot leak onto another
+// data call before this block is deleted: the target's name matches one of these
+// prefixes, AND its deadline is later than both sources' (the ztmf#448 invariant,
+// which this path must carry itself since it bypasses findPreviousDataCall).
+// Both prefixes are accepted because the source cycles disagree on the convention
+// ("FY2025 Q3" vs "FY25 ZTM") and the operator types the FY26 name.
 var rolloverHardcodeTargetPrefixes = []string{"FY2026", "FY26"}
 
-// matchesRolloverHardcodeTarget reports whether name is the FY2026 cycle this
-// override is scoped to. Case-insensitive: the operator types the name.
 func matchesRolloverHardcodeTarget(name string) bool {
 	upper := strings.ToUpper(strings.TrimSpace(name))
 	for _, prefix := range rolloverHardcodeTargetPrefixes {
@@ -853,12 +778,10 @@ func matchesRolloverHardcodeTarget(name string) bool {
 	return false
 }
 
-// copyPreviousScoresOpDivHardcoded performs the OpDiv-keyed rollover described
-// above. handled is false when the override does not apply, in which case the
-// caller must fall back to the normal global path. It does not apply when either
-// named cycle is missing, when the new call is itself one of them, or when the
-// new call fails either target gate (name, deadline ordering). Every decline is
-// logged with a specific reason.
+// copyPreviousScoresOpDivHardcoded performs the OpDiv-keyed rollover. handled is
+// false when the override does not apply (missing source, target is a source, or
+// either gate rejects it), in which case the caller falls back to the global path.
+// Every decline logs a specific reason.
 func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (copied int64, handled bool, err error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
@@ -872,11 +795,9 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 		targetName                 string
 		targetDeadline             time.Time
 	)
-	// The two id subqueries MUST stay ahead of the GREATEST: a missing source name
+	// The id subqueries MUST stay ahead of the GREATEST: a missing source name
 	// yields NULL, which fails the scan into int32 and takes the inactive path.
-	// GREATEST would not catch it on its own - unlike most Postgres functions it
-	// ignores NULL arguments, so GREATEST(NULL, deadline) returns the deadline and
-	// a half-present source pair would look valid.
+	// GREATEST alone would not catch it - it ignores NULL arguments.
 	err = conn.QueryRow(ctx, `
 		SELECT
 			(SELECT datacallid FROM datacalls WHERE datacall = $1),
@@ -889,8 +810,6 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 		rolloverHardcodeCMSSource, rolloverHardcodeOtherSource, dataCallID,
 	).Scan(&cmsSourceID, &otherSourceID, &latestSourceDeadline, &targetName, &targetDeadline)
 	if err != nil {
-		// Either name is absent (NULL -> scan error) or the query failed. Not an
-		// anomaly: the override simply does not apply here.
 		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=source_lookup err=%v", dataCallID, err)
 		return 0, false, nil
 	}
@@ -899,46 +818,32 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 		return 0, false, nil
 	}
 
-	// Gate 1: name. See rolloverHardcodeTargetPrefixes.
 	if !matchesRolloverHardcodeTarget(targetName) {
 		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=target_name_not_fy2026 name=%q want_prefix=%v",
 			dataCallID, targetName, rolloverHardcodeTargetPrefixes)
 		return 0, false, nil
 	}
 
-	// Gate 2: deadline ordering, i.e. the ztmf#448 invariant. A call named FY26
-	// but deadlined before either source is a backfill, not the next cycle.
+	// ztmf#448: a call named FY26 but deadlined before either source is a backfill.
 	if !targetDeadline.After(latestSourceDeadline) {
 		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=target_deadline_not_after_sources name=%q target_deadline=%s latest_source_deadline=%s",
 			dataCallID, targetName, targetDeadline.Format(time.RFC3339), latestSourceDeadline.Format(time.RFC3339))
 		return 0, false, nil
 	}
 
-	// The OpDiv selects the ONE cycle a system may read. The CASE in the WHERE
-	// clause is the exclusion: a row survives only if its datacallid is the source
-	// assigned to that system's OpDiv, so the other cycle is never a candidate and
-	// there is nothing to rank between them.
+	// The CASE in the WHERE clause IS the exclusion: a row survives only if its
+	// datacallid is the source assigned to that system's OpDiv.
 	//
-	// JOIN opdivs, not LEFT JOIN: fismasystems.opdiv_id is NOT NULL with an FK to
-	// opdivs, so every system resolves. Under exclusion an unmatched OpDiv would
-	// silently route a system to the HHS cycle and strand it there, so the inner
-	// join is the safer shape - a system that somehow failed to resolve would be
-	// dropped and counted by "stranded" rather than mis-routed in silence.
+	// DISTINCT ON (fismasystemid, functionid) guarantees one answer per question -
+	// scores has no uniqueness constraint, so a cycle may hold duplicates.
 	//
-	// DISTINCT ON (fismasystemid, functionid) guarantees at most one answer per
-	// question. scores has no uniqueness constraint, so a source cycle holding
-	// duplicate rows for one question would otherwise copy both; scoreid DESC
-	// makes the winner the most recently inserted row rather than arbitrary.
+	// status is seeded 'not_started' as on the normal path (ztmf#435).
 	//
-	// status is seeded as the 'not_started' literal, same as the normal path
-	// (ztmf#435) - the answer carries forward, its review state does not.
-	//
-	// The ::int casts on the CASE branches are REQUIRED, not decoration. Both
-	// branches are bind parameters, so with nothing to infer from Postgres resolves
-	// the CASE result type to text and the comparison becomes integer = text, which
-	// fails the whole copy at runtime with SQLSTATE 42883 ("operator does not
-	// exist"). It cannot be caught by testing the query with literal ids
-	// substituted - literals carry their own type and resolve fine. Do not remove.
+	// The ::int casts are REQUIRED, not decoration. Both CASE branches are bind
+	// parameters, so Postgres resolves the CASE to text and the comparison becomes
+	// integer = text, failing the copy at runtime with SQLSTATE 42883. Testing with
+	// literal ids, or PREPARE with declared types, will NOT catch this - both supply
+	// the type information pgx omits. Do not remove.
 	const copySQL = `
 		INSERT INTO scores (fismasystemid, datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status)
 		SELECT DISTINCT ON (s.fismasystemid, fo.functionid)
@@ -958,48 +863,23 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 	}
 	copied = tag.RowsAffected()
 
-	// Diagnostics.
+	// Diagnostics. Three of these are not self-explanatory:
 	//
-	// from_cms_source / from_other_source report which cycle each surviving answer
-	// actually came from, so the run can be checked against expectations rather
-	// than assumed. cms_systems / other_systems show how the OpDiv axis actually
-	// partitions the inventory (see migration 0028).
-	//
-	// selected_rows is the raw row count AFTER the OpDiv exclusion - the rows the
-	// copy was entitled to read. selected_rows - copied is therefore exactly what
-	// DISTINCT ON collapsed as duplicates. src_rows (both cycles, unfiltered) is
-	// reported alongside it so src_rows - selected_rows shows how much the
-	// exclusion discarded outright. Keeping the two separate matters: conflating
-	// them would report deliberately excluded rows as deduplication and hide the
-	// size of what exclusion is dropping.
-	//
-	// "stranded" counts systems that have answers in SOME source cycle but got no
-	// rows in the new call - i.e. systems whose assigned cycle has nothing for
-	// them. Both sides should read zero: each cycle is the authoritative record for
-	// the systems routed to it, so a system that answered anywhere answered there.
-	// It is broken out by side so a nonzero value is triageable rather than just
-	// alarming - cms_stranded means a CMS system has no CMS-cycle answers, which
-	// falsifies the premise the exclusion rests on, and other_stranded the same for
-	// the HHS side.
-	//
-	// misfiled_carried counts rows whose functionoptionid points at a function
-	// outside the system's own scoring environment (ztmf-misc#256) - these carry
-	// verbatim and produce the exactly-1.00 failure. It is deliberately restricted
-	// to systems that HAVE a scoring environment: a system whose
-	// datacenterenvironment has no datacenterenvironments row, or maps to a NULL
-	// scoring_key (the DECOMMISSIONED marker, migration 0045), matches no function
-	// at all and would otherwise report as 100% mis-filed. Those are counted
-	// separately as unscored_env - a different condition with a different fix.
-	//
-	// dropped_unresolvable counts assigned rows the copy silently discards because
-	// functionoptionid resolves to nothing. Do NOT assume the FK makes this
-	// impossible: scores_functionoptionid_fkey reports convalidated = t, but it was
-	// created against an empty table and bulk loads run under
-	// session_replication_role = replica, which bypasses FK triggers entirely. The
-	// prod snapshot really does contain rows the schema calls impossible - 33 of
-	// them in FY2025 Q3, all functionoptionid = -1 sentinels across 11 systems. The
-	// copy's INNER JOIN drops them, so this is a genuine partial-copy signal, not a
-	// theoretical one.
+	//   selected_rows  rows AFTER the OpDiv exclusion, so selected_rows - copied is
+	//                  duplicate collapse and src_rows - selected_rows is what the
+	//                  exclusion discarded. Conflating the two would report excluded
+	//                  rows as deduplication.
+	//   misfiled_carried  restricted to systems that HAVE a scoring environment; one
+	//                  with an unmapped datacenterenvironment or a NULL scoring_key
+	//                  (DECOMMISSIONED, migration 0045) matches no function at all
+	//                  and would otherwise read as 100% mis-filed. Counted separately
+	//                  as unscored_env.
+	//   dropped_unresolvable  assigned rows the copy discards because
+	//                  functionoptionid resolves to nothing. The FK does NOT make
+	//                  this impossible: it reports convalidated = t but was created
+	//                  against an empty table, and bulk loads run under
+	//                  session_replication_role = replica, bypassing FK triggers.
+	//                  Real data contains such rows.
 	var fromCMS, fromOther, cmsSystems, otherSystems, cmsStranded, otherStranded, misfiled, unscoredEnv, srcRows, selectedRows, droppedUnresolvable int64
 	diagErr := conn.QueryRow(ctx, `
 		WITH assigned AS (
@@ -1015,8 +895,7 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 			  FROM assigned
 			 ORDER BY fismasystemid, functionid, scoreid DESC
 		),
-		-- Systems that answered SOMETHING in either cycle but landed nothing in the
-		-- new call, split by which cycle they were routed to.
+		-- Answered in some cycle, landed nothing in the new call.
 		missing AS (
 			SELECT fs.fismasystemid, o.code AS opdiv_code
 			  FROM fismasystems fs
@@ -1072,36 +951,20 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 		cmsSystems, otherSystems, srcRows, selectedRows, srcRows-selectedRows, copied, selectedRows-copied, droppedUnresolvable,
 		fromCMS, fromOther, cmsStranded, otherStranded, misfiled, unscoredEnv)
 
-	// Partial-copy detection. An earlier revision of this comment claimed the
-	// enforced FKs made a partial copy impossible and that the check could never
-	// fire. That was wrong, and measurably so - see dropped_unresolvable above.
-	// Rows whose functionoptionid resolves to nothing exist in the real data and
-	// the copy's INNER JOIN discards them without a word.
 	if droppedUnresolvable > 0 {
 		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=%d copied=%d err=<none> reason=hardcode_unresolvable_rows dropped=%d",
 			dataCallID, selectedRows+droppedUnresolvable, copied, droppedUnresolvable)
 	}
 
-	// Zero-copy detection, the ztmf#411 semantic. A nonzero source with an empty
-	// result is the failure that must not ship silently - it is what the missing
-	// ::int casts produced (integer = text, SQLSTATE 42883) before they were added.
-	//
-	// Compared against selected_rows, not src_rows: under exclusion a zero copy
-	// with a nonzero src_rows is legitimate if the exclusion discarded everything,
-	// and that case is reported by the stranding alarm below instead.
-	//
-	// Same alarm token as the normal path so it surfaces through the existing
-	// CloudWatch metric.
+	// Zero-copy detection (ztmf#411). Against selected_rows, not src_rows: under
+	// exclusion a zero copy with nonzero src_rows is legitimate. Reuses the normal
+	// path's alarm token so it hits the existing CloudWatch metric.
 	if copied == 0 && selectedRows > 0 {
 		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=%d copied=0 err=<none> reason=hardcode_empty_copy", dataCallID, selectedRows)
 	}
 
-	// Stranding alarm. Expected to be silent: under the source-of-truth rule every
-	// system that answered at all answered in its assigned cycle. If it does fire,
-	// the premise is wrong for those systems - they answered in one cycle, were
-	// routed to the other, and rolled forward EMPTY with no re-run path (ztmf#411).
-	// That is the signal to delete the new data call and fix the source data before
-	// recreating it, not something to accept and move past.
+	// These systems rolled forward EMPTY and the copy has no re-run path
+	// (ztmf#411). Investigate before anyone starts answering.
 	if cmsStranded > 0 || otherStranded > 0 {
 		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=>0 copied=%d err=<none> reason=hardcode_stranded_systems cms_stranded=%d other_stranded=%d",
 			dataCallID, copied, cmsStranded, otherStranded)

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -13,6 +13,7 @@ import (
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
 	"github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // rawQuery wraps a hand-built SQL string and its arguments so it can flow
@@ -757,16 +758,63 @@ ORDER BY ps.datacallid, ps.fismasystemid, ps.pillarid
 const (
 	rolloverHardcodeCMSSource   = "FY2025 Q3" // CMS's own hand-entered cycle
 	rolloverHardcodeOtherSource = "FY25 ZTM"  // HHS import
-	rolloverHardcodeCMSOpDiv    = "CMS"       // opdivs.code seeded by migration 0026
+	// Compared case-insensitively via UPPER() at every site. opdivs.code is
+	// editable through PUT /opdivs/{id} (OpDiv.Save updates it unconditionally,
+	// validate only trims) and migration 0026's uniqueness index is on
+	// LOWER(code), so renaming CMS to "cms" saves cleanly. An exact-case compare
+	// would then match no rows, drop every system to the ELSE branch, and source
+	// the whole estate from the HHS cycle - this PR's own bug, reproduced. Keep
+	// this constant uppercase.
+	rolloverHardcodeCMSOpDiv = "CMS" // opdivs.code seeded by migration 0026
 )
 
-// Gated to FY2026 on two independent conditions so it cannot leak onto another
-// data call before this block is deleted: the target's name matches one of these
-// prefixes, AND its deadline is later than both sources' (the ztmf#448 invariant,
-// which this path must carry itself since it bypasses findPreviousDataCall).
-// Both prefixes are accepted because the source cycles disagree on the convention
-// ("FY2025 Q3" vs "FY25 ZTM") and the operator types the FY26 name.
+// Gated to the FY2026 cycle on three independent conditions so it cannot leak
+// onto another data call before this block is deleted:
+//
+//  1. the target's name starts with one of these prefixes
+//  2. its deadline is later than both sources' - the ztmf#448 invariant, which
+//     this path must carry itself since it bypasses findPreviousDataCall
+//  3. it is the FIRST cycle matching these prefixes (see
+//     earlierRolloverHardcodeTargets) - without it a second same-year call
+//     re-sources from the 2025 cycles and discards everything FY2026 accrued
+//
+// BOTH year forms are accepted on purpose. FY2026 is the single unified cycle
+// covering all of HHS including CMS - merging the two 2025 lineages into one is
+// the entire point of this change, so there is no separate HHS import cycle to
+// keep out. The final name is not fixed yet and the two prior conventions
+// disagree ("FY2025 Q3" four-digit, "FY25 ZTM" two-digit), so excluding either
+// form risks the override silently declining on the real cycle - which ships the
+// P0 this exists to prevent. Gate 3 is what keeps the broad prefix safe: only the
+// first matching cycle is ever treated as the target.
 var rolloverHardcodeTargetPrefixes = []string{"FY2026", "FY26"}
+
+// earlierRolloverHardcodeTargets returns the names of FY26-prefixed data calls
+// that precede the target, ordered ahead of it by (deadline, datacallid) - the
+// same ordering findPreviousDataCall uses. A non-empty result means the target is
+// not the first FY26 cycle and the override must not apply.
+func earlierRolloverHardcodeTargets(ctx context.Context, conn *pgxpool.Conn, dataCallID int32, targetDeadline time.Time) ([]string, error) {
+	rows, err := conn.Query(ctx, `
+		SELECT datacall FROM datacalls
+		 WHERE datacallid <> $1
+		   AND (deadline < $2 OR (deadline = $2 AND datacallid < $1))`,
+		dataCallID, targetDeadline)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var earlier []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		if matchesRolloverHardcodeTarget(name) {
+			earlier = append(earlier, name)
+		}
+	}
+	return earlier, rows.Err()
+}
 
 func matchesRolloverHardcodeTarget(name string) bool {
 	upper := strings.ToUpper(strings.TrimSpace(name))
@@ -831,6 +879,27 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 		return 0, false, nil
 	}
 
+	// Gate 3: the target must be the FIRST FY26-prefixed cycle. Without this, a
+	// second same-year call (FY2026 Q4, a redo, a mid-year backfill) passes gates
+	// 1 and 2 and re-sources from the 2025 cycles, discarding everything the real
+	// FY26 cycle accumulated. This path REPLACES findPreviousDataCall, so it would
+	// not be missing the right answer - it would be overriding it. FY2025 Q3
+	// establishes quarter suffixes as the convention, so a second FY26 call is the
+	// likelier hazard, not FY2027.
+	//
+	// The candidate list is filtered in Go with the same matcher the name gate
+	// uses, so the two can never disagree. datacalls holds single-digit row counts.
+	earlier, err := earlierRolloverHardcodeTargets(ctx, conn, dataCallID, targetDeadline)
+	if err != nil {
+		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=predecessor_scan err=%v", dataCallID, err)
+		return 0, false, nil
+	}
+	if len(earlier) > 0 {
+		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=not_first_fy2026_cycle name=%q earlier=%v",
+			dataCallID, targetName, earlier)
+		return 0, false, nil
+	}
+
 	// The CASE in the WHERE clause IS the exclusion: a row survives only if its
 	// datacallid is the source assigned to that system's OpDiv.
 	//
@@ -853,7 +922,7 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 		  JOIN fismasystems fs     ON fs.fismasystemid    = s.fismasystemid
 		  JOIN functionoptions fo  ON fo.functionoptionid = s.functionoptionid
 		  JOIN opdivs o            ON o.opdiv_id          = fs.opdiv_id
-		 WHERE s.datacallid = CASE WHEN o.code = $4 THEN $2::int ELSE $3::int END
+		 WHERE s.datacallid = CASE WHEN UPPER(o.code) = $4 THEN $2::int ELSE $3::int END
 		 ORDER BY s.fismasystemid, fo.functionid, s.scoreid DESC`
 
 	tag, err := conn.Exec(ctx, copySQL, dataCallID, cmsSourceID, otherSourceID, rolloverHardcodeCMSOpDiv)
@@ -883,12 +952,12 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 	var fromCMS, fromOther, cmsSystems, otherSystems, cmsStranded, otherStranded, misfiled, unscoredEnv, srcRows, selectedRows, droppedUnresolvable int64
 	diagErr := conn.QueryRow(ctx, `
 		WITH assigned AS (
-			SELECT s.scoreid, s.fismasystemid, s.datacallid, fo.functionid, o.code AS opdiv_code
+			SELECT s.scoreid, s.fismasystemid, s.datacallid, fo.functionid, UPPER(o.code) AS opdiv_code
 			  FROM scores s
 			  JOIN fismasystems fs    ON fs.fismasystemid    = s.fismasystemid
 			  JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
 			  JOIN opdivs o           ON o.opdiv_id          = fs.opdiv_id
-			 WHERE s.datacallid = CASE WHEN o.code = $3 THEN $1::int ELSE $2::int END
+			 WHERE s.datacallid = CASE WHEN UPPER(o.code) = $3 THEN $1::int ELSE $2::int END
 		),
 		winners AS (
 			SELECT DISTINCT ON (fismasystemid, functionid) datacallid AS won_from
@@ -897,7 +966,7 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 		),
 		-- Answered in some cycle, landed nothing in the new call.
 		missing AS (
-			SELECT fs.fismasystemid, o.code AS opdiv_code
+			SELECT fs.fismasystemid, UPPER(o.code) AS opdiv_code
 			  FROM fismasystems fs
 			  JOIN opdivs o ON o.opdiv_id = fs.opdiv_id
 			 WHERE fs.fismasystemid IN (SELECT fismasystemid FROM scores WHERE datacallid IN ($1, $2))
@@ -908,10 +977,10 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 			(SELECT COUNT(*) FROM winners WHERE won_from = $2),
 			(SELECT COUNT(*) FROM fismasystems fsc
 			   JOIN opdivs oc ON oc.opdiv_id = fsc.opdiv_id
-			  WHERE oc.code = $3),
+			  WHERE UPPER(oc.code) = $3),
 			(SELECT COUNT(*) FROM fismasystems fso
 			   JOIN opdivs oo ON oo.opdiv_id = fso.opdiv_id
-			  WHERE oo.code IS DISTINCT FROM $3),
+			  WHERE UPPER(oo.code) IS DISTINCT FROM $3),
 			(SELECT COUNT(*) FROM missing WHERE opdiv_code = $3),
 			(SELECT COUNT(*) FROM missing WHERE opdiv_code IS DISTINCT FROM $3),
 			(SELECT COUNT(*)
@@ -937,7 +1006,7 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 			   JOIN fismasystems fs4 ON fs4.fismasystemid = s.fismasystemid
 			   JOIN opdivs o4        ON o4.opdiv_id       = fs4.opdiv_id
 			   LEFT JOIN functionoptions fo4 ON fo4.functionoptionid = s.functionoptionid
-			  WHERE s.datacallid = CASE WHEN o4.code = $3 THEN $1::int ELSE $2::int END
+			  WHERE s.datacallid = CASE WHEN UPPER(o4.code) = $3 THEN $1::int ELSE $2::int END
 			    AND fo4.functionoptionid IS NULL)`,
 		cmsSourceID, otherSourceID, rolloverHardcodeCMSOpDiv, dataCallID,
 	).Scan(&fromCMS, &fromOther, &cmsSystems, &otherSystems, &cmsStranded, &otherStranded, &misfiled, &unscoredEnv, &srcRows, &selectedRows, &droppedUnresolvable)
@@ -965,6 +1034,16 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 
 	// These systems rolled forward EMPTY and the copy has no re-run path
 	// (ztmf#411). Investigate before anyone starts answering.
+	// cms_systems == 0 means the CMS OpDiv code did not match ANY system, so every
+	// system silently took the ELSE branch and sourced from the HHS cycle - this
+	// PR's own bug. None of the other alarms catch it: copied is nonzero because
+	// the other bucket copied fine. Promote it so it pages instead of sitting in
+	// an info line that a human has to read.
+	if cmsSystems == 0 {
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=>0 copied=%d err=<none> reason=hardcode_no_cms_systems opdiv_code=%q",
+			dataCallID, copied, rolloverHardcodeCMSOpDiv)
+	}
+
 	if cmsStranded > 0 || otherStranded > 0 {
 		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=>0 copied=%d err=<none> reason=hardcode_stranded_systems cms_stranded=%d other_stranded=%d",
 			dataCallID, copied, cmsStranded, otherStranded)

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -784,10 +784,19 @@ ORDER BY ps.datacallid, ps.fismasystemid, ps.pillarid
 //	  JOIN opdivs o ON o.opdiv_id = fs.opdiv_id
 //	 WHERE fs.fismasystemid IN (SELECT fismasystemid FROM scores
 //	                             WHERE datacallid IN (<cms>, <other>))
-//	   AND fs.fismasystemid NOT IN (
-//	         SELECT fismasystemid FROM scores WHERE datacallid =
-//	           CASE WHEN o.code = 'CMS' THEN <cms> ELSE <other> END)
+//	   AND NOT EXISTS (
+//	         SELECT 1 FROM scores sc
+//	           JOIN functionoptions fo ON fo.functionoptionid = sc.functionoptionid
+//	          WHERE sc.fismasystemid = fs.fismasystemid
+//	            AND sc.datacallid = CASE WHEN o.code = 'CMS' THEN <cms> ELSE <other> END)
 //	 GROUP BY o.code;
+//
+// The JOIN to functionoptions is load-bearing: "has rows in the assigned cycle"
+// is not the same question as "has rows the copy can carry". A system whose only
+// answers are functionoptionid = -1 sentinels passes the first test and still
+// rolls forward empty. Omitting the join under-reports - it predicted 8 against
+// an actual 9 on the prod-like snapshot, and the one it missed was exactly that
+// case.
 //
 // A second accepted consequence: exclusion carries mis-filed rows
 // (ztmf-misc#256) forward with no escape hatch. A system whose assigned cycle
@@ -923,6 +932,13 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 	//
 	// status is seeded as the 'not_started' literal, same as the normal path
 	// (ztmf#435) - the answer carries forward, its review state does not.
+	//
+	// The ::int casts on the CASE branches are REQUIRED, not decoration. Both
+	// branches are bind parameters, so with nothing to infer from Postgres resolves
+	// the CASE result type to text and the comparison becomes integer = text, which
+	// fails the whole copy at runtime with SQLSTATE 42883 ("operator does not
+	// exist"). It cannot be caught by testing the query with literal ids
+	// substituted - literals carry their own type and resolve fine. Do not remove.
 	const copySQL = `
 		INSERT INTO scores (fismasystemid, datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status)
 		SELECT DISTINCT ON (s.fismasystemid, fo.functionid)
@@ -932,7 +948,7 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 		  JOIN fismasystems fs     ON fs.fismasystemid    = s.fismasystemid
 		  JOIN functionoptions fo  ON fo.functionoptionid = s.functionoptionid
 		  JOIN opdivs o            ON o.opdiv_id          = fs.opdiv_id
-		 WHERE s.datacallid = CASE WHEN o.code = $4 THEN $2 ELSE $3 END
+		 WHERE s.datacallid = CASE WHEN o.code = $4 THEN $2::int ELSE $3::int END
 		 ORDER BY s.fismasystemid, fo.functionid, s.scoreid DESC`
 
 	tag, err := conn.Exec(ctx, copySQL, dataCallID, cmsSourceID, otherSourceID, rolloverHardcodeCMSOpDiv)
@@ -974,7 +990,17 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 	// scoring_key (the DECOMMISSIONED marker, migration 0045), matches no function
 	// at all and would otherwise report as 100% mis-filed. Those are counted
 	// separately as unscored_env - a different condition with a different fix.
-	var fromCMS, fromOther, cmsSystems, otherSystems, cmsStranded, otherStranded, misfiled, unscoredEnv, srcRows, selectedRows int64
+	//
+	// dropped_unresolvable counts assigned rows the copy silently discards because
+	// functionoptionid resolves to nothing. Do NOT assume the FK makes this
+	// impossible: scores_functionoptionid_fkey reports convalidated = t, but it was
+	// created against an empty table and bulk loads run under
+	// session_replication_role = replica, which bypasses FK triggers entirely. The
+	// prod snapshot really does contain rows the schema calls impossible - 33 of
+	// them in FY2025 Q3, all functionoptionid = -1 sentinels across 11 systems. The
+	// copy's INNER JOIN drops them, so this is a genuine partial-copy signal, not a
+	// theoretical one.
+	var fromCMS, fromOther, cmsSystems, otherSystems, cmsStranded, otherStranded, misfiled, unscoredEnv, srcRows, selectedRows, droppedUnresolvable int64
 	diagErr := conn.QueryRow(ctx, `
 		WITH assigned AS (
 			SELECT s.scoreid, s.fismasystemid, s.datacallid, fo.functionid, o.code AS opdiv_code
@@ -982,7 +1008,7 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 			  JOIN fismasystems fs    ON fs.fismasystemid    = s.fismasystemid
 			  JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
 			  JOIN opdivs o           ON o.opdiv_id          = fs.opdiv_id
-			 WHERE s.datacallid = CASE WHEN o.code = $3 THEN $1 ELSE $2 END
+			 WHERE s.datacallid = CASE WHEN o.code = $3 THEN $1::int ELSE $2::int END
 		),
 		winners AS (
 			SELECT DISTINCT ON (fismasystemid, functionid) datacallid AS won_from
@@ -1026,27 +1052,39 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 			  WHERE s.datacallid = $4
 			    AND dce2.scoring_key IS NULL),
 			(SELECT COUNT(*) FROM scores WHERE datacallid IN ($1, $2)),
-			(SELECT COUNT(*) FROM assigned)`,
+			(SELECT COUNT(*) FROM assigned),
+			(SELECT COUNT(*)
+			   FROM scores s
+			   JOIN fismasystems fs4 ON fs4.fismasystemid = s.fismasystemid
+			   JOIN opdivs o4        ON o4.opdiv_id       = fs4.opdiv_id
+			   LEFT JOIN functionoptions fo4 ON fo4.functionoptionid = s.functionoptionid
+			  WHERE s.datacallid = CASE WHEN o4.code = $3 THEN $1::int ELSE $2::int END
+			    AND fo4.functionoptionid IS NULL)`,
 		cmsSourceID, otherSourceID, rolloverHardcodeCMSOpDiv, dataCallID,
-	).Scan(&fromCMS, &fromOther, &cmsSystems, &otherSystems, &cmsStranded, &otherStranded, &misfiled, &unscoredEnv, &srcRows, &selectedRows)
+	).Scan(&fromCMS, &fromOther, &cmsSystems, &otherSystems, &cmsStranded, &otherStranded, &misfiled, &unscoredEnv, &srcRows, &selectedRows, &droppedUnresolvable)
 	if diagErr != nil {
 		log.Printf("ROLLOVER_HARDCODE datacall=%d status=active copied=%d diagnostics_err=%v", dataCallID, copied, diagErr)
 		return copied, true, nil
 	}
 
-	log.Printf("ROLLOVER_HARDCODE datacall=%d status=active mode=exclusion cms_source=%d(%q) other_source=%d(%q) cms_systems=%d other_systems=%d src_rows=%d selected_rows=%d excluded_rows=%d copied=%d deduped=%d from_cms_source=%d from_other_source=%d cms_stranded=%d other_stranded=%d misfiled_carried=%d unscored_env=%d",
+	log.Printf("ROLLOVER_HARDCODE datacall=%d status=active mode=exclusion cms_source=%d(%q) other_source=%d(%q) cms_systems=%d other_systems=%d src_rows=%d selected_rows=%d excluded_rows=%d copied=%d deduped=%d dropped_unresolvable=%d from_cms_source=%d from_other_source=%d cms_stranded=%d other_stranded=%d misfiled_carried=%d unscored_env=%d",
 		dataCallID, cmsSourceID, rolloverHardcodeCMSSource, otherSourceID, rolloverHardcodeOtherSource,
-		cmsSystems, otherSystems, srcRows, selectedRows, srcRows-selectedRows, copied, selectedRows-copied,
+		cmsSystems, otherSystems, srcRows, selectedRows, srcRows-selectedRows, copied, selectedRows-copied, droppedUnresolvable,
 		fromCMS, fromOther, cmsStranded, otherStranded, misfiled, unscoredEnv)
 
-	// Zero-copy detection, the ztmf#411 semantic. Deliberately NOT a partial-copy
-	// check: scores has enforced FKs to fismasystems and functionoptions, so the
-	// copy's INNER JOINs cannot drop a row, and INSERT...SELECT is atomic - there
-	// is no partial mode to detect. (Comparing copied against fromCMS+fromOther
-	// would be worse than useless: the winners CTE applies the same joins and
-	// filters as the copy, so the two are equal by construction and the check
-	// could never fire.) A nonzero source with an empty result is the one failure
-	// this path can actually have, and it is the one that must not ship silently.
+	// Partial-copy detection. An earlier revision of this comment claimed the
+	// enforced FKs made a partial copy impossible and that the check could never
+	// fire. That was wrong, and measurably so - see dropped_unresolvable above.
+	// Rows whose functionoptionid resolves to nothing exist in the real data and
+	// the copy's INNER JOIN discards them without a word.
+	if droppedUnresolvable > 0 {
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=%d copied=%d err=<none> reason=hardcode_unresolvable_rows dropped=%d",
+			dataCallID, selectedRows+droppedUnresolvable, copied, droppedUnresolvable)
+	}
+
+	// Zero-copy detection, the ztmf#411 semantic. A nonzero source with an empty
+	// result is the failure that must not ship silently - it is what the missing
+	// ::int casts produced (integer = text, SQLSTATE 42883) before they were added.
 	//
 	// Compared against selected_rows, not src_rows: under exclusion a zero copy
 	// with a nonzero src_rows is legitimate if the exclusion discarded everything,

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -738,6 +738,343 @@ ORDER BY ps.datacallid, ps.fismasystemid, ps.pillarid
 	return sql, args
 }
 
+// ---------------------------------------------------------------------------
+// TEMPORARY HARD-CODE - ztmf#500. DELETE THIS ENTIRE BLOCK after the FY2026
+// data call has been created, along with the call site in copyPreviousScores.
+//
+// Rule: CMS systems roll forward from CMS's own hand-entered ZTMF cycle; every
+// other OpDiv rolls forward from the HHS import cycle. This replaces the single
+// global predecessor (findPreviousDataCall) for one cycle only.
+//
+// OpDiv is an EXCLUSION, not a preference. A system's OpDiv selects exactly one
+// source cycle and the other is not read at all: a CMS system never inherits an
+// HHS-import answer, even for a question it has no CMS-cycle answer for. Danny
+// Bowne confirmed there is no case where a CMS system should pull from the HHS
+// cycle - any such gap was already resolved in the data cleanup - so a CMS
+// system missing from FY2025 Q3 is a data problem to fix at the source, not one
+// to paper over at rollover time.
+//
+// This is safe because the assigned cycle IS each side's source of truth: a CMS
+// system's answers live in the CMS cycle, so reading only that cycle reads
+// everything it has. Exclusion is not discarding a fallback, it is declining to
+// overlay a second, non-authoritative copy of the same systems.
+//
+// The two cycles are separate lineages, not one record with gaps. CMS ran its
+// own hand-entered call; the HHS ZTM cycles were loaded independently and their
+// systems only arrived in ZTMF recently. Where they overlap - the HHS import
+// carries its own view of some CMS systems - the CMS entry is the record and the
+// imported view is not. That overlap is precisely what made the global
+// predecessor wrong: it handed CMS systems the imported view because that cycle
+// happened to have the later deadline. So a CMS system appearing in FY25 ZTM is
+// expected and is not evidence that it needs to read from there.
+//
+// Consequence, intended: FY25 ZTM's rows for CMS systems do not carry into FY26
+// at all. They remain queryable as history under their own datacallid, but the
+// forward line for a CMS system is its CMS-cycle answer only.
+//
+// The mechanical risk that remains is a system with no rows at all in its
+// assigned cycle - it rolls forward EMPTY, and this copy runs once with no
+// re-run path (ztmf#411). Under the rule above that count should be zero on both
+// sides. It is measured rather than assumed ("stranded" in the diagnostics
+// below), because zero is the premise the design rests on and a one-shot,
+// unrecoverable copy is a bad place to find out otherwise. Confirming it against
+// the target database before creating the real cycle costs one query:
+//
+//	SELECT o.code, COUNT(*) FROM fismasystems fs
+//	  JOIN opdivs o ON o.opdiv_id = fs.opdiv_id
+//	 WHERE fs.fismasystemid IN (SELECT fismasystemid FROM scores
+//	                             WHERE datacallid IN (<cms>, <other>))
+//	   AND fs.fismasystemid NOT IN (
+//	         SELECT fismasystemid FROM scores WHERE datacallid =
+//	           CASE WHEN o.code = 'CMS' THEN <cms> ELSE <other> END)
+//	 GROUP BY o.code;
+//
+// A second accepted consequence: exclusion carries mis-filed rows
+// (ztmf-misc#256) forward with no escape hatch. A system whose assigned cycle
+// holds a functionoptionid pointing outside its own scoring environment keeps
+// that row and scores exactly 1.00; the other cycle's correct answer is not
+// consulted. misfiled_carried below counts these.
+//
+// fismasystems.opdiv_id is NOT NULL with an FK to opdivs (migrations 0029,
+// 0027), so the OpDiv always resolves and no system can be routed by accident.
+// Migration 0028 backfilled every pre-existing row to CMS, so the CMS branch is
+// the overwhelmingly common one.
+//
+// Sources are resolved by NAME, not by hard-coded IDs: datacalls.datacall is
+// UNIQUE (migration 0013) and the IDs differ between dev and prod, so names are
+// the only portable handle. If either name is missing the override does nothing
+// and the caller falls through to the existing global path unchanged - so this
+// is inert on any environment that lacks both 2025 cycles.
+const (
+	rolloverHardcodeCMSSource   = "FY2025 Q3" // CMS's own hand-entered cycle
+	rolloverHardcodeOtherSource = "FY25 ZTM"  // HHS import
+	rolloverHardcodeCMSOpDiv    = "CMS"       // opdivs.code seeded by migration 0026
+)
+
+// The override is gated to the FY2026 cycle on TWO independent conditions, so it
+// cannot leak onto any other data call while this block is still deployed:
+//
+//  1. The target's name starts with one of rolloverHardcodeTargetPrefixes.
+//     Excludes FY2027 and anything else created before the removal ticket lands,
+//     which is what makes "delete this after FY26 kicks off" safe rather than a
+//     deadline. Both prefixes are accepted because the two source cycles
+//     themselves disagree on the convention ("FY2025 Q3" vs "FY25 ZTM") and the
+//     FY26 name is chosen by the operator at creation time.
+//  2. The target's deadline is later than BOTH sources' deadlines. This is the
+//     ztmf#448 invariant restated: a backfill call with an earlier deadline must
+//     not pull a 2025 cycle forward, no matter what it is named. The override
+//     replaces findPreviousDataCall entirely, so it has to carry #448's guarantee
+//     itself rather than inherit it.
+//
+// A declined target is logged with the specific reason and the actual name, so a
+// gate that rejects the real FY26 call is diagnosable from the log line alone
+// rather than looking like a normal rollover. That failure mode matters: the copy
+// runs once, at creation, with no re-run path (ztmf#411).
+var rolloverHardcodeTargetPrefixes = []string{"FY2026", "FY26"}
+
+// matchesRolloverHardcodeTarget reports whether name is the FY2026 cycle this
+// override is scoped to. Case-insensitive: the operator types the name.
+func matchesRolloverHardcodeTarget(name string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(name))
+	for _, prefix := range rolloverHardcodeTargetPrefixes {
+		if strings.HasPrefix(upper, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// copyPreviousScoresOpDivHardcoded performs the OpDiv-keyed rollover described
+// above. handled is false when the override does not apply, in which case the
+// caller must fall back to the normal global path. It does not apply when either
+// named cycle is missing, when the new call is itself one of them, or when the
+// new call fails either target gate (name, deadline ordering). Every decline is
+// logged with a specific reason.
+func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (copied int64, handled bool, err error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return 0, false, nil // fall through; the normal path reports the error
+	}
+	defer conn.Release()
+
+	var (
+		cmsSourceID, otherSourceID int32
+		latestSourceDeadline       time.Time
+		targetName                 string
+		targetDeadline             time.Time
+	)
+	// The two id subqueries MUST stay ahead of the GREATEST: a missing source name
+	// yields NULL, which fails the scan into int32 and takes the inactive path.
+	// GREATEST would not catch it on its own - unlike most Postgres functions it
+	// ignores NULL arguments, so GREATEST(NULL, deadline) returns the deadline and
+	// a half-present source pair would look valid.
+	err = conn.QueryRow(ctx, `
+		SELECT
+			(SELECT datacallid FROM datacalls WHERE datacall = $1),
+			(SELECT datacallid FROM datacalls WHERE datacall = $2),
+			GREATEST(
+				(SELECT deadline FROM datacalls WHERE datacall = $1),
+				(SELECT deadline FROM datacalls WHERE datacall = $2)),
+			(SELECT datacall FROM datacalls WHERE datacallid = $3),
+			(SELECT deadline FROM datacalls WHERE datacallid = $3)`,
+		rolloverHardcodeCMSSource, rolloverHardcodeOtherSource, dataCallID,
+	).Scan(&cmsSourceID, &otherSourceID, &latestSourceDeadline, &targetName, &targetDeadline)
+	if err != nil {
+		// Either name is absent (NULL -> scan error) or the query failed. Not an
+		// anomaly: the override simply does not apply here.
+		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=source_lookup err=%v", dataCallID, err)
+		return 0, false, nil
+	}
+	if dataCallID == cmsSourceID || dataCallID == otherSourceID {
+		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=target_is_a_source", dataCallID)
+		return 0, false, nil
+	}
+
+	// Gate 1: name. See rolloverHardcodeTargetPrefixes.
+	if !matchesRolloverHardcodeTarget(targetName) {
+		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=target_name_not_fy2026 name=%q want_prefix=%v",
+			dataCallID, targetName, rolloverHardcodeTargetPrefixes)
+		return 0, false, nil
+	}
+
+	// Gate 2: deadline ordering, i.e. the ztmf#448 invariant. A call named FY26
+	// but deadlined before either source is a backfill, not the next cycle.
+	if !targetDeadline.After(latestSourceDeadline) {
+		log.Printf("ROLLOVER_HARDCODE datacall=%d status=inactive reason=target_deadline_not_after_sources name=%q target_deadline=%s latest_source_deadline=%s",
+			dataCallID, targetName, targetDeadline.Format(time.RFC3339), latestSourceDeadline.Format(time.RFC3339))
+		return 0, false, nil
+	}
+
+	// The OpDiv selects the ONE cycle a system may read. The CASE in the WHERE
+	// clause is the exclusion: a row survives only if its datacallid is the source
+	// assigned to that system's OpDiv, so the other cycle is never a candidate and
+	// there is nothing to rank between them.
+	//
+	// JOIN opdivs, not LEFT JOIN: fismasystems.opdiv_id is NOT NULL with an FK to
+	// opdivs, so every system resolves. Under exclusion an unmatched OpDiv would
+	// silently route a system to the HHS cycle and strand it there, so the inner
+	// join is the safer shape - a system that somehow failed to resolve would be
+	// dropped and counted by "stranded" rather than mis-routed in silence.
+	//
+	// DISTINCT ON (fismasystemid, functionid) guarantees at most one answer per
+	// question. scores has no uniqueness constraint, so a source cycle holding
+	// duplicate rows for one question would otherwise copy both; scoreid DESC
+	// makes the winner the most recently inserted row rather than arbitrary.
+	//
+	// status is seeded as the 'not_started' literal, same as the normal path
+	// (ztmf#435) - the answer carries forward, its review state does not.
+	const copySQL = `
+		INSERT INTO scores (fismasystemid, datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status)
+		SELECT DISTINCT ON (s.fismasystemid, fo.functionid)
+		       s.fismasystemid, s.datecalculated, s.notes, s.notes_is_ai_summary,
+		       s.functionoptionid, $1, 'not_started'
+		  FROM scores s
+		  JOIN fismasystems fs     ON fs.fismasystemid    = s.fismasystemid
+		  JOIN functionoptions fo  ON fo.functionoptionid = s.functionoptionid
+		  JOIN opdivs o            ON o.opdiv_id          = fs.opdiv_id
+		 WHERE s.datacallid = CASE WHEN o.code = $4 THEN $2 ELSE $3 END
+		 ORDER BY s.fismasystemid, fo.functionid, s.scoreid DESC`
+
+	tag, err := conn.Exec(ctx, copySQL, dataCallID, cmsSourceID, otherSourceID, rolloverHardcodeCMSOpDiv)
+	if err != nil {
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=? copied=0 err=%v", dataCallID, err)
+		return 0, true, err
+	}
+	copied = tag.RowsAffected()
+
+	// Diagnostics.
+	//
+	// from_cms_source / from_other_source report which cycle each surviving answer
+	// actually came from, so the run can be checked against expectations rather
+	// than assumed. cms_systems / other_systems show how the OpDiv axis actually
+	// partitions the inventory (see migration 0028).
+	//
+	// selected_rows is the raw row count AFTER the OpDiv exclusion - the rows the
+	// copy was entitled to read. selected_rows - copied is therefore exactly what
+	// DISTINCT ON collapsed as duplicates. src_rows (both cycles, unfiltered) is
+	// reported alongside it so src_rows - selected_rows shows how much the
+	// exclusion discarded outright. Keeping the two separate matters: conflating
+	// them would report deliberately excluded rows as deduplication and hide the
+	// size of what exclusion is dropping.
+	//
+	// "stranded" counts systems that have answers in SOME source cycle but got no
+	// rows in the new call - i.e. systems whose assigned cycle has nothing for
+	// them. Both sides should read zero: each cycle is the authoritative record for
+	// the systems routed to it, so a system that answered anywhere answered there.
+	// It is broken out by side so a nonzero value is triageable rather than just
+	// alarming - cms_stranded means a CMS system has no CMS-cycle answers, which
+	// falsifies the premise the exclusion rests on, and other_stranded the same for
+	// the HHS side.
+	//
+	// misfiled_carried counts rows whose functionoptionid points at a function
+	// outside the system's own scoring environment (ztmf-misc#256) - these carry
+	// verbatim and produce the exactly-1.00 failure. It is deliberately restricted
+	// to systems that HAVE a scoring environment: a system whose
+	// datacenterenvironment has no datacenterenvironments row, or maps to a NULL
+	// scoring_key (the DECOMMISSIONED marker, migration 0045), matches no function
+	// at all and would otherwise report as 100% mis-filed. Those are counted
+	// separately as unscored_env - a different condition with a different fix.
+	var fromCMS, fromOther, cmsSystems, otherSystems, cmsStranded, otherStranded, misfiled, unscoredEnv, srcRows, selectedRows int64
+	diagErr := conn.QueryRow(ctx, `
+		WITH assigned AS (
+			SELECT s.scoreid, s.fismasystemid, s.datacallid, fo.functionid, o.code AS opdiv_code
+			  FROM scores s
+			  JOIN fismasystems fs    ON fs.fismasystemid    = s.fismasystemid
+			  JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+			  JOIN opdivs o           ON o.opdiv_id          = fs.opdiv_id
+			 WHERE s.datacallid = CASE WHEN o.code = $3 THEN $1 ELSE $2 END
+		),
+		winners AS (
+			SELECT DISTINCT ON (fismasystemid, functionid) datacallid AS won_from
+			  FROM assigned
+			 ORDER BY fismasystemid, functionid, scoreid DESC
+		),
+		-- Systems that answered SOMETHING in either cycle but landed nothing in the
+		-- new call, split by which cycle they were routed to.
+		missing AS (
+			SELECT fs.fismasystemid, o.code AS opdiv_code
+			  FROM fismasystems fs
+			  JOIN opdivs o ON o.opdiv_id = fs.opdiv_id
+			 WHERE fs.fismasystemid IN (SELECT fismasystemid FROM scores WHERE datacallid IN ($1, $2))
+			   AND fs.fismasystemid NOT IN (SELECT fismasystemid FROM scores WHERE datacallid = $4)
+		)
+		SELECT
+			(SELECT COUNT(*) FROM winners WHERE won_from = $1),
+			(SELECT COUNT(*) FROM winners WHERE won_from = $2),
+			(SELECT COUNT(*) FROM fismasystems fsc
+			   JOIN opdivs oc ON oc.opdiv_id = fsc.opdiv_id
+			  WHERE oc.code = $3),
+			(SELECT COUNT(*) FROM fismasystems fso
+			   JOIN opdivs oo ON oo.opdiv_id = fso.opdiv_id
+			  WHERE oo.code IS DISTINCT FROM $3),
+			(SELECT COUNT(*) FROM missing WHERE opdiv_code = $3),
+			(SELECT COUNT(*) FROM missing WHERE opdiv_code IS DISTINCT FROM $3),
+			(SELECT COUNT(*)
+			   FROM scores s
+			   JOIN fismasystems fs2    ON fs2.fismasystemid    = s.fismasystemid
+			   JOIN functionoptions fo2 ON fo2.functionoptionid = s.functionoptionid
+			   LEFT JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs2.datacenterenvironment
+			   LEFT JOIN functions f    ON f.functionid = fo2.functionid
+			                           AND f.datacenterenvironment = dce.scoring_key
+			  WHERE s.datacallid = $4
+			    AND dce.scoring_key IS NOT NULL
+			    AND f.functionid IS NULL),
+			(SELECT COUNT(*)
+			   FROM scores s
+			   JOIN fismasystems fs3 ON fs3.fismasystemid = s.fismasystemid
+			   LEFT JOIN datacenterenvironments dce2 ON dce2.datacenterenvironment = fs3.datacenterenvironment
+			  WHERE s.datacallid = $4
+			    AND dce2.scoring_key IS NULL),
+			(SELECT COUNT(*) FROM scores WHERE datacallid IN ($1, $2)),
+			(SELECT COUNT(*) FROM assigned)`,
+		cmsSourceID, otherSourceID, rolloverHardcodeCMSOpDiv, dataCallID,
+	).Scan(&fromCMS, &fromOther, &cmsSystems, &otherSystems, &cmsStranded, &otherStranded, &misfiled, &unscoredEnv, &srcRows, &selectedRows)
+	if diagErr != nil {
+		log.Printf("ROLLOVER_HARDCODE datacall=%d status=active copied=%d diagnostics_err=%v", dataCallID, copied, diagErr)
+		return copied, true, nil
+	}
+
+	log.Printf("ROLLOVER_HARDCODE datacall=%d status=active mode=exclusion cms_source=%d(%q) other_source=%d(%q) cms_systems=%d other_systems=%d src_rows=%d selected_rows=%d excluded_rows=%d copied=%d deduped=%d from_cms_source=%d from_other_source=%d cms_stranded=%d other_stranded=%d misfiled_carried=%d unscored_env=%d",
+		dataCallID, cmsSourceID, rolloverHardcodeCMSSource, otherSourceID, rolloverHardcodeOtherSource,
+		cmsSystems, otherSystems, srcRows, selectedRows, srcRows-selectedRows, copied, selectedRows-copied,
+		fromCMS, fromOther, cmsStranded, otherStranded, misfiled, unscoredEnv)
+
+	// Zero-copy detection, the ztmf#411 semantic. Deliberately NOT a partial-copy
+	// check: scores has enforced FKs to fismasystems and functionoptions, so the
+	// copy's INNER JOINs cannot drop a row, and INSERT...SELECT is atomic - there
+	// is no partial mode to detect. (Comparing copied against fromCMS+fromOther
+	// would be worse than useless: the winners CTE applies the same joins and
+	// filters as the copy, so the two are equal by construction and the check
+	// could never fire.) A nonzero source with an empty result is the one failure
+	// this path can actually have, and it is the one that must not ship silently.
+	//
+	// Compared against selected_rows, not src_rows: under exclusion a zero copy
+	// with a nonzero src_rows is legitimate if the exclusion discarded everything,
+	// and that case is reported by the stranding alarm below instead.
+	//
+	// Same alarm token as the normal path so it surfaces through the existing
+	// CloudWatch metric.
+	if copied == 0 && selectedRows > 0 {
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=%d copied=0 err=<none> reason=hardcode_empty_copy", dataCallID, selectedRows)
+	}
+
+	// Stranding alarm. Expected to be silent: under the source-of-truth rule every
+	// system that answered at all answered in its assigned cycle. If it does fire,
+	// the premise is wrong for those systems - they answered in one cycle, were
+	// routed to the other, and rolled forward EMPTY with no re-run path (ztmf#411).
+	// That is the signal to delete the new data call and fix the source data before
+	// recreating it, not something to accept and move past.
+	if cmsStranded > 0 || otherStranded > 0 {
+		log.Printf("ROLLOVER_ANOMALY datacall=%d expected=>0 copied=%d err=<none> reason=hardcode_stranded_systems cms_stranded=%d other_stranded=%d",
+			dataCallID, copied, cmsStranded, otherStranded)
+	}
+
+	return copied, true, nil
+}
+
+// END TEMPORARY HARD-CODE - ztmf#500
+// ---------------------------------------------------------------------------
+
 // copyPreviousScores rolls the previous cycle's answers forward into the
 // newly created data call identified by dataCallID (the *latest* datacall; the
 // previous one is discovered via findPreviousDataCall). It returns the number
@@ -748,6 +1085,15 @@ ORDER BY ps.datacallid, ps.fismasystemid, ps.pillarid
 // ROLLOVER_ANOMALY log token (wired to a CloudWatch metric alarm) so an empty
 // cycle is detected rather than shipped silently. See ztmf#411.
 func copyPreviousScores(ctx context.Context, dataCallID int32) (int64, error) {
+	// TEMPORARY (ztmf#500): OpDiv-keyed rollover override for the FY26 cycle.
+	// Takes precedence over the global findPreviousDataCall path below, but only
+	// for the FY2026 call itself - every other data call, including a backfill or
+	// a future cycle, falls through to findPreviousDataCall unchanged. REMOVE
+	// after the FY2026 call is created.
+	if copied, handled, err := copyPreviousScoresOpDivHardcoded(ctx, dataCallID); handled {
+		return copied, err
+	}
+
 	prevDataCall, err := findPreviousDataCall(ctx, dataCallID)
 	if err != nil {
 		// No previous cycle (the first-ever data call) is the expected, benign

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -494,3 +494,39 @@ func TestDerefString(t *testing.T) {
 			"pointer to empty string is distinct from nil and must round-trip")
 	})
 }
+
+// TestMatchesRolloverHardcodeTarget covers the name gate on the ztmf#500
+// rollover override. The gate is what scopes the hardcode to the FY2026 cycle
+// alone, so that deleting the block after FY26 is created is ordinary cleanup
+// rather than a deadline: until it is deleted, every non-FY26 data call must
+// fall through to the normal findPreviousDataCall path.
+//
+// Both naming conventions are accepted because the two source cycles disagree
+// ("FY2025 Q3" vs "FY25 ZTM") and the FY26 name is typed by the operator.
+//
+// DELETE THIS TEST with the override it covers.
+func TestMatchesRolloverHardcodeTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		want  bool
+		about string
+	}{
+		{"FY2026 Q1", true, "long-form convention, as FY2025 Q3 uses"},
+		{"FY26 ZTM", true, "short-form convention, as FY25 ZTM uses"},
+		{"FY2026", true, "bare year"},
+		{"fy2026 q1", true, "gate is case-insensitive - the operator types this"},
+		{"  FY2026 Q1  ", true, "surrounding whitespace is tolerated"},
+
+		{"FY2027 Q1", false, "the next cycle must NOT be hijacked if removal slips"},
+		{"FY27 ZTM", false, "next cycle, short form"},
+		{"FY2025 Q3", false, "a source cycle is never a target"},
+		{"FY25 ZTM", false, "a source cycle is never a target"},
+		{"FY2024 Backfill", false, "backfills roll forward normally (ztmf#448)"},
+		{"Audit Fields Smoke Cycle", false, "unrelated cycle"},
+		{"", false, "empty name"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, matchesRolloverHardcodeTarget(tc.name), tc.about)
+		})
+	}
+}

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -501,8 +501,11 @@ func TestDerefString(t *testing.T) {
 // rather than a deadline: until it is deleted, every non-FY26 data call must
 // fall through to the normal findPreviousDataCall path.
 //
-// Both naming conventions are accepted because the two source cycles disagree
-// ("FY2025 Q3" vs "FY25 ZTM") and the FY26 name is typed by the operator.
+// Both year forms match: FY2026 is a single unified cycle for all of HHS
+// including CMS, its final name is not fixed, and the two prior conventions
+// disagree ("FY2025 Q3" vs "FY25 ZTM"). Declining the real cycle over a naming
+// guess is the costlier failure, so the first-cycle gate keeps the broad prefix
+// safe.
 //
 // DELETE THIS TEST with the override it covers.
 func TestMatchesRolloverHardcodeTarget(t *testing.T) {
@@ -512,7 +515,7 @@ func TestMatchesRolloverHardcodeTarget(t *testing.T) {
 		about string
 	}{
 		{"FY2026 Q1", true, "long-form convention, as FY2025 Q3 uses"},
-		{"FY26 ZTM", true, "short-form convention, as FY25 ZTM uses"},
+		{"FY26 ZTM", true, "two-digit form - the unified cycle may be named either way"},
 		{"FY2026", true, "bare year"},
 		{"fy2026 q1", true, "gate is case-insensitive - the operator types this"},
 		{"  FY2026 Q1  ", true, "surrounding whitespace is tolerated"},


### PR DESCRIPTION
Closes the P0 in #500 for the FY2026 cycle. **Temporary by design — this block is deleted once the FY2026 data call exists in prod.**

## Problem

`copyPreviousScores` resolves **one** predecessor cycle globally, for every system. That was correct while ZTMF ran a single annual cadence. It is not correct now that two independent cycles cover FY2025:

| Cycle | Owner | Deadline |
|---|---|---|
| `FY2025 Q3` | CMS's own hand-entered call | 2025-05-07 |
| `FY25 ZTM` | HHS import | 2025-09-30 |

`findPreviousDataCall` orders by `deadline DESC` (the #448 fix — correct, and kept). So `FY25 ZTM` wins on its later September deadline and **every CMS system inherits HHS's imported view of itself** instead of the answers its ISSOs submitted. Reproduced on a prod snapshot in #500: the new cycle took all 38,160 rows from `FY25 ZTM` and ignored `FY2025 Q3` entirely.

## Approach

A system's OpDiv selects exactly **one** source cycle; the other is not read at all.

- CMS systems (`opdivs.code = 'CMS'`) → `FY2025 Q3`
- every other OpDiv → `FY25 ZTM`

Exclusion, not preference. The two cycles are separate lineages, not one record with gaps — CMS ran its own call, and the HHS ZTM cycles were loaded independently with their systems only arriving in ZTMF recently. Where they overlap (the import carries its own view of some CMS systems), the CMS entry is the record and the imported view is not authoritative. That overlap is exactly what made the global predecessor wrong. Confirmed with the data owner: there is no case where a CMS system should pull from the HHS cycle.

Routing is by `fismasystems.opdiv_id`, which is `NOT NULL` with an FK to `opdivs` (migrations 0027/0029), so every system resolves and none can be routed by accident.

## Gating

Two independent conditions, so the override cannot leak onto any other data call before it is removed:

1. **Name** — target starts with `FY2026` or `FY26`. Both year forms are accepted deliberately: FY2026 is a single unified cycle covering all of HHS including CMS, its final name is not fixed, and the prior conventions disagree (`FY2025 Q3` four-digit vs `FY25 ZTM` two-digit). Declining the real cycle over a naming guess is the costlier failure.
2. **Deadline** — target's deadline must be later than *both* sources'. This is the **#448 invariant restated**: a call named FY26 but deadlined earlier is a backfill, not the next cycle. The override replaces `findPreviousDataCall` entirely, so it carries #448's guarantee itself rather than inheriting it.
3. **First cycle only** — the target must be the earliest cycle matching those prefixes, ordered by `(deadline, datacallid)`. Without this a second same-year call (`FY2026 Q4`, a redo, a backfill) passes gates 1 and 2 and re-sources from the 2025 cycles, *discarding* everything the real FY2026 cycle accrued. This gate is what makes the broad prefix in gate 1 safe. It reads live state, not history — deleting a data call and recreating it re-arms the override, so dev stays re-testable.

Sources resolve by **name, not id** — `datacalls.datacall` is `UNIQUE` (migration 0013) and ids differ between dev and prod. Any decline logs a specific reason and falls through to the existing global path unchanged, so this is inert on any environment lacking both 2025 cycles.

## Safety

**The diff is purely additive — no existing line is removed.** `findPreviousDataCall` and the normal copy path are byte-identical.

- `status` still seeded as the `'not_started'` literal in the same `INSERT…SELECT` (#435 — the answer carries forward, its review state does not)
- `DISTINCT ON (fismasystemid, functionid)` guarantees one answer per question; `scores` has no uniqueness constraint, so a source cycle holding duplicates would otherwise copy both
- rollover stays best-effort: a copy error is logged, never fails the data call create

## Observability

One `ROLLOVER_HARDCODE` line per create. On the FY26 create:

```
ROLLOVER_HARDCODE datacall=<new> status=active mode=exclusion
  cms_source=<id>("FY2025 Q3") other_source=<id>("FY25 ZTM")
  cms_systems=… other_systems=…
  src_rows=… selected_rows=… excluded_rows=…
  copied=… deduped=… dropped_unresolvable=…
  from_cms_source=… from_other_source=…
  cms_stranded=… other_stranded=…
  misfiled_carried=… unscored_env=…
```

`from_cms_source` is the headline check — under the old behavior it would be **0**. `excluded_rows` is the fix working: HHS's view of CMS systems, discarded.

`status=inactive` with a reason means the override declined and the normal path ran (`source_lookup`, `target_name_not_fy2026`, `target_deadline_not_after_sources`, `target_is_a_source`).

Alarms reuse the existing `ROLLOVER_ANOMALY` token, so they page through the current CloudWatch metric with no new infra:
- `reason=hardcode_empty_copy` — rows selected, none written
- `reason=hardcode_stranded_systems` — a system answered somewhere but rolled forward empty
- `reason=hardcode_unresolvable_rows` — assigned rows the copy could not carry because `functionoptionid` resolves to nothing

Two diagnostics were corrected while building this and are worth noting for anyone reading the log:
- `misfiled_carried` is restricted to systems that **have** a scoring environment. Without that, every row for a system whose `datacenterenvironment` is unmapped or maps to a NULL `scoring_key` (the `DECOMMISSIONED` marker, migration 0045) reports as mis-filed — measured 36 reported / 36 false on the local fixture. Those are counted separately as `unscored_env`.
- Row accounting separates `excluded_rows` (dropped by the OpDiv filter) from `deduped` (collapsed duplicates). Conflating them would report deliberately excluded rows as deduplication and hide how much exclusion drops.

`dropped_unresolvable` is a genuine partial-copy signal. An earlier revision of this PR argued it was unnecessary because enforced FKs meant the copy's INNER JOINs could not drop a row. **That was wrong** — `scores_functionoptionid_fkey` reports `convalidated = t` only because it was created against an empty table, and bulk loads run under `session_replication_role = replica`, which bypasses FK triggers. The real data contains 33 rows across 11 systems in `FY2025 Q3` with `functionoptionid = -1`, which has no `functionoptions` row. The copy discards them silently, so the check reports 33 rather than never firing. See the review comment below.

## Testing

- `make test-unit` — passes
- `make test-integration` (isolated freshly-seeded DB) — passes
- `TestMatchesRolloverHardcodeTarget` — 12 cases covering both naming conventions, case-insensitivity, and rejection of FY2027 / backfills / the source cycles
- **End-to-end through `POST /api/v1/datacalls`** against a prod-like snapshot: 993 systems, 13 OpDivs, 262 CMS / 731 other. Both routing branches exercised.

Verified against the database after the run:

| Assertion | Result |
|---|---|
| CMS rows not sourced from `FY2025 Q3` | **0** |
| non-CMS rows not sourced from `FY25 ZTM` | **0** |
| rows with status ≠ `not_started` | **0** |
| duplicate answers per (system, function) | **0** |
| orphan rows carried forward | **0** |
| `FY2027 Q1` | declined, `reason=target_name_not_fy2026`, fell through to `findPreviousDataCall` |

Against unpatched `main` on the same data:

| | main | this PR |
|---|---|---|
| CMS systems fed the HHS imported view | 226 | **0** |
| Systems covered | 957 | 969 |
| Systems rolled forward empty | 21 | 9 |
| Systems properly scored (not exactly 1.00) | 196 | 272 |

The committed fixture cannot exercise this — `_test_data_empire.sql` has `FY25 ZTM` but no `FY2025 Q3`, so the override is inert there and no existing test path changes behavior.

**Note for anyone modifying the copy SQL:** the `::int` casts on the CASE branches are load-bearing and cannot be validated in psql. Literal ids and `PREPARE p(int,…)` both supply the type information pgx omits, so a psql harness will certify SQL that fails at runtime with `integer = text`. It needs a real POST.

## Before creating the prod cycle

1. Confirm the exact names — `SELECT datacallid, datacall, deadline FROM datacalls ORDER BY deadline DESC;`. A mismatch means a **silent no-op**: FY26 would roll from HHS exactly as today, with only a `status=inactive` log line to show for it.
2. Name the FY2026 call starting `FY2026` or `FY26`, deadline after 2025-09-30.
3. **Decide the seven CMS-tagged HHS arrivals** — see the review comment; identifiers are in the internal handoff doc. They carry forward today and roll forward empty under exclusion. Retagging them to their true OpDiv makes this a clean win.
4. Check the log: `from_cms_source > 0` and `other_stranded=0`. `cms_stranded` is expected to be **9** on current data, from three known causes — not a reason to abort, but confirm the breakdown matches.

The copy runs **once**, at creation, with no re-run path (#411). If the log is wrong, recovery is deleting the data call — `scores_datacallid_fkey` cascades — and recreating it. Verify before anyone begins answering.

## Removal

Delete the block between `TEMPORARY HARD-CODE - ztmf#500` and `END TEMPORARY HARD-CODE`, plus the 4-line call site in `copyPreviousScores`, and optionally `TestMatchesRolloverHardcodeTarget`. No schema change, no migration, nothing to unwind — the rows written are ordinary `scores` rows identical in shape to a normal rollover.

From FY2026 onward there is a single global predecessor again containing every system, so #500 goes dormant on its own. The durable per-OpDiv design (#500 decisions 2 and 3, and the missing cycle-ownership column on `datacalls`) is still open and only matters if genuinely divergent per-OpDiv cadences return.



