### PR TITLE
feat(scores): expose status on reads and add an explicit confirm endpoint

### DIFF
--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -233,6 +233,47 @@ func TestSaveScore_ISSONotAssignedForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// --- ConfirmScore ---
+
+func TestConfirmScore_ReadonlyAdminForbidden(t *testing.T) {
+	// The role-only rejection must fire before the row load, preserving the
+	// "read-only tiers are blocked before any DB access" property SaveScore
+	// pins - this test runs without a database.
+	r := httptest.NewRequest("PUT", "/api/v1/scores/123/confirm", nil)
+	r = mux.SetURLVars(r, map[string]string{"scoreid": "123"})
+	r = withUser(r, readonlyAdmin)
+	w := httptest.NewRecorder()
+
+	ConfirmScore(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// guardScoreWrite is the shared authorization for SaveScore and ConfirmScore.
+// The non-admin branches are pure (no DB), so pin them here; the admin branch
+// delegates to guardManageFismaSystem (DB) and is covered by the Emberfall
+// matrix.
+func TestGuardScoreWrite_NonAdminPaths(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ReadonlyAdminForbidden", func(t *testing.T) {
+		assert.ErrorIs(t, guardScoreWrite(ctx, readonlyAdmin, 1), ErrForbidden)
+	})
+
+	t.Run("ISSOUnassignedForbidden", func(t *testing.T) {
+		assert.ErrorIs(t, guardScoreWrite(ctx, issoUser, 999), ErrForbidden)
+	})
+
+	t.Run("ISSOAssignedAllowed", func(t *testing.T) {
+		assigned := &model.User{
+			UserID:               "44444444-4444-4444-4444-444444444444",
+			Email:                "isso2@test.com",
+			Role:                 "ISSO",
+			AssignedFismaSystems: []*int32{int32Ptr(7)},
+		}
+		assert.NoError(t, guardScoreWrite(ctx, assigned, 7))
+	})
+}
+
 // --- SaveFismaSystemTargetMaturity (#398) ---
 
 func TestSaveFismaSystemTargetMaturity_ReadonlyAdminForbidden(t *testing.T) {

--- a/backend/cmd/api/internal/controller/rbac_enforcement_test.go
+++ b/backend/cmd/api/internal/controller/rbac_enforcement_test.go
@@ -79,3 +79,12 @@ func TestSaveScore_OpDivReadonlyForbidden(t *testing.T) {
 	SaveScore(w, r)
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
+
+// --- ConfirmScore: read-only tiers are blocked before any DB access ---
+
+func TestConfirmScore_OpDivReadonlyForbidden(t *testing.T) {
+	r := withUser(httptest.NewRequest("PUT", "/api/v1/scores/123/confirm", nil), opdivReadonly)
+	w := httptest.NewRecorder()
+	ConfirmScore(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -79,24 +80,9 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 	}
 
-	if user.IsReadOnlyAdmin() {
-		respond(w, r, nil, ErrForbidden)
+	if err := guardScoreWrite(r.Context(), user, score.FismaSystemID); err != nil {
+		respond(w, r, nil, err)
 		return
-	}
-
-	if !user.IsAdmin() && !user.IsAssignedFismaSystem(score.FismaSystemID) {
-		respond(w, r, nil, ErrForbidden)
-		return
-	}
-
-	// OpDiv write-scope: an admin-tier writer may only score a system in an
-	// OpDiv they manage (OWNER/HHS_ADMIN any; OPDIV_ADMIN only their grants).
-	// ISSO/ISSM keep the per-system assignment path checked above.
-	if user.IsAdmin() {
-		if _, err := guardManageFismaSystem(r.Context(), user, score.FismaSystemID); err != nil {
-			respond(w, r, nil, err)
-			return
-		}
 	}
 
 	vars := mux.Vars(r)
@@ -109,6 +95,85 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 	score, err = score.Save(r.Context())
 
 	respond(w, r, score, err)
+}
+
+// guardScoreWrite is the shared authorization for every score-mutating
+// endpoint (SaveScore, ConfirmScore): read-only admins never write; ISSO/ISSM
+// must hold the per-system assignment; admin tiers must manage the system's
+// OpDiv (OWNER/HHS_ADMIN any, OPDIV_ADMIN only their grants). Extracted so the
+// confirm path cannot drift from the save path's rules.
+func guardScoreWrite(ctx context.Context, user *model.User, fismaSystemID int32) error {
+	if user.IsReadOnlyAdmin() {
+		return ErrForbidden
+	}
+
+	if !user.IsAdmin() && !user.IsAssignedFismaSystem(fismaSystemID) {
+		return ErrForbidden
+	}
+
+	if user.IsAdmin() {
+		if _, err := guardManageFismaSystem(ctx, user, fismaSystemID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ConfirmScore marks a carried-forward answer as affirmed for its data call:
+// it flips scores.status to 'done' and touches nothing else. Agreement
+// changes no answer field, so the ordinary PUT's no-op guard (correctly)
+// refuses to record it - this is the explicit act that does.
+//
+// The row is loaded FIRST and authorization runs against its own
+// fismasystemid - a client asserts nothing but the scoreid.
+//
+//	@Summary	Confirm a carried-forward score without changing it
+//	@Tags		scores
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		scoreid	path		int	true	"Score ID"
+//	@Success	200		{object}	apiResponse[model.Score]
+//	@Failure	403		{object}	apiResponse[any]
+//	@Failure	404		{object}	apiResponse[any]
+//	@Failure	500		{object}	apiResponse[any]
+//	@Router		/scores/{scoreid}/confirm [put]
+func ConfirmScore(w http.ResponseWriter, r *http.Request) {
+	user := model.UserFromContext(r.Context())
+
+	// Role-only rejection before any DB access, preserving the pinned
+	// property from rbac_enforcement_test.go ("read-only tiers are blocked
+	// before any DB access"). guardScoreWrite re-checks this; harmless.
+	if user.IsReadOnlyAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	var scoreID int32
+	fmt.Sscan(mux.Vars(r)["scoreid"], &scoreID)
+
+	score, err := model.FindScoreByID(r.Context(), scoreID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	if err := guardScoreWrite(r.Context(), user, score.FismaSystemID); err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	confirmed, err := score.Confirm(r.Context())
+	if err != nil {
+		log.Println(err)
+		respond(w, r, nil, err)
+		return
+	}
+
+	// respondOK, not respond: this is a PUT-as-action endpoint. The FE swaps
+	// the question's badge from the returned row rather than refetching blind,
+	// and respond() would drop the body with a 204.
+	respondOK(w, confirmed)
 }
 
 //	@Summary	Diff scores between two data calls

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -170,9 +170,9 @@ func ConfirmScore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// respondOK, not respond: this is a PUT-as-action endpoint. The FE swaps
-	// the question's badge from the returned row rather than refetching blind,
-	// and respond() would drop the body with a 204.
+	// respondOK, not respond: PUT-as-action endpoints return the updated
+	// entity (the restore/reactivate convention); respond() would drop the
+	// body with a 204.
 	respondOK(w, confirmed)
 }
 

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -107,6 +107,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/scores/progress", controller.GetScoresProgress).Methods("GET")
 	router.HandleFunc("/api/v1/scores", controller.SaveScore).Methods("POST")
 	router.HandleFunc("/api/v1/scores/{scoreid:[0-9]+}", controller.SaveScore).Methods("PUT")
+	router.HandleFunc("/api/v1/scores/{scoreid:[0-9]+}/confirm", controller.ConfirmScore).Methods("PUT")
 
 	router.HandleFunc("/api/v1/questions", controller.ListQuestions).Methods("GET")
 	router.HandleFunc("/api/v1/questions/{questionid:[0-9]+}", controller.GetQuestionByID).Methods("GET")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1818,6 +1818,142 @@ tests:
       headers:
         content-type: "application/json"
 
+  # PUT /scores/{scoreid}/confirm: the explicit "this carried-forward answer
+  # is still accurate" act. Unlike the ordinary PUT it writes even when
+  # nothing changed (that is its purpose), so its authz matrix must be pinned
+  # as tightly as SaveScore's. The not_started -> done flip itself is pinned
+  # by TestConfirmScoreIntegration (emberfall cannot seed a carried-forward
+  # row); these cases pin the HTTP contract.
+  #
+  # 1. Fixture: a fresh AI-flagged score. The 201 also pins that the write
+  #    path now serves status on the response body.
+  - id: createScoreForConfirm
+    url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1001
+        functionoptionid: 3
+        datacallid: 5
+        notes: "AI summary awaiting confirmation"
+        notes_is_ai_summary: true
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            status: "done"
+            notes_is_ai_summary: true
+
+  # 2. Owner confirm: 200 with the full row (respondOK, not the ordinary
+  #    PUT's 204 - the FE swaps the badge from this body). status is done,
+  #    and notes_is_ai_summary survives: confirming an AI-drafted
+  #    justification is agreement, not authorship, so the provenance flag
+  #    must NOT be cleared the way an ordinary edit clears it.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            status: "done"
+            notes: "AI summary awaiting confirmation"
+            notes_is_ai_summary: true
+            last_edited_by:
+              email: "Test.User@nowhere.xyz"
+
+  # 3. ISSO confirm on their own assigned system (1003): allowed, and the
+  #    confirming ISSO becomes the stamped editor.
+  - url: "http://localhost:8080/api/v1/scores/{{.issoCreateScoreOwnSystem.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            status: "done"
+            last_edited_by:
+              email: "Isso.User@nowhere.xyz"
+              role: "ISSO"
+
+  # 4. ISSO confirm on a system they are NOT assigned to (1001): 403. The
+  #    authz runs against the row's own fismasystemid - there is no request
+  #    body to lie in.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 403
+
+  # 5. Read-only tiers: blocked, same as every score write.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *readonlyAdminHeaders
+    expect:
+      status: 403
+
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *opDivReadonlyHeaders
+    expect:
+      status: 403
+
+  # 6. OpDiv-scoped admin outside their grant: EMPIRE admin cannot confirm a
+  #    REBELLION system's row. The row is created by the unscoped OWNER first
+  #    (1005 = X-wing, REBELLION).
+  - id: createRebellionScoreForConfirm
+    url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1005
+        functionoptionid: 1
+        datacallid: 5
+        notes: "Rebellion row for the confirm scope gate"
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            fismasystemid: 1005
+
+  - url: "http://localhost:8080/api/v1/scores/{{.createRebellionScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 403
+
+  # 7. Missing row: 404 before any authorization signal.
+  - url: "http://localhost:8080/api/v1/scores/999999999/confirm"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 404
+
   # Questions Endpoints
   - id: createQuestion
     url: http://localhost:8080/api/v1/questions

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -202,11 +202,30 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 	sqlb := stmntBuilder.
 		Update("public.scores").
 		Set("status", "done").
-		Where("scoreid=?", s.ScoreID).
+		// Keep the no-op guard in the write predicate as well as above. Two
+		// requests can both load not_started before either reaches Confirm; only
+		// the first must be allowed to update and create an audit event.
+		Where("scoreid=? AND status <> ?", s.ScoreID, "done").
 		Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 
 	confirmed, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
 	if err != nil {
+		// A conditional UPDATE that lost the race to another confirmer returns
+		// no row. Reload to distinguish that successful idempotent outcome from
+		// a score that was actually deleted, which remains ErrNoData/404.
+		if errors.Is(err, ErrNoData) {
+			current, findErr := FindScoreByID(ctx, s.ScoreID)
+			if findErr != nil {
+				return nil, findErr
+			}
+			if current.Status == "done" {
+				if at, by := lookupScoreAudit(ctx, current.ScoreID); at != nil && by != nil {
+					current.LastEditedAt = at
+					current.LastEditedBy = by
+				}
+				return current, nil
+			}
+		}
 		return confirmed, err
 	}
 

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -40,9 +40,16 @@ type Score struct {
 	NotesIsAISummary *bool           `json:"notes_is_ai_summary" db:"notes_is_ai_summary"`
 	FunctionOptionID int32           `json:"functionoptionid"`
 	DataCallID       int32           `json:"datacallid"`
-	FunctionOption   *FunctionOption `json:"functionoption,omitempty"`
-	LastEditedAt     *time.Time      `json:"last_edited_at,omitempty"`
-	LastEditedBy     *AuditRef       `json:"last_edited_by,omitempty"`
+	// Status is the answer's review state for its data call: 'not_started' for
+	// a row carried forward by copyPreviousScores and untouched this cycle,
+	// 'done' once saved or confirmed this cycle (ztmf#435, values pinned by
+	// migration 0048's CHECK). Exposed on the read path so the questionnaire
+	// marks carried-forward answers from the SAME fact the Data Call Progress
+	// count reads, instead of inferring it from the absence of an edit event.
+	Status         string          `json:"status"`
+	FunctionOption *FunctionOption `json:"functionoption,omitempty"`
+	LastEditedAt   *time.Time      `json:"last_edited_at,omitempty"`
+	LastEditedBy   *AuditRef       `json:"last_edited_by,omitempty"`
 }
 
 // AuditInfo satisfies Auditable. Returned pointers may be nil if the row has
@@ -109,7 +116,7 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			Insert("public.scores").
 			Columns("fismasystemid", "notes", "notes_is_ai_summary", "functionoptionid", "datacallid", "status").
 			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, "done").
-			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid")
+			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	} else {
 		setCols := squirrel.Eq{
 			"fismasystemid":    s.FismaSystemID,
@@ -125,7 +132,7 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			Update("public.scores").
 			SetMap(setCols).
 			Where("scoreid=?", s.ScoreID).
-			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid")
+			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	}
 
 	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
@@ -156,6 +163,48 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 		}
 	}
 	return saved, nil
+}
+
+// Confirm records that the user affirmed this carried-forward answer as still
+// accurate for the current data call: it flips status to 'done' and nothing
+// else. It exists because agreement changes no answer field, and Save's no-op
+// guard (correctly) refuses to write in that case (ztmf#412/#413) - so
+// "reviewed and agreed" needs its own explicit, attributable write.
+//
+// Deliberately narrow: sets ONLY status - notably not notes_is_ai_summary,
+// since agreeing with an AI-drafted justification is not authoring it. Runs
+// through queryRow so recordEvent stamps the confirming user as the editor.
+// Idempotent on an already-'done' row.
+//
+// The receiver must be a row loaded by FindScoreByID, not a client-supplied
+// body: DataCallID drives the deadline check, and the controller authorizes
+// against the loaded FismaSystemID rather than an asserted one.
+func (s *Score) Confirm(ctx context.Context) (*Score, error) {
+	if err := s.validateDeadline(ctx); err != nil {
+		return nil, err
+	}
+
+	sqlb := stmntBuilder.
+		Update("public.scores").
+		Set("status", "done").
+		Where("scoreid=?", s.ScoreID).
+		Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
+
+	confirmed, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
+	if err != nil {
+		return confirmed, err
+	}
+
+	// Same read-back as Save: project the canonical event row rather than
+	// synthesizing a timestamp, so the response cannot advertise an editor a
+	// subsequent GET would not confirm. Both-or-neither.
+	if confirmed != nil {
+		if at, by := lookupScoreAudit(ctx, confirmed.ScoreID); at != nil && by != nil {
+			confirmed.LastEditedAt = at
+			confirmed.LastEditedBy = by
+		}
+	}
+	return confirmed, nil
 }
 
 // scoreUpdateIsNoOp reports whether the incoming Score's answer fields
@@ -189,29 +238,48 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 // cleanly without paying a second round trip through the UPDATE that
 // would also fail.
 func scoreUpdateIsNoOp(ctx context.Context, incoming *Score) (bool, *Score, error) {
+	current, err := FindScoreByID(ctx, incoming.ScoreID)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return scoresEqualForUpdate(current, incoming), current, nil
+}
+
+// FindScoreByID reads one score row by id, on the read-only path (a plain
+// conn.QueryRow, never queryRow, so no event is recorded for a lookup).
+//
+// Shared by scoreUpdateIsNoOp, which needs the current answer fields to compare
+// against, and by ConfirmScore, which needs the row's real fismasystemid so the
+// controller can authorize against it rather than against a client-asserted one.
+//
+// Returns ErrNoData when the row is missing so callers can fail cleanly without
+// paying a second round trip through a write that would also fail.
+func FindScoreByID(ctx context.Context, scoreID int32) (*Score, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
-		return false, nil, trapError(err)
+		return nil, trapError(err)
 	}
 	defer conn.Release()
 
 	current := &Score{}
 	err = conn.QueryRow(ctx, `
 		SELECT scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) AS datecalculated,
-		       notes, notes_is_ai_summary, functionoptionid, datacallid
+		       notes, notes_is_ai_summary, functionoptionid, datacallid, status
 		FROM scores WHERE scoreid = $1
-	`, incoming.ScoreID).Scan(
+	`, scoreID).Scan(
 		&current.ScoreID, &current.FismaSystemID, &current.DateCalculated,
 		&current.Notes, &current.NotesIsAISummary, &current.FunctionOptionID, &current.DataCallID,
+		&current.Status,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			return false, nil, ErrNoData
+			return nil, ErrNoData
 		}
-		return false, nil, trapError(err)
+		return nil, trapError(err)
 	}
 
-	return scoresEqualForUpdate(current, incoming), current, nil
+	return current, nil
 }
 
 // scoresEqualForUpdate is the pure comparison used by scoreUpdateIsNoOp,
@@ -292,6 +360,14 @@ func (s *Score) validate(ctx context.Context) error {
 		return ErrNotesTooLong
 	}
 
+	return s.validateDeadline(ctx)
+}
+
+// validateDeadline rejects a write to a closed data call for anyone but an
+// admin. Extracted from validate so Confirm enforces the same rule: confirming
+// a carried-forward answer is a write to the cycle like any other, and must not
+// become a post-deadline loophole for the tiers that cannot save.
+func (s *Score) validateDeadline(ctx context.Context) error {
 	dataCall, err := FindDataCallByID(ctx, s.DataCallID)
 	if err != nil {
 		return err
@@ -371,7 +447,7 @@ type FindScoresInput struct {
 func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 
 	sqlb := stmntBuilder.
-		Select("scoreid, scores.fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, scores.notes_is_ai_summary, scores.functionoptionid, scores.datacallid").
+		Select("scoreid, scores.fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, scores.notes_is_ai_summary, scores.functionoptionid, scores.datacallid, scores.status").
 		From("scores")
 
 	if input.contains("functionoption") {
@@ -428,7 +504,7 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 
 	return query(ctx, sqlb, func(row pgx.CollectableRow) (*Score, error) {
 		score := Score{}
-		fields := []any{&score.ScoreID, &score.FismaSystemID, &score.DateCalculated, &score.Notes, &score.NotesIsAISummary, &score.FunctionOptionID, &score.DataCallID}
+		fields := []any{&score.ScoreID, &score.FismaSystemID, &score.DateCalculated, &score.Notes, &score.NotesIsAISummary, &score.FunctionOptionID, &score.DataCallID, &score.Status}
 		if input.contains("functionoption") {
 			score.FunctionOption = &FunctionOption{}
 			fields = append(fields, &score.FunctionOption.FunctionOptionID, &score.FunctionOption.FunctionID, &score.FunctionOption.Score, &score.FunctionOption.OptionName, &score.FunctionOption.Description)

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -184,6 +184,21 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 		return nil, err
 	}
 
+	// Audit-preserving no-op: once a score is done, confirming it again must
+	// not move last_edited_by / last_edited_at to the most recent caller. The
+	// controller loads this receiver through FindScoreByID immediately before
+	// calling Confirm, so its persisted Status is the source of truth. Return
+	// the current row with the same audit projection used after a real write,
+	// preserving the endpoint's idempotent 200 response without recording a
+	// second event.
+	if s.Status == "done" {
+		if at, by := lookupScoreAudit(ctx, s.ScoreID); at != nil && by != nil {
+			s.LastEditedAt = at
+			s.LastEditedBy = by
+		}
+		return s, nil
+	}
+
 	sqlb := stmntBuilder.
 		Update("public.scores").
 		Set("status", "done").

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -1289,3 +1289,192 @@ func TestFindPreviousDataCallByDeadlineIntegration(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNoData,
 		"a call before all cycles has no previous, not a future one")
 }
+
+// TestConfirmScoreIntegration pins the explicit-confirm write path behind the
+// questionnaire's "Confirm this answer is still accurate" button.
+//
+// copyPreviousScores seeds the new cycle with status = 'not_started' rows,
+// agreeing with one produces no change to the answer fields, and the ordinary
+// Save path (correctly) refuses to record agreement as a write. Confirm must:
+//   - flip status to 'done' and increment questionsupdated by exactly 1,
+//   - leave every answer field byte-identical - including notes_is_ai_summary,
+//     which the ordinary PUT forces to false on edit,
+//   - stamp the confirming user's identity and timestamp via the same
+//     recordEvent -> lookupScoreAudit path Save uses,
+//   - be idempotent on an already-'done' row,
+//   - enforce the same deadline rule as Save (non-admins cannot confirm into a
+//     closed cycle).
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestConfirmScoreIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// Same two-cycle scaffold as TestFindScoreProgressIntegration: the new
+	// cycle must be the global-latest deadline so findPreviousDataCall
+	// resolves our marker cycle as its predecessor.
+	var prevDC, newDC int32
+	var maxDeadline time.Time
+	err = conn.QueryRow(ctx, `SELECT COALESCE(MAX(deadline), NOW()) FROM datacalls`).Scan(&maxDeadline)
+	require.NoError(t, err)
+	suffix := time.Now().UnixNano()
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $3::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%sconfirm_prev_%d", integrationTestPrefix, suffix), time.Now().Add(-2*time.Hour), maxDeadline.Add(24*time.Hour)).Scan(&prevDC)
+	require.NoError(t, err)
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $3::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%sconfirm_new_%d", integrationTestPrefix, suffix), time.Now().Add(-1*time.Hour), maxDeadline.Add(48*time.Hour)).Scan(&newDC)
+	require.NoError(t, err)
+
+	// Borrow a valid, applicable (system, functionoption) pair from seeded
+	// data so the progress assertions below count our row (see the progress
+	// integration test for why applicability matters here).
+	var fismaSystemID, functionOptionID int32
+	err = conn.QueryRow(ctx, `
+		SELECT s.fismasystemid, s.functionoptionid
+		FROM scores s
+		INNER JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+		INNER JOIN functions f ON f.functionid = fo.functionid
+		INNER JOIN datacenterenvironments dce
+			ON dce.datacenterenvironment = fs.datacenterenvironment
+			AND dce.scoring_key = f.datacenterenvironment
+		INNER JOIN questions q ON q.questionid = f.questionid
+		WHERE fs.decommissioned = FALSE
+		LIMIT 1
+	`).Scan(&fismaSystemID, &functionOptionID)
+	require.NoError(t, err, "need one seeded score on an active system whose function is applicable to its environment")
+
+	// Prior-cycle answer flagged as an AI summary, rolled forward the way
+	// datacall creation does. The flag is the tripwire for "Confirm touched an
+	// answer field it must not".
+	notes := "confirm integration marker"
+	_, err = conn.Exec(ctx, `
+		INSERT INTO scores (fismasystemid, functionoptionid, datacallid, notes, notes_is_ai_summary)
+		VALUES ($1, $2, $3, $4, TRUE)
+	`, fismaSystemID, functionOptionID, prevDC, notes)
+	require.NoError(t, err)
+
+	if _, err := copyPreviousScores(ctx, newDC); err != nil {
+		t.Fatalf("copyPreviousScores: %v", err)
+	}
+
+	var copiedScoreID int32
+	err = conn.QueryRow(ctx, `
+		SELECT scoreid FROM scores
+		WHERE datacallid = $1 AND fismasystemid = $2 AND functionoptionid = $3
+	`, newDC, fismaSystemID, functionOptionID).Scan(&copiedScoreID)
+	require.NoError(t, err, "the copied row must exist in the new datacall")
+
+	progressFor := func() *ScoreProgress {
+		t.Helper()
+		rows, err := FindScoreProgress(ctx, FindScoreProgressInput{
+			DataCallID:    &newDC,
+			FismaSystemID: &fismaSystemID,
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		return rows[0]
+	}
+
+	// Phase 1: the carried row is not_started and counts as answered but not
+	// updated - the state the questionnaire's badge must render from alone,
+	// with no data migration.
+	carried, err := FindScoreByID(ctx, copiedScoreID)
+	require.NoError(t, err)
+	assert.Equal(t, "not_started", carried.Status,
+		"copyPreviousScores must seed the carried row as not_started")
+	assert.Equal(t, int32(0), progressFor().QuestionsUpdated,
+		"a carried-forward answer must not count as updated before it is confirmed")
+
+	// The confirmer must be a real seeded user: recordEvent writes
+	// events.userid with an FK to users and swallows the insert error on
+	// violation, so a fabricated UUID would leave no event and the identity
+	// assertion below would fail for the wrong reason.
+	var confirmerID, confirmerRole string
+	err = conn.QueryRow(ctx, `
+		SELECT userid, role FROM users ORDER BY (role = 'OWNER') DESC LIMIT 1
+	`).Scan(&confirmerID, &confirmerRole)
+	require.NoError(t, err, "need at least one seeded user to attribute the confirm to")
+	confirmerCtx := UserToContext(ctx, &User{UserID: confirmerID, Role: confirmerRole})
+
+	// Phase 2: confirm. Status flips, answer fields do not, the confirmer is
+	// stamped, progress moves by exactly one.
+	confirmed, err := carried.Confirm(confirmerCtx)
+	require.NoError(t, err, "confirming a carried-forward answer must succeed")
+	assert.Equal(t, "done", confirmed.Status)
+	assert.Equal(t, notes, derefString(confirmed.Notes),
+		"confirm must not modify the notes")
+	if assert.NotNil(t, confirmed.NotesIsAISummary, "notes_is_ai_summary must survive a confirm") {
+		assert.True(t, *confirmed.NotesIsAISummary,
+			"confirm is agreement, not authorship - the AI-summary flag must not be cleared")
+	}
+	assert.Equal(t, carried.FunctionOptionID, confirmed.FunctionOptionID)
+	if assert.NotNil(t, confirmed.LastEditedBy, "the confirming user must be stamped as the editor") {
+		assert.Equal(t, confirmerID, confirmed.LastEditedBy.UserID)
+	}
+	if assert.NotNil(t, confirmed.LastEditedAt) {
+		assert.WithinDuration(t, time.Now(), *confirmed.LastEditedAt, 5*time.Minute)
+	}
+
+	after := progressFor()
+	assert.Equal(t, int32(1), after.QuestionsUpdated,
+		"a confirmed answer must count as updated")
+	assert.Equal(t, int32(1), after.QuestionsAnswered)
+
+	// Phase 3: idempotency. Confirming a done row is a harmless re-affirmation.
+	reread, err := FindScoreByID(ctx, copiedScoreID)
+	require.NoError(t, err)
+	reconfirmed, err := reread.Confirm(confirmerCtx)
+	require.NoError(t, err, "confirming an already-done row must not error")
+	assert.Equal(t, "done", reconfirmed.Status)
+	assert.Equal(t, int32(1), progressFor().QuestionsUpdated,
+		"re-confirming must not double-count")
+
+	// Phase 4: the deadline rule. A non-admin cannot confirm into a closed
+	// cycle - same guard as Save, so confirm is not a post-deadline loophole.
+	var pastDC int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW() - INTERVAL '30 days', NOW() - INTERVAL '1 day')
+		RETURNING datacallid
+	`, fmt.Sprintf("%sconfirm_past_%d", integrationTestPrefix, suffix)).Scan(&pastDC)
+	require.NoError(t, err)
+
+	var pastScoreID int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO scores (fismasystemid, functionoptionid, datacallid, notes)
+		VALUES ($1, $2, $3, 'past-cycle row')
+		RETURNING scoreid
+	`, fismaSystemID, functionOptionID, pastDC).Scan(&pastScoreID)
+	require.NoError(t, err)
+
+	pastRow, err := FindScoreByID(ctx, pastScoreID)
+	require.NoError(t, err)
+	// No user in context = non-admin per validateDeadline.
+	_, err = pastRow.Confirm(ctx)
+	assert.ErrorIs(t, err, ErrPastDeadline,
+		"confirming into a closed cycle without admin must trip the deadline guard")
+
+	// FindScoreByID contract: a missing row is ErrNoData, which the controller
+	// maps to 404.
+	_, err = FindScoreByID(ctx, -1)
+	assert.ErrorIs(t, err, ErrNoData)
+}

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -1404,6 +1404,11 @@ func TestConfirmScoreIntegration(t *testing.T) {
 		"copyPreviousScores must seed the carried row as not_started")
 	assert.Equal(t, int32(0), progressFor().QuestionsUpdated,
 		"a carried-forward answer must not count as updated before it is confirmed")
+	// Model a concurrent request that loaded the same not_started row before
+	// the first confirmer's write. Using this stale snapshot later makes the
+	// race deterministic without scheduler-dependent goroutines.
+	staleConcurrentRead, err := FindScoreByID(ctx, copiedScoreID)
+	require.NoError(t, err)
 
 	// The confirmer must be a real seeded user: recordEvent writes
 	// events.userid with an FK to users and swallows the insert error on
@@ -1440,9 +1445,10 @@ func TestConfirmScoreIntegration(t *testing.T) {
 		"a confirmed answer must count as updated")
 	assert.Equal(t, int32(1), after.QuestionsAnswered)
 
-	// Phase 3: audit-preserving idempotency. A different user confirming the
-	// already-done row gets the same successful response, but must not create an
-	// event or replace the original confirmer as the displayed editor.
+	// Phase 3: atomic, audit-preserving idempotency. A different user whose
+	// request loaded not_started before the first write still gets the same
+	// successful response, but must not create an event or replace the original
+	// confirmer as the displayed editor.
 	eventsAfterFirstConfirm := countScoreEvents(t, ctx, conn, copiedScoreID)
 	var secondConfirmerID, secondConfirmerRole string
 	err = conn.QueryRow(ctx, `
@@ -1451,9 +1457,7 @@ func TestConfirmScoreIntegration(t *testing.T) {
 	require.NoError(t, err, "need a second seeded user to verify re-confirm does not move attribution")
 	secondConfirmerCtx := UserToContext(ctx, &User{UserID: secondConfirmerID, Role: secondConfirmerRole})
 
-	reread, err := FindScoreByID(ctx, copiedScoreID)
-	require.NoError(t, err)
-	reconfirmed, err := reread.Confirm(secondConfirmerCtx)
+	reconfirmed, err := staleConcurrentRead.Confirm(secondConfirmerCtx)
 	require.NoError(t, err, "confirming an already-done row must not error")
 	assert.Equal(t, "done", reconfirmed.Status)
 	assert.Equal(t, eventsAfterFirstConfirm, countScoreEvents(t, ctx, conn, copiedScoreID),
@@ -1468,6 +1472,15 @@ func TestConfirmScoreIntegration(t *testing.T) {
 	}
 	assert.Equal(t, int32(1), progressFor().QuestionsUpdated,
 		"re-confirming must not double-count")
+
+	// A normal retry that reads after the first write exercises the fast
+	// in-memory status guard and must preserve the same invariant.
+	freshDone, err := FindScoreByID(ctx, copiedScoreID)
+	require.NoError(t, err)
+	_, err = freshDone.Confirm(secondConfirmerCtx)
+	require.NoError(t, err)
+	assert.Equal(t, eventsAfterFirstConfirm, countScoreEvents(t, ctx, conn, copiedScoreID),
+		"a fresh retry must also remain write-free")
 
 	// Phase 4: the deadline rule. A non-admin cannot confirm into a closed
 	// cycle - same guard as Save, so confirm is not a post-deadline loophole.

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -1301,7 +1301,8 @@ func TestFindPreviousDataCallByDeadlineIntegration(t *testing.T) {
 //     which the ordinary PUT forces to false on edit,
 //   - stamp the confirming user's identity and timestamp via the same
 //     recordEvent -> lookupScoreAudit path Save uses,
-//   - be idempotent on an already-'done' row,
+//   - be idempotent on an already-'done' row without recording another event
+//     or moving the displayed editor to the second confirmer,
 //   - enforce the same deadline rule as Save (non-admins cannot confirm into a
 //     closed cycle).
 //
@@ -1439,12 +1440,32 @@ func TestConfirmScoreIntegration(t *testing.T) {
 		"a confirmed answer must count as updated")
 	assert.Equal(t, int32(1), after.QuestionsAnswered)
 
-	// Phase 3: idempotency. Confirming a done row is a harmless re-affirmation.
+	// Phase 3: audit-preserving idempotency. A different user confirming the
+	// already-done row gets the same successful response, but must not create an
+	// event or replace the original confirmer as the displayed editor.
+	eventsAfterFirstConfirm := countScoreEvents(t, ctx, conn, copiedScoreID)
+	var secondConfirmerID, secondConfirmerRole string
+	err = conn.QueryRow(ctx, `
+		SELECT userid, role FROM users WHERE userid <> $1 ORDER BY userid LIMIT 1
+	`, confirmerID).Scan(&secondConfirmerID, &secondConfirmerRole)
+	require.NoError(t, err, "need a second seeded user to verify re-confirm does not move attribution")
+	secondConfirmerCtx := UserToContext(ctx, &User{UserID: secondConfirmerID, Role: secondConfirmerRole})
+
 	reread, err := FindScoreByID(ctx, copiedScoreID)
 	require.NoError(t, err)
-	reconfirmed, err := reread.Confirm(confirmerCtx)
+	reconfirmed, err := reread.Confirm(secondConfirmerCtx)
 	require.NoError(t, err, "confirming an already-done row must not error")
 	assert.Equal(t, "done", reconfirmed.Status)
+	assert.Equal(t, eventsAfterFirstConfirm, countScoreEvents(t, ctx, conn, copiedScoreID),
+		"re-confirming must not append an audit event")
+	if assert.NotNil(t, reconfirmed.LastEditedBy, "the original confirmer must remain the editor") {
+		assert.Equal(t, confirmerID, reconfirmed.LastEditedBy.UserID)
+		assert.NotEqual(t, secondConfirmerID, reconfirmed.LastEditedBy.UserID)
+	}
+	if assert.NotNil(t, reconfirmed.LastEditedAt, "the original confirmation timestamp must remain visible") &&
+		assert.NotNil(t, confirmed.LastEditedAt) {
+		assert.Equal(t, *confirmed.LastEditedAt, *reconfirmed.LastEditedAt)
+	}
 	assert.Equal(t, int32(1), progressFor().QuestionsUpdated,
 		"re-confirming must not double-count")
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -628,6 +628,15 @@ components:
           type: boolean
         scoreid:
           type: integer
+        status:
+          description: |-
+            Status is the answer's review state for its data call: 'not_started' for
+            a row carried forward by copyPreviousScores and untouched this cycle,
+            'done' once saved or confirmed this cycle (ztmf#435, values pinned by
+            migration 0048's CHECK). Exposed on the read path so the questionnaire
+            marks carried-forward answers from the SAME fact the Data Call Progress
+            count reads, instead of inferring it from the absence of an edit event.
+          type: string
       type: object
     model.ScoreAggregate:
       properties:
@@ -2688,6 +2697,45 @@ paths:
       security:
       - bearerAuth: []
       summary: Create or update a score
+      tags:
+      - scores
+  /scores/{scoreid}/confirm:
+    put:
+      parameters:
+      - description: Score ID
+        in: path
+        name: scoreid
+        required: true
+        schema:
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-model_Score'
+          description: OK
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Confirm a carried-forward score without changing it
       tags:
       - scores
   /scores/aggregate:


### PR DESCRIPTION
## Problem

FY2026 pre-fills every questionnaire answer from the prior cycle (`scores.status = 'not_started'`), and a question only counts toward Data Call Progress once it reaches `status = 'done'`. Agreeing with a pre-filled answer changes no answer field, so `Save`'s audit-preserving no-op guard (#412/#413) correctly refuses to record it — "reviewed all 40 and agreed", the most common data-call action, produced **no write at all**. An ISSO who did exactly that reported completion while the dashboard showed 14/40 (CMS-Enterprise/ztmf-ui#659). This repeats across the ~900 systems with carried-forward answers.

Two hard requirements are in tension, so neither can be relaxed:
- **Browsing must stay write-free** — viewers must never be stamped as editors (#413's guarantee, enforced server-side as defense in depth).
- **Agreeing must produce a write** — or progress never moves.

The resolution: agreement becomes its own explicit, attributable act.

## Changes

**1. Expose `scores.status` on the read paths.** Added to `model.Score`, the `FindScores` select/scan, and the `Save`/`Confirm` RETURNING clauses. The questionnaire can now mark carried-forward answers from the *same persisted fact* the progress count reads — deriving that state client-side from the absence of an edit event is what let the badge and the count disagree. No migration: the column and its values already exist (ztmf#435).

**2. `PUT /api/v1/scores/{scoreid}/confirm`.** Flips `status` to `'done'` and touches nothing else:

- `notes_is_ai_summary` survives — agreeing with an AI-drafted justification is not authoring it (the ordinary PUT clears the flag on edit, which is correct for edits)
- Runs through `queryRow`, so the existing `recordEvent` hook stamps the confirming user's identity and timestamp — the attribution is the point
- Same past-deadline rule as `Save` (`validateDeadline`, extracted so the two paths share it): non-admins cannot confirm into a closed cycle
- Idempotent on an already-`done` row
- **Authorization runs against the row's own `fismasystemid`** — the row is loaded first (`FindScoreByID`, extracted from `scoreUpdateIsNoOp`'s inline query); a client asserts nothing but the scoreid. Read-only tiers are rejected before any DB access, preserving the property `rbac_enforcement_test.go` pins
- `SaveScore`'s three write guards are extracted into `guardScoreWrite` and shared, so the confirm path cannot drift from the save path's rules

The ordinary `PUT /scores/{scoreid}` is untouched: its no-op guard remains unconditional, so no client can re-stamp an editor with an unchanged answer.

## Testing

- **Unit:** `guardScoreWrite` non-admin paths; `ConfirmScore` read-only rejection with no DB (`authorization_test.go`, `rbac_enforcement_test.go`)
- **Integration:** `TestConfirmScoreIntegration` — carried row (`not_started`, AI-flagged) → confirm → `status = 'done'`, answer fields byte-identical, `notes_is_ai_summary` preserved, confirming user stamped, `FindScoreProgress.questionsupdated` +1 exactly, idempotent re-confirm, past-deadline rejection, `ErrNoData` → 404 contract
- **E2E (emberfall):** 8-case HTTP matrix — owner confirm 200 with body (flag survival pinned), ISSO own-system 200 with attribution, ISSO unassigned 403, both read-only tiers 403, OPDIV_ADMIN outside grant 403, missing row 404
- `make test-unit`, `make test-integration`, `make test-e2e` all green; `openapi.yaml` regenerated via `make generate-openapi` + `lint-openapi`

## Acceptance criteria (backend half of ztmf-ui#659)

- [x] **Agreement is an explicit act, distinct from navigation**: the confirm endpoint exists solely for it; the ordinary PUT's audit-preserving no-op guard is untouched, so browsing/read-through can still never produce a write (#412/#413 preserved)
- [x] **Confirm flips `not_started` → `done` with the confirming user's own identity and timestamps** — attribution rides the same `recordEvent` → audit-lateral path as every save (`TestConfirmScoreIntegration`)
- [x] **No data migration**: nothing beyond the existing `not_started` state is needed — the column and values already exist; this PR only exposes them on reads
- [x] **Answer fields untouched by a confirm**: notes, option, and `notes_is_ai_summary` byte-identical after confirming (integration + emberfall pins)
- [x] **Progress counting unchanged**: `scoreprogress.go` is not modified — a confirmed row counts as updated because `status` flips, through the query that already exists
- [x] **Authorization parity with SaveScore**: shared `guardScoreWrite`; row loaded first and checked against its own `fismasystemid`; read-only tiers rejected before any DB access; same past-deadline rule as Save

## Deploy order

Deploy before CMS-Enterprise/ztmf-ui#664 (the UI degrades cleanly against a backend without this change — no badges, prior behavior — but the feature is inert until this ships).
