### PR TITLE
fix(fismasystems): let OpDiv-scoped admins write the ISSO name

### DIFF
--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -424,6 +424,35 @@ func TestSaveFismaSystem_ReadonlyAdminForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// isso_name is writable by OpDiv-scoped admins, so it is the one field in the
+// extended set whose gate could plausibly be loosened further. These two tiers
+// are the ones a "let the ISSO fix their own name" or "read-only should be able
+// to correct a typo" change would reach for, and both must stay behind
+// SaveFismaSystem's admin gate. The gate returns before any database call.
+func TestSaveFismaSystem_ISSONameDeniedTiersForbidden(t *testing.T) {
+	for name, u := range map[string]*model.User{
+		"ISSO":                 issoUser,
+		"OPDIV_READONLY_ADMIN": opdivReadonly,
+	} {
+		t.Run(name, func(t *testing.T) {
+			body := jsonBody(t, map[string]any{
+				"fismauid":     "12345678-1234-4abc-8def-123456789abc",
+				"fismaacronym": "TEST",
+				"fismaname":    "Test System",
+				"isso_name":    "Should Never Persist",
+			})
+			r := httptest.NewRequest("PUT", "/api/v1/fismasystems/1", body)
+			r.Header.Set("Content-Type", "application/json")
+			r = mux.SetURLVars(r, map[string]string{"fismasystemid": "1"})
+			r = withUser(r, u)
+			w := httptest.NewRecorder()
+
+			SaveFismaSystem(w, r)
+			assert.Equal(t, http.StatusForbidden, w.Code, "%s must not write isso_name", name)
+		})
+	}
+}
+
 // --- DeleteFismaSystem ---
 
 func TestDeleteFismaSystem_ReadonlyAdminForbidden(t *testing.T) {

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -104,9 +104,10 @@ func GetFismaSystem(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, fismasystem, nil)
 }
 
-// clearHHSMetadata nils the 12 HHS onboarding fields on a FismaSystem.
-// Called on INSERT when the acting user lacks unscoped read access.
-func clearHHSMetadata(fs *model.FismaSystem) {
+// clearUnscopedOnlyFields nils the 11 system-attribute fields only an
+// unscoped-write admin may set. Called on INSERT when the acting user lacks
+// unscoped read access.
+func clearUnscopedOnlyFields(fs *model.FismaSystem) {
 	fs.HVA = nil
 	fs.FIPS = nil
 	fs.SystemType = nil
@@ -118,25 +119,28 @@ func clearHHSMetadata(fs *model.FismaSystem) {
 	fs.SystemOwner = nil
 	fs.SystemOwnerEmail = nil
 	fs.Legacy = nil
-	fs.ISSOName = nil
 }
 
-// copyHHSMetadata copies the 12 HHS onboarding fields from src onto dst.
-// Called on UPDATE when the acting user lacks unscoped read access so that
-// a scoped admin edit does not wipe HHS metadata they cannot see.
-func copyHHSMetadata(src, dst *model.FismaSystem) {
-	dst.HVA = src.HVA
-	dst.FIPS = src.FIPS
-	dst.SystemType = src.SystemType
-	dst.CloudSystem = src.CloudSystem
-	dst.CloudServiceModel = src.CloudServiceModel
-	dst.CloudVendor = src.CloudVendor
-	dst.SystemOperator = src.SystemOperator
-	dst.GocoCocGoGo = src.GocoCocGoGo
-	dst.SystemOwner = src.SystemOwner
-	dst.SystemOwnerEmail = src.SystemOwnerEmail
-	dst.Legacy = src.Legacy
-	dst.ISSOName = src.ISSOName
+// preserveUnscopedOnlyFields overwrites the 11 system-attribute fields on
+// incoming with the values already stored on existing. Called on UPDATE when
+// the acting user lacks unscoped read access, so a full-form PUT from a tier
+// that may not write these fields cannot wipe them.
+//
+// The set covers system attributes only. isso_name is a contact name that an
+// OpDiv-scoped admin may write on systems in their granted OpDivs, so it is
+// not part of this set and passes through from the request.
+func preserveUnscopedOnlyFields(existing, incoming *model.FismaSystem) {
+	incoming.HVA = existing.HVA
+	incoming.FIPS = existing.FIPS
+	incoming.SystemType = existing.SystemType
+	incoming.CloudSystem = existing.CloudSystem
+	incoming.CloudServiceModel = existing.CloudServiceModel
+	incoming.CloudVendor = existing.CloudVendor
+	incoming.SystemOperator = existing.SystemOperator
+	incoming.GocoCocGoGo = existing.GocoCocGoGo
+	incoming.SystemOwner = existing.SystemOwner
+	incoming.SystemOwnerEmail = existing.SystemOwnerEmail
+	incoming.Legacy = existing.Legacy
 }
 
 // guardManageFismaSystem fetches the target system and verifies the acting user
@@ -247,13 +251,19 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// HHS metadata gate: only OWNER and HHS_ADMIN may write the 11 HHS onboarding
-	// fields (HasUnscopedRead gates this; HHS_READONLY_ADMIN is already blocked by
-	// IsAdmin() above). On INSERT, clear fields for scoped actors. On UPDATE, copy
-	// stored values so a scoped admin edit does not wipe data they cannot see.
+	// Only OWNER and HHS_ADMIN may write the 11 system-attribute fields
+	// (HasUnscopedRead gates this; HHS_READONLY_ADMIN is already blocked by
+	// IsAdmin() above). Every scoped admin can READ all of them - the list and
+	// GET reads return every column and only filter rows by OpDiv - so this is
+	// partial-PUT protection, not confidentiality: a tier that may not write
+	// them must not wipe them by round-tripping a form. On INSERT the fields are
+	// cleared; on UPDATE the stored values are restored over the request.
+	//
+	// guardManageFismaSystem also authorizes the write itself, so reaching Save
+	// on the UPDATE path means the caller may manage this specific system.
 	if f.FismaSystemID == 0 {
 		if !authdUser.HasUnscopedRead() {
-			clearHHSMetadata(f)
+			clearUnscopedOnlyFields(f)
 		}
 	} else if !authdUser.HasUnscopedRead() {
 		existing, err := guardManageFismaSystem(r.Context(), authdUser, f.FismaSystemID)
@@ -261,7 +271,7 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 			respond(w, r, nil, err)
 			return
 		}
-		copyHHSMetadata(existing, f)
+		preserveUnscopedOnlyFields(existing, f)
 	}
 
 	f, err = f.Save(r.Context(), model.WithPresentBoolFields(presentBools))

--- a/backend/cmd/api/internal/controller/fismasystems_metadata_test.go
+++ b/backend/cmd/api/internal/controller/fismasystems_metadata_test.go
@@ -1,0 +1,124 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// storedSystem returns a system whose every gated field carries a distinct
+// "stored" value, standing in for the row already in the database.
+func storedSystem() *model.FismaSystem {
+	s := func(v string) *string { return &v }
+	b := func(v bool) *bool { return &v }
+	return &model.FismaSystem{
+		HVA:               b(true),
+		FIPS:              s("stored-fips"),
+		SystemType:        s("stored-type"),
+		CloudSystem:       b(true),
+		CloudServiceModel: []string{"IaaS"},
+		CloudVendor:       s("stored-vendor"),
+		SystemOperator:    s("stored-operator"),
+		GocoCocGoGo:       s("stored-goco"),
+		SystemOwner:       s("stored-owner"),
+		SystemOwnerEmail:  s("stored-owner@example.gov"),
+		Legacy:            b(true),
+		ISSOName:          s("Stored ISSO"),
+	}
+}
+
+// requestedSystem returns a system whose every gated field carries a distinct
+// "requested" value, standing in for the decoded PUT body. Every value differs
+// from storedSystem's so a copy is detectable.
+func requestedSystem() *model.FismaSystem {
+	s := func(v string) *string { return &v }
+	b := func(v bool) *bool { return &v }
+	return &model.FismaSystem{
+		HVA:               b(false),
+		FIPS:              s("requested-fips"),
+		SystemType:        s("requested-type"),
+		CloudSystem:       b(false),
+		CloudServiceModel: []string{"SaaS"},
+		CloudVendor:       s("requested-vendor"),
+		SystemOperator:    s("requested-operator"),
+		GocoCocGoGo:       s("requested-goco"),
+		SystemOwner:       s("requested-owner"),
+		SystemOwnerEmail:  s("requested-owner@example.gov"),
+		Legacy:            b(false),
+		ISSOName:          s("Requested ISSO"),
+	}
+}
+
+// The 11 system attributes are restored from the stored row so a scoped
+// admin's full-form PUT cannot wipe them, while the ISSO name they sent
+// survives to reach Save.
+func TestPreserveUnscopedOnlyFields_ISSONameStaysRequested(t *testing.T) {
+	existing, incoming := storedSystem(), requestedSystem()
+
+	preserveUnscopedOnlyFields(existing, incoming)
+
+	assert.Equal(t, existing.HVA, incoming.HVA, "hva must be restored from the stored row")
+	assert.Equal(t, existing.FIPS, incoming.FIPS, "fips must be restored from the stored row")
+	assert.Equal(t, existing.SystemType, incoming.SystemType, "system_type must be restored from the stored row")
+	assert.Equal(t, existing.CloudSystem, incoming.CloudSystem, "cloud_system must be restored from the stored row")
+	assert.Equal(t, existing.CloudServiceModel, incoming.CloudServiceModel, "cloud_service_model must be restored from the stored row")
+	assert.Equal(t, existing.CloudVendor, incoming.CloudVendor, "cloud_vendor must be restored from the stored row")
+	assert.Equal(t, existing.SystemOperator, incoming.SystemOperator, "system_operator must be restored from the stored row")
+	assert.Equal(t, existing.GocoCocGoGo, incoming.GocoCocGoGo, "goco_coco_gogo must be restored from the stored row")
+	assert.Equal(t, existing.SystemOwner, incoming.SystemOwner, "system_owner must be restored from the stored row")
+	assert.Equal(t, existing.SystemOwnerEmail, incoming.SystemOwnerEmail, "system_owner_email must be restored from the stored row")
+	assert.Equal(t, existing.Legacy, incoming.Legacy, "legacy must be restored from the stored row")
+
+	assert.Equal(t, "Requested ISSO", *incoming.ISSOName,
+		"isso_name is OpDiv-writable and must keep the value the request sent")
+}
+
+// A nil requested ISSO name means the key was omitted, which Save reads as
+// "leave the stored value alone". Restoring the stored name here would turn an
+// omission into an explicit rewrite.
+func TestPreserveUnscopedOnlyFields_OmittedISSONameStaysNil(t *testing.T) {
+	existing, incoming := storedSystem(), requestedSystem()
+	incoming.ISSOName = nil
+
+	preserveUnscopedOnlyFields(existing, incoming)
+
+	assert.Nil(t, incoming.ISSOName, "an omitted isso_name must stay nil so Save leaves the stored value untouched")
+}
+
+// On create the same 11 attributes are cleared for a scoped admin, but the ISSO
+// name they supplied has to survive or the create silently drops it.
+func TestClearUnscopedOnlyFields_ISSONameSurvives(t *testing.T) {
+	incoming := requestedSystem()
+
+	clearUnscopedOnlyFields(incoming)
+
+	assert.Nil(t, incoming.HVA, "hva must be cleared")
+	assert.Nil(t, incoming.FIPS, "fips must be cleared")
+	assert.Nil(t, incoming.SystemType, "system_type must be cleared")
+	assert.Nil(t, incoming.CloudSystem, "cloud_system must be cleared")
+	assert.Nil(t, incoming.CloudServiceModel, "cloud_service_model must be cleared")
+	assert.Nil(t, incoming.CloudVendor, "cloud_vendor must be cleared")
+	assert.Nil(t, incoming.SystemOperator, "system_operator must be cleared")
+	assert.Nil(t, incoming.GocoCocGoGo, "goco_coco_gogo must be cleared")
+	assert.Nil(t, incoming.SystemOwner, "system_owner must be cleared")
+	assert.Nil(t, incoming.SystemOwnerEmail, "system_owner_email must be cleared")
+	assert.Nil(t, incoming.Legacy, "legacy must be cleared")
+
+	assert.Equal(t, "Requested ISSO", *incoming.ISSOName,
+		"isso_name is OpDiv-writable and must survive the create-path clear")
+}
+
+// The two helpers hand-maintain the same field list, which is how isso_name
+// came to be in both. Clearing is preserving from a zero-valued row, so the
+// two must agree field for field.
+func TestUnscopedOnlyFields_ClearAndPreserveGovernSameSet(t *testing.T) {
+	cleared := requestedSystem()
+	clearUnscopedOnlyFields(cleared)
+
+	preserved := requestedSystem()
+	preserveUnscopedOnlyFields(&model.FismaSystem{}, preserved)
+
+	assert.Equal(t, cleared, preserved,
+		"clearUnscopedOnlyFields and preserveUnscopedOnlyFields must govern an identical field set")
+}

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -164,8 +164,10 @@ updatedScoreData: &updatedScoreData
   notes: "Updated by Emberfall test"
 
 # HHS metadata anchor (12 fields). Used to exercise the RBAC write gate:
-# OWNER writes land in DB; scoped admins are stripped on create and preserved
-# on update. Values are intentionally Star-Wars-themed to match the fixture.
+# OWNER writes land in DB. For scoped admins the 11 system attributes are
+# stripped on create and restored on update, while isso_name is OpDiv-writable
+# and takes their value on both paths. Values are intentionally Star-Wars-themed
+# to match the fixture.
 hhsExpected: &hhsExpected
   hva: true
   fips: "Moderate"
@@ -793,8 +795,9 @@ tests:
 
   # Test B — Scoped admin RBAC gate.
   #
-  # Part 1: opDivAdmin POSTs a system with HHS fields → clearHHSMetadata
-  # strips them; created record has null HHS fields.
+  # Part 1: opDivAdmin POSTs a system with HHS fields → clearUnscopedOnlyFields
+  # strips the 11 system attributes; the created record has them null. isso_name
+  # is not in that set - an OpDiv-scoped admin may write it - so it persists.
   # opdiv_id 15 = EMPIRE OpDiv, position 15 in the seed INSERT sequence
   # (_test_data_empire.sql). If this fails with 403, the seed order changed.
   - id: createFismaSystemScopedAdmin
@@ -825,7 +828,7 @@ tests:
             system_owner: null
             system_owner_email: null
             legacy: null
-            isso_name: null
+            isso_name: "Darth Vader" # OpDiv-writable, so the POSTed value persists
 
   # Part 2: OWNER sets HHS fields on system 1002 (EMPIRE OpDiv — opDivAdmin
   # holds a write grant for this system).
@@ -840,8 +843,11 @@ tests:
     expect:
       status: 204
 
-  # Part 3: opDivAdmin PUTs system 1002 with different HHS values →
-  # copyHHSMetadata overwrites them back to the stored values.
+  # Part 3: opDivAdmin PUTs system 1002 with different values. The 11 system
+  # attributes are restored from the stored row by preserveUnscopedOnlyFields;
+  # isso_name is not in that set, so the OpDiv admin's value takes effect. The
+  # isso_name sent here must differ from the value OWNER stored in Part 2, or
+  # the GET below cannot tell a successful write from a restored one.
   - url: "http://localhost:8080/api/v1/fismasystems/1002"
     method: PUT
     headers:
@@ -850,12 +856,15 @@ tests:
     body:
       json:
         <<: *system1002WithHHSData
-        hva: false # scoped-admin overwrite attempt; copyHHSMetadata restores the stored value
+        hva: false # scoped-admin overwrite attempt; the stored value is restored
         system_owner: "Impostor"
+        isso_name: "Wilhuff Tarkin" # OpDiv-writable, so this one does take effect
     expect:
       status: 204
 
-  # GET confirms OWNER's values survived the scoped admin PUT.
+  # GET confirms OWNER's values survived the scoped admin PUT, while the
+  # OpDiv admin's isso_name landed. The explicit isso_name overrides the value
+  # carried by the hhsExpected merge key.
   - url: "http://localhost:8080/api/v1/fismasystems/1002"
     method: GET
     headers:
@@ -868,6 +877,7 @@ tests:
         json:
           data:
             <<: *hhsExpected
+            isso_name: "Wilhuff Tarkin"
 
   - url: http://localhost:8080/api/v1/fismasystems
     method: GET

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -64,7 +64,12 @@ type FismaSystem struct {
 	SystemOwner      *string `json:"system_owner" db:"system_owner"`
 	SystemOwnerEmail *string `json:"system_owner_email" db:"system_owner_email"`
 	Legacy           *bool   `json:"legacy" db:"legacy"`
-	ISSOName         *string `json:"isso_name" db:"isso_name"`
+	// ISSOName is the ISSO's display name. Unlike the system attributes above
+	// it, an OpDiv-scoped admin may write it on systems in their granted
+	// OpDivs. NULL means no stored override: the systems list read falls back
+	// to the fullname on the user record matching issoemail, so clearing this
+	// restores that derived name.
+	ISSOName *string `json:"isso_name" db:"isso_name"`
 	// Risk-based target maturity (#398). NULL = no ISSO has asserted a target
 	// yet; the UI presents the Advanced default. Written only via
 	// SaveTargetMaturity, never through Save().
@@ -358,8 +363,8 @@ func (f *FismaSystem) Save(ctx context.Context, opts ...SaveOption) (*FismaSyste
 		// Metadata fields distinguish three request states (ztmf#442):
 		//   - omitted / null (nil pointer / nil slice) -> leave the stored value
 		//     untouched, so a partial PUT never wipes importer data (and a
-		//     scoped-admin edit, whose HHS fields copyHHSMetadata has set to the
-		//     stored values, is a no-op here);
+		//     scoped-admin edit, whose unscoped-only fields the controller has
+		//     already set to the stored values, is a no-op here);
 		//   - "" (a cleared text input) / empty slice -> write NULL, so a blank
 		//     actually clears the value rather than persisting "" / an empty array;
 		//   - a value -> write it.

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -451,6 +451,12 @@ components:
             (the epic rule: never coerce a missing value to false/No).
           type: boolean
         isso_name:
+          description: |-
+            ISSOName is the ISSO's display name. Unlike the system attributes above
+            it, an OpDiv-scoped admin may write it on systems in their granted
+            OpDivs. NULL means no stored override: the systems list read falls back
+            to the fullname on the user record matching issoemail, so clearing this
+            restores that derived name.
           type: string
         issoemail:
           type: string


### PR DESCRIPTION
Closes #509

## What was wrong

`isso_name` arrived alongside the HHS onboarding columns and was grouped with them in the system write path, so only the unscoped-write tiers could set it. An `OPDIV_ADMIN`'s value was replaced with the stored one and the request still returned 204, so the edit looked like it worked.

That mattered more than a normal permission gap, because `isso_name` is a stored column and the systems list read resolves the display name as:

```sql
COALESCE(fismasystems.isso_name,
         (SELECT fullname FROM users WHERE LOWER(email) = LOWER(fismasystems.issoemail) LIMIT 1))
```

The stored column wins. CMS systems have it NULL, so their name derives from `issoemail` and self-heals whenever the email is corrected. Systems whose column the onboarding import populated keep the imported name forever: updating the ISSO email changes the email and nothing else. With the field also locked in the UI, those names were uncorrectable by anyone.

## The change

Two deleted assignments. `isso_name` no longer participates in the field set that gets cleared on create and restored on update for scoped actors.

No new authorization, because the authorization already ran. `guardManageFismaSystem` evaluates `CanManageFismaSystem` against the **stored** system's `opdiv_id` before the restore, so an `OPDIV_ADMIN` reaching that point may already manage that specific system. On create, an OpDiv-tier actor must already pass `IsAssignedOpDiv` for the `opdiv_id` they send. Both paths are unchanged by this PR and both already scope the actor correctly. No model changes were needed either: `isso_name` was already in the INSERT column list and the UPDATE column map.

Resulting matrix:

| Actor | `isso_name` |
|---|---|
| `OWNER`, `HHS_ADMIN` | writable on any system |
| `OPDIV_ADMIN` | writable on systems in an OpDiv they hold a grant for |
| `OPDIV_ADMIN`, out of scope | 403, nothing written |
| `HHS_READONLY_ADMIN`, `OPDIV_READONLY_ADMIN`, `ISSO`, `ISSM`, `SYSTEM_DELEGATE` | rejected before reaching the field |

The other 11 fields keep their existing behavior for every tier.

Three request states are preserved: an omitted key leaves the stored value alone, `""` writes NULL, a value is written. The NULL case is load-bearing rather than an edge case, because it is what restores the email-derived name. Clearing the field is the correct fix for a system that should track its ISSO's user record, and the frontend change will say so at the point of edit.

Both helpers are renamed after the permission rule rather than the workbook the fields came from, since the old `*HHSMetadata` names are what made a contact name read as protected system metadata. One comment claiming the copy shielded "data they cannot see" is corrected: scoped admins can read every one of those columns, the list and GET reads return them all and only filter rows by OpDiv. The copy is partial-PUT protection, not confidentiality.

## Reviewer note: the E2E suite was asserting the bug

`emberfall_tests.yml` Test B needed two fixes, and they are the reason the diff touches that file:

- Part 1 expected `isso_name: null` in the response after an OpDiv admin create. That was the silent discard written down as expected behavior.
- Part 3 sent the same `isso_name` an unscoped admin had already stored, so the trailing GET passed whether the write landed or was restored. It now sends a distinct name with an explicit override on the merge key, so the assertion can actually distinguish the two.

## Test plan

- `go test -short ./...` (no database, what CI gates on): 597 pass
- integration suite against a freshly seeded database: 87 pass
- Emberfall end to end: 187 ran, 0 failed
- `make generate-openapi` then `make lint-openapi`: spec regenerated from the Go doc comment, Redocly exit 0, no errors. The spec is generated, so it is not hand-edited.
- Direct database check after the E2E run, which is the evidence that matters most:

| System | Path | `isso_name` | `system_owner` | `hva` |
|---|---|---|---|---|
| 1002 | UPDATE by OpDiv admin | their value landed | unscoped admin's stored value, not the one the OpDiv admin sent | unscoped admin's stored value, not the one sent |
| created | INSERT by OpDiv admin | persisted | null | null |

Note for anyone running these locally: `make test-e2e` and `make test-integration` both rely on a foreground `sleep`, which is blocked in some sandboxed shells. When that happens `make` exits 0 **without running the tests**. Drive the containers and test binaries directly with a readiness poll if a green exit looks too fast to be real. They are fine in CI.

## Not in scope

Two pre-existing behaviors that this PR does not introduce and should not be blamed on it:

- `Save` rejects `cloud_system == false` alongside a non-empty `cloud_service_model`. A row carrying that combination from an import cannot be edited at all by a scoped admin, because the restore repopulates both and the save 400s. Latent today, untouched here.
- `PUT /fismasystems/0` matches the `[0-9]+` route regex and the handler treats ID 0 as a create, so that URL is an alias for POST. Authorization is unaffected, since the create path still requires the OpDiv grant, but explicitly rejecting 0 is worth a small cleanup ticket.

Once anyone writes `isso_name` on a CMS system, the derived value is shadowed until the field is cleared. That is intended for OpDivs with no load, and the frontend change covers communicating it.

The frontend half is CMS-Enterprise/ztmf-ui#661 and must not ship until this deploys, or the field reports success and discards the change.
