### PR TITLE
feat(fismasystems): OpDiv-writable owner contact fields + one shared isso_name derivation

### DIFF
--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -76,7 +76,10 @@ func ListFismaSystems(w http.ResponseWriter, r *http.Request) {
 func GetFismaSystem(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
 	vars := mux.Vars(r)
-	input := model.FindFismaSystemsInput{}
+	// A display read: resolve the ISSO display name the same way the list
+	// does, so the two endpoints cannot disagree on the same system
+	// (ztmf#510). Internal fetches that feed write paths keep the raw column.
+	input := model.FindFismaSystemsInput{ResolveISSOName: true}
 
 	if v, ok := vars["fismasystemid"]; ok {
 		var fismasystemID int32
@@ -104,7 +107,7 @@ func GetFismaSystem(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, fismasystem, nil)
 }
 
-// clearUnscopedOnlyFields nils the 11 system-attribute fields only an
+// clearUnscopedOnlyFields nils the 9 system-attribute fields only an
 // unscoped-write admin may set. Called on INSERT when the acting user lacks
 // unscoped read access.
 func clearUnscopedOnlyFields(fs *model.FismaSystem) {
@@ -116,19 +119,21 @@ func clearUnscopedOnlyFields(fs *model.FismaSystem) {
 	fs.CloudVendor = nil
 	fs.SystemOperator = nil
 	fs.GocoCocGoGo = nil
-	fs.SystemOwner = nil
-	fs.SystemOwnerEmail = nil
 	fs.Legacy = nil
 }
 
-// preserveUnscopedOnlyFields overwrites the 11 system-attribute fields on
+// preserveUnscopedOnlyFields overwrites the 9 system-attribute fields on
 // incoming with the values already stored on existing. Called on UPDATE when
 // the acting user lacks unscoped read access, so a full-form PUT from a tier
 // that may not write these fields cannot wipe them.
 //
-// The set covers system attributes only. isso_name is a contact name that an
-// OpDiv-scoped admin may write on systems in their granted OpDivs, so it is
-// not part of this set and passes through from the request.
+// The set covers system attributes only. The contact fields - isso_name,
+// system_owner, system_owner_email - are writable by an OpDiv-scoped admin on
+// systems in their granted OpDivs (ztmf#511, ztmf#512), so they are not part
+// of this set and pass through from the request. The owner fields matter more
+// than a display preference: unlike isso_name they have no COALESCE fallback
+// to a user record, so the stored column is the only source there is, and
+// no onboarding load refreshes them for non-CMS OpDivs.
 func preserveUnscopedOnlyFields(existing, incoming *model.FismaSystem) {
 	incoming.HVA = existing.HVA
 	incoming.FIPS = existing.FIPS
@@ -138,8 +143,6 @@ func preserveUnscopedOnlyFields(existing, incoming *model.FismaSystem) {
 	incoming.CloudVendor = existing.CloudVendor
 	incoming.SystemOperator = existing.SystemOperator
 	incoming.GocoCocGoGo = existing.GocoCocGoGo
-	incoming.SystemOwner = existing.SystemOwner
-	incoming.SystemOwnerEmail = existing.SystemOwnerEmail
 	incoming.Legacy = existing.Legacy
 }
 
@@ -251,7 +254,7 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Only OWNER and HHS_ADMIN may write the 11 system-attribute fields
+	// Only OWNER and HHS_ADMIN may write the 9 system-attribute fields
 	// (HasUnscopedRead gates this; HHS_READONLY_ADMIN is already blocked by
 	// IsAdmin() above). Every scoped admin can READ all of them - the list and
 	// GET reads return every column and only filter rows by OpDiv - so this is

--- a/backend/cmd/api/internal/controller/fismasystems_issoname_integration_test.go
+++ b/backend/cmd/api/internal/controller/fismasystems_issoname_integration_test.go
@@ -1,0 +1,51 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The model-layer test in internal/model pins that FindFismaSystem CAN resolve
+// the ISSO display name. This one pins that GetFismaSystem actually ASKS it to.
+// Without this, dropping ResolveISSOName from the handler leaves the model test
+// green while ztmf#510 silently regresses: the single-system GET would go back
+// to returning the raw column and disagreeing with the list.
+//
+// Seed system 1002 carries isso_name NULL with an issoemail matching the
+// Admiral Piett user record, so a resolved response can only come from the
+// COALESCE fallback.
+func TestGetFismaSystemResolvesISSONameIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	r := httptest.NewRequest("GET", "/api/v1/fismasystems/1002", nil)
+	r = mux.SetURLVars(r, map[string]string{"fismasystemid": "1002"})
+	r = withUser(r, adminUser)
+	w := httptest.NewRecorder()
+
+	GetFismaSystem(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			FismaSystemID int32   `json:"fismasystemid"`
+			ISSOName      *string `json:"isso_name"`
+			ISSOEmail     *string `json:"issoemail"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, int32(1002), resp.Data.FismaSystemID)
+
+	require.NotNil(t, resp.Data.ISSOName,
+		"the single-system GET must resolve the ISSO name from the user record "+
+			"the way the list does (ztmf#510); a nil here means the handler "+
+			"stopped setting ResolveISSOName")
+	assert.Equal(t, "Admiral Piett", *resp.Data.ISSOName)
+}

--- a/backend/cmd/api/internal/controller/fismasystems_metadata_test.go
+++ b/backend/cmd/api/internal/controller/fismasystems_metadata_test.go
@@ -50,10 +50,10 @@ func requestedSystem() *model.FismaSystem {
 	}
 }
 
-// The 11 system attributes are restored from the stored row so a scoped
-// admin's full-form PUT cannot wipe them, while the ISSO name they sent
-// survives to reach Save.
-func TestPreserveUnscopedOnlyFields_ISSONameStaysRequested(t *testing.T) {
+// The 9 system attributes are restored from the stored row so a scoped
+// admin's full-form PUT cannot wipe them, while the contact fields they sent
+// (isso_name, system_owner, system_owner_email) survive to reach Save.
+func TestPreserveUnscopedOnlyFields_ContactFieldsStayRequested(t *testing.T) {
 	existing, incoming := storedSystem(), requestedSystem()
 
 	preserveUnscopedOnlyFields(existing, incoming)
@@ -66,29 +66,36 @@ func TestPreserveUnscopedOnlyFields_ISSONameStaysRequested(t *testing.T) {
 	assert.Equal(t, existing.CloudVendor, incoming.CloudVendor, "cloud_vendor must be restored from the stored row")
 	assert.Equal(t, existing.SystemOperator, incoming.SystemOperator, "system_operator must be restored from the stored row")
 	assert.Equal(t, existing.GocoCocGoGo, incoming.GocoCocGoGo, "goco_coco_gogo must be restored from the stored row")
-	assert.Equal(t, existing.SystemOwner, incoming.SystemOwner, "system_owner must be restored from the stored row")
-	assert.Equal(t, existing.SystemOwnerEmail, incoming.SystemOwnerEmail, "system_owner_email must be restored from the stored row")
 	assert.Equal(t, existing.Legacy, incoming.Legacy, "legacy must be restored from the stored row")
 
 	assert.Equal(t, "Requested ISSO", *incoming.ISSOName,
 		"isso_name is OpDiv-writable and must keep the value the request sent")
+	assert.Equal(t, "requested-owner", *incoming.SystemOwner,
+		"system_owner is OpDiv-writable and must keep the value the request sent")
+	assert.Equal(t, "requested-owner@example.gov", *incoming.SystemOwnerEmail,
+		"system_owner_email is OpDiv-writable and must keep the value the request sent")
 }
 
-// A nil requested ISSO name means the key was omitted, which Save reads as
-// "leave the stored value alone". Restoring the stored name here would turn an
+// A nil requested contact field means the key was omitted, which Save reads as
+// "leave the stored value alone". Restoring the stored value here would turn an
 // omission into an explicit rewrite.
-func TestPreserveUnscopedOnlyFields_OmittedISSONameStaysNil(t *testing.T) {
+func TestPreserveUnscopedOnlyFields_OmittedContactFieldsStayNil(t *testing.T) {
 	existing, incoming := storedSystem(), requestedSystem()
 	incoming.ISSOName = nil
+	incoming.SystemOwner = nil
+	incoming.SystemOwnerEmail = nil
 
 	preserveUnscopedOnlyFields(existing, incoming)
 
 	assert.Nil(t, incoming.ISSOName, "an omitted isso_name must stay nil so Save leaves the stored value untouched")
+	assert.Nil(t, incoming.SystemOwner, "an omitted system_owner must stay nil so Save leaves the stored value untouched")
+	assert.Nil(t, incoming.SystemOwnerEmail, "an omitted system_owner_email must stay nil so Save leaves the stored value untouched")
 }
 
-// On create the same 11 attributes are cleared for a scoped admin, but the ISSO
-// name they supplied has to survive or the create silently drops it.
-func TestClearUnscopedOnlyFields_ISSONameSurvives(t *testing.T) {
+// On create the same 9 attributes are cleared for a scoped admin, but the
+// contact fields they supplied have to survive or the create silently drops
+// them.
+func TestClearUnscopedOnlyFields_ContactFieldsSurvive(t *testing.T) {
 	incoming := requestedSystem()
 
 	clearUnscopedOnlyFields(incoming)
@@ -101,16 +108,18 @@ func TestClearUnscopedOnlyFields_ISSONameSurvives(t *testing.T) {
 	assert.Nil(t, incoming.CloudVendor, "cloud_vendor must be cleared")
 	assert.Nil(t, incoming.SystemOperator, "system_operator must be cleared")
 	assert.Nil(t, incoming.GocoCocGoGo, "goco_coco_gogo must be cleared")
-	assert.Nil(t, incoming.SystemOwner, "system_owner must be cleared")
-	assert.Nil(t, incoming.SystemOwnerEmail, "system_owner_email must be cleared")
 	assert.Nil(t, incoming.Legacy, "legacy must be cleared")
 
 	assert.Equal(t, "Requested ISSO", *incoming.ISSOName,
 		"isso_name is OpDiv-writable and must survive the create-path clear")
+	assert.Equal(t, "requested-owner", *incoming.SystemOwner,
+		"system_owner is OpDiv-writable and must survive the create-path clear")
+	assert.Equal(t, "requested-owner@example.gov", *incoming.SystemOwnerEmail,
+		"system_owner_email is OpDiv-writable and must survive the create-path clear")
 }
 
-// The two helpers hand-maintain the same field list, which is how isso_name
-// came to be in both. Clearing is preserving from a zero-valued row, so the
+// The two helpers hand-maintain the same field list, which is how the contact
+// fields came to be in both. Clearing is preserving from a zero-valued row, so the
 // two must agree field for field.
 func TestUnscopedOnlyFields_ClearAndPreserveGovernSameSet(t *testing.T) {
 	cleared := requestedSystem()

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -164,10 +164,11 @@ updatedScoreData: &updatedScoreData
   notes: "Updated by Emberfall test"
 
 # HHS metadata anchor (12 fields). Used to exercise the RBAC write gate:
-# OWNER writes land in DB. For scoped admins the 11 system attributes are
-# stripped on create and restored on update, while isso_name is OpDiv-writable
-# and takes their value on both paths. Values are intentionally Star-Wars-themed
-# to match the fixture.
+# OWNER writes land in DB. For scoped admins the 9 system attributes are
+# stripped on create and restored on update, while the contact fields -
+# isso_name, system_owner, system_owner_email - are OpDiv-writable and take
+# their value on both paths (ztmf#511, ztmf#512). Values are intentionally
+# Star-Wars-themed to match the fixture.
 hhsExpected: &hhsExpected
   hva: true
   fips: "Moderate"
@@ -796,8 +797,9 @@ tests:
   # Test B — Scoped admin RBAC gate.
   #
   # Part 1: opDivAdmin POSTs a system with HHS fields → clearUnscopedOnlyFields
-  # strips the 11 system attributes; the created record has them null. isso_name
-  # is not in that set - an OpDiv-scoped admin may write it - so it persists.
+  # strips the 9 system attributes; the created record has them null. The
+  # contact fields (isso_name, system_owner, system_owner_email) are not in
+  # that set - an OpDiv-scoped admin may write them - so they persist.
   # opdiv_id 15 = EMPIRE OpDiv, position 15 in the seed INSERT sequence
   # (_test_data_empire.sql). If this fails with 403, the seed order changed.
   - id: createFismaSystemScopedAdmin
@@ -825,10 +827,10 @@ tests:
             cloud_vendor: null
             system_operator: null
             goco_coco_gogo: null
-            system_owner: null
-            system_owner_email: null
             legacy: null
             isso_name: "Darth Vader" # OpDiv-writable, so the POSTed value persists
+            system_owner: "Grand Moff Tarkin" # OpDiv-writable (ztmf#512)
+            system_owner_email: "tarkin@deathstar.empire" # OpDiv-writable (ztmf#512)
 
   # Part 2: OWNER sets HHS fields on system 1002 (EMPIRE OpDiv — opDivAdmin
   # holds a write grant for this system).
@@ -843,11 +845,12 @@ tests:
     expect:
       status: 204
 
-  # Part 3: opDivAdmin PUTs system 1002 with different values. The 11 system
+  # Part 3: opDivAdmin PUTs system 1002 with different values. The 9 system
   # attributes are restored from the stored row by preserveUnscopedOnlyFields;
-  # isso_name is not in that set, so the OpDiv admin's value takes effect. The
-  # isso_name sent here must differ from the value OWNER stored in Part 2, or
-  # the GET below cannot tell a successful write from a restored one.
+  # the contact fields are not in that set, so the OpDiv admin's values take
+  # effect. Every contact value sent here must differ from what OWNER stored
+  # in Part 2, or the GET below cannot tell a successful write from a
+  # restored one.
   - url: "http://localhost:8080/api/v1/fismasystems/1002"
     method: PUT
     headers:
@@ -857,14 +860,15 @@ tests:
       json:
         <<: *system1002WithHHSData
         hva: false # scoped-admin overwrite attempt; the stored value is restored
-        system_owner: "Impostor"
         isso_name: "Wilhuff Tarkin" # OpDiv-writable, so this one does take effect
+        system_owner: "Firmus Piett" # OpDiv-writable (ztmf#512), takes effect
+        system_owner_email: "piett@executor.empire" # OpDiv-writable (ztmf#512), takes effect
     expect:
       status: 204
 
-  # GET confirms OWNER's values survived the scoped admin PUT, while the
-  # OpDiv admin's isso_name landed. The explicit isso_name overrides the value
-  # carried by the hhsExpected merge key.
+  # GET confirms OWNER's system-attribute values survived the scoped admin
+  # PUT, while the OpDiv admin's contact fields landed. The explicit keys
+  # override the values carried by the hhsExpected merge key.
   - url: "http://localhost:8080/api/v1/fismasystems/1002"
     method: GET
     headers:
@@ -878,6 +882,8 @@ tests:
           data:
             <<: *hhsExpected
             isso_name: "Wilhuff Tarkin"
+            system_owner: "Firmus Piett"
+            system_owner_email: "piett@executor.empire"
 
   - url: http://localhost:8080/api/v1/fismasystems
     method: GET

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -61,6 +61,10 @@ type FismaSystem struct {
 	CloudVendor       *string  `json:"cloud_vendor" db:"cloud_vendor"`
 	SystemOperator    *string  `json:"system_operator" db:"system_operator"`
 	GocoCocGoGo       *string  `json:"goco_coco_gogo" db:"goco_coco_gogo"`
+	// SystemOwner / SystemOwnerEmail are contact fields, writable by an
+	// OpDiv-scoped admin on systems in their granted OpDivs (ztmf#512). Unlike
+	// ISSOName there is no derivation fallback: the stored column is the only
+	// source of the owner's name, so clearing it just clears it.
 	SystemOwner      *string `json:"system_owner" db:"system_owner"`
 	SystemOwnerEmail *string `json:"system_owner_email" db:"system_owner_email"`
 	Legacy           *bool   `json:"legacy" db:"legacy"`
@@ -90,6 +94,29 @@ type FindFismaSystemsInput struct {
 	// their lifecycle (mid-provisioning, all-revoked, etc.).
 	RestrictToOpDivIDs bool
 	Decommissioned     bool `schema:"decommissioned"`
+	// ResolveISSOName swaps the raw isso_name column for the COALESCE that
+	// falls back to the ISSO's user record (see resolveISSONameColumn). Set by
+	// DISPLAY reads only - the list always resolves, the single-system GET
+	// resolves when the controller asks. Internal fetches that feed write
+	// paths (guardManageFismaSystem and friends) must leave it false, or a
+	// derived name enters an entity that flows toward Save and gets persisted
+	// as a stored override (ztmf#510's acceptance constraint).
+	ResolveISSOName bool
+}
+
+// resolveISSONameColumn rewrites the isso_name entry of a column list into the
+// COALESCE that resolves a single ISSO display name: HHS systems carry
+// isso_name directly; CMS systems carry only issoemail, which maps to the
+// ISSO's user record. email is unique, so the correlated subquery returns at
+// most one row. This is THE derivation - both the list and the single-system
+// GET share it (ztmf#510), so the two reads cannot disagree.
+func resolveISSONameColumn(c []string) {
+	for i := range c {
+		if c[i] == "isso_name" {
+			c[i] = "COALESCE(fismasystems.isso_name, " +
+				"(SELECT fullname FROM users WHERE LOWER(email) = LOWER(fismasystems.issoemail) LIMIT 1)) AS isso_name"
+		}
+	}
 }
 
 func FindFismaSystems(ctx context.Context, input FindFismaSystemsInput) ([]*FismaSystem, error) {
@@ -97,19 +124,10 @@ func FindFismaSystems(ctx context.Context, input FindFismaSystemsInput) ([]*Fism
 	c := []string{"fismasystems.fismasystemid as fismasystemid"}
 	c = append(c, fismaSystemColumns[1:]...)
 
-	// Resolve a single ISSO display name for the systems table. HHS systems carry
-	// isso_name directly; CMS systems carry only issoemail, which maps to the
-	// ISSO's user record - so COALESCE yields one populated name column for both
-	// populations without a per-row lookup. email is unique, so the correlated
-	// subquery returns at most one row. Read-only: the write path never sets
-	// isso_name from this, so a resolved name is never persisted back. Applied to
-	// the list only; the single-system GET returns the stored value unchanged.
-	for i := range c {
-		if c[i] == "isso_name" {
-			c[i] = "COALESCE(fismasystems.isso_name, " +
-				"(SELECT fullname FROM users WHERE LOWER(email) = LOWER(fismasystems.issoemail) LIMIT 1)) AS isso_name"
-		}
-	}
+	// The list is always a display read, so it always resolves the ISSO
+	// display name. Read-only: the write path never sets isso_name from this,
+	// so a resolved name is never persisted back.
+	resolveISSONameColumn(c)
 	sqlb := stmntBuilder.Select(c...).From("fismasystems")
 
 	// Filter decommissioned systems
@@ -158,8 +176,14 @@ func FindFismaSystem(ctx context.Context, input FindFismaSystemsInput) (*FismaSy
 		}
 	}
 
+	c := make([]string, len(fismaSystemColumns))
+	copy(c, fismaSystemColumns)
+	if input.ResolveISSOName {
+		resolveISSONameColumn(c)
+	}
+
 	sqlb := stmntBuilder.
-		Select(fismaSystemColumns...).
+		Select(c...).
 		From("fismasystems").
 		Where("fismasystems.fismasystemid=?", input.FismaSystemID)
 

--- a/backend/internal/model/fismasystems_issoname_integration_test.go
+++ b/backend/internal/model/fismasystems_issoname_integration_test.go
@@ -60,8 +60,11 @@ func TestFismaSystemISSONameResolutionIntegration(t *testing.T) {
 		require.NoError(t, err)
 		_, err = conn.Exec(ctx, "UPDATE fismasystems SET isso_name='Stored Override' WHERE fismasystemid=$1", sysID)
 		require.NoError(t, err)
+		// Restore and release in ONE cleanup: a bare defer would release the
+		// pooled connection before t.Cleanup runs the restore Exec.
 		t.Cleanup(func() {
 			_, err := conn.Exec(ctx, "UPDATE fismasystems SET isso_name=NULL WHERE fismasystemid=$1", sysID)
+			conn.Release()
 			require.NoError(t, err)
 		})
 

--- a/backend/internal/model/fismasystems_issoname_integration_test.go
+++ b/backend/internal/model/fismasystems_issoname_integration_test.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ztmf#510: the list and the single-system GET must agree on isso_name for the
+// same system, whichever way that system resolves it. Seed system 1002 (SSD-EX)
+// carries isso_name NULL with an issoemail matching the Admiral Piett user
+// record, so it exercises the fallback; an in-test stored override exercises
+// the direct column. The raw (unresolved) read is asserted too, because write
+// paths depend on it staying raw: a derived name entering an entity that flows
+// toward Save would be persisted as a stored override.
+func TestFismaSystemISSONameResolutionIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	sysID := int32(1002)
+
+	listName := func(t *testing.T) *string {
+		t.Helper()
+		rows, err := FindFismaSystems(ctx, FindFismaSystemsInput{})
+		require.NoError(t, err)
+		for _, fs := range rows {
+			if fs.FismaSystemID == sysID {
+				return fs.ISSOName
+			}
+		}
+		t.Fatalf("system %d not in list results", sysID)
+		return nil
+	}
+	singleName := func(t *testing.T, resolve bool) *string {
+		t.Helper()
+		fs, err := FindFismaSystem(ctx, FindFismaSystemsInput{FismaSystemID: &sysID, ResolveISSOName: resolve})
+		require.NoError(t, err)
+		require.NotNil(t, fs)
+		return fs.ISSOName
+	}
+
+	t.Run("FallbackSystemAgreesAcrossReads", func(t *testing.T) {
+		// seed state: isso_name NULL, issoemail -> Admiral Piett's user record
+		ln, sn := listName(t), singleName(t, true)
+		require.NotNil(t, ln, "list must resolve the fallback name")
+		require.NotNil(t, sn, "resolved single GET must resolve the fallback name")
+		assert.Equal(t, "Admiral Piett", *ln)
+		assert.Equal(t, *ln, *sn, "list and single-system GET must agree (ztmf#510)")
+
+		assert.Nil(t, singleName(t, false),
+			"the raw read must return the stored NULL - write paths depend on it")
+	})
+
+	t.Run("StoredSystemAgreesAcrossReads", func(t *testing.T) {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.Exec(ctx, "UPDATE fismasystems SET isso_name='Stored Override' WHERE fismasystemid=$1", sysID)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, err := conn.Exec(ctx, "UPDATE fismasystems SET isso_name=NULL WHERE fismasystemid=$1", sysID)
+			require.NoError(t, err)
+		})
+
+		ln, sn := listName(t), singleName(t, true)
+		require.NotNil(t, ln)
+		require.NotNil(t, sn)
+		assert.Equal(t, "Stored Override", *ln, "a stored name must win over the fallback")
+		assert.Equal(t, *ln, *sn, "list and single-system GET must agree (ztmf#510)")
+
+		raw := singleName(t, false)
+		require.NotNil(t, raw)
+		assert.Equal(t, "Stored Override", *raw)
+	})
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -475,6 +475,11 @@ components:
         system_operator:
           type: string
         system_owner:
+          description: |-
+            SystemOwner / SystemOwnerEmail are contact fields, writable by an
+            OpDiv-scoped admin on systems in their granted OpDivs (ztmf#512). Unlike
+            ISSOName there is no derivation fallback: the stored column is the only
+            source of the owner's name, so clearing it just clears it.
           type: string
         system_owner_email:
           type: string


### PR DESCRIPTION
Closes #512, closes #510. Stacked on #511 - the base is `fix/isso-name-opdiv-writable` and GitHub will retarget to `main` when it merges; only the top commit is new here.

## #512 - owner contact fields become OpDiv-writable

`system_owner` and `system_owner_email` leave the unscoped-only set and follow the #511 pattern exactly: same `guardManageFismaSystem` authorization, same three request states (omitted leaves the stored value, `""` clears, a value writes), same helper/unit/E2E test shape. The protected set shrinks to 9.

On the grouping question raised in the #512 thread: the remaining 9 do share one rule. They are facts about the system itself - impact level, hosting, operator model, lifecycle - while the three fields now outside the set are pointers at people, which is precisely what OpDiv admins exist to maintain. The set is not being whittled field by field; it converged on the rule the #511 rename named.

One divergence from `isso_name` that the UI companion must not paper over: there is no derivation behind the owner fields, so clearing them just clears them. The "clearing restores the name from the user account" help text pattern cannot be copied across (per the #512 thread).

## #510 - one shared isso_name derivation

The list read and the single-system GET disagreed on `isso_name` for systems relying on the email fallback. The derivation now lives in one helper (`resolveISSONameColumn`) used by both reads:

- the list resolves always, as before
- the single-system GET resolves via a new opt-in `ResolveISSOName` input, set only by the display read
- every internal fetch that feeds a write path (`guardManageFismaSystem`, `guardViewFismaSystem`, `FindFismaSystemByUUID`) keeps the raw column, so a derived name can never enter an entity that flows toward `Save` - the acceptance constraint from #510

A new integration test covers a fallback system and a stored-override system through both reads, and pins the raw read for write-path safety. If a derivation is ever wanted for the owner fields, there is now exactly one place to put it.

Known and accepted, not fixed here: a third-party client that round-trips a full GET body into a PUT could persist a resolved name as a stored override. The first-party UI cannot - the field is read-only in the field config and both PUT paths send only the dirty diff.

Being precise about the delta, because an earlier draft of this description undersold it. This does not merely inherit an exposure the list endpoint already had; it **widens that exposure to the single-system fallback path**. The frontend falls back to `GET /fismasystems/:id` when a system is absent from the list array - in practice a decommissioned system, or a direct URL load before the list populates. That path previously returned the raw stored column, so a resolved name could not reach the edit form there at all. Both consequences follow from the same change:

- the em-dash-after-clearing case on that path disappears, closing a residual recorded on #510 with no frontend change
- the accidental-override exposure now extends to that path, where it did not exist before

A separate `isso_name_resolved` response field is the clean fix if it is ever wanted, and that widening is what motivates it.

## Testing

- unit: helper set tests extended to the contact-field trio, including omitted-key semantics
- integration: new `TestFismaSystemISSONameResolutionIntegration` (stored vs fallback, both reads, raw-read pin)
- E2E: emberfall Test B extended - scoped-admin create and update now take contact-field values while the 9 attributes stay protected; full suite 187/187
- `make generate-openapi` run; spec committed

## Coordination

The UI companion for the owner fields should ride with ztmf-ui#661 (same field-config flag covers create modal and the System Details edit view, which is the surface that matters), with its own help text per the divergence above.

