### PR TITLE
fix(scores): authorize score updates against the stored row

### DIFF
--- a/backend/cmd/api/internal/controller/rbac_enforcement_test.go
+++ b/backend/cmd/api/internal/controller/rbac_enforcement_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,6 +79,31 @@ func TestSaveScore_OpDivReadonlyForbidden(t *testing.T) {
 	w := httptest.NewRecorder()
 	SaveScore(w, r)
 	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// The UPDATE path has to be pinned separately from the create path above,
+// because a PUT that authorizes against the stored row must look that row up
+// and the lookup is easy to place before the role check.
+//
+// The assertion uses a scoreid that cannot exist, which is what makes this
+// test discriminate. Rejecting on role first is a 403. Looking the row up
+// first is a 404 - and that difference is exactly the leak: a tier that must
+// never touch the database could otherwise probe which score ids exist by
+// reading the status code. Asserting 403 on an existing id would prove
+// nothing, since guardScoreWrite rejects read-only tiers a few lines later
+// either way.
+func TestSaveScore_OpDivReadonlyForbiddenOnUpdate(t *testing.T) {
+	const missingScoreID = "2147483600" // no fixture allocates anything near this
+	body := jsonBody(t, map[string]any{"fismasystemid": 1002, "functionoptionid": 1, "datacallid": 3})
+	r := httptest.NewRequest("PUT", "/api/v1/scores/"+missingScoreID, body)
+	r = mux.SetURLVars(r, map[string]string{"scoreid": missingScoreID})
+	r = withUser(r, opdivReadonly)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	SaveScore(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"a read-only tier must be rejected on role before the stored-row lookup, "+
+			"otherwise the 403/404 split reveals which score ids exist")
 }
 
 // --- ConfirmScore: read-only tiers are blocked before any DB access ---

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -80,8 +80,14 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 	}
 
-	if err := guardScoreWrite(r.Context(), user, score.FismaSystemID); err != nil {
-		respond(w, r, nil, err)
+	// Role-only rejection before any DB access, matching ConfirmScore and
+	// preserving the property pinned in rbac_enforcement_test.go ("read-only
+	// tiers are blocked before any DB access"). Without this the update path
+	// below would look the row up first, which both breaks that invariant and
+	// lets a read-only caller tell an existing scoreid from a missing one by
+	// the 404-vs-403 difference. guardScoreWrite re-checks this; harmless.
+	if user.IsReadOnlyAdmin() {
+		respond(w, r, nil, ErrForbidden)
 		return
 	}
 
@@ -90,6 +96,47 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 	if v, ok := vars["scoreid"]; ok {
 		fmt.Sscan(v, &scoreID)
 		score.ScoreID = scoreID
+	}
+
+	// Authorization is deliberately asymmetric between create and update.
+	//
+	// UPDATE: authorize against the STORED row, never the request body. The
+	// body's fismasystemid is a client assertion; trusting it let any caller
+	// with write access to one system reach every score row by id, since the
+	// UPDATE is keyed on scoreid alone. Load the row first and guard on what
+	// is actually there. The stored datacallid is also carried onto the
+	// receiver so the deadline is evaluated against the cycle the row belongs
+	// to rather than one the caller names.
+	//
+	// CREATE: no row exists yet, so the body's fismasystemid is the only
+	// thing to authorize against, which is correct there.
+	if score.ScoreID != 0 {
+		stored, err := model.FindScoreByID(r.Context(), score.ScoreID)
+		if err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+		if err := guardScoreWrite(r.Context(), user, stored.FismaSystemID); err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+		// Both columns are immutable on update (Save omits them from the SET
+		// list); pinning them here keeps the receiver honest for the deadline
+		// check and the no-op comparison.
+		score.FismaSystemID = stored.FismaSystemID
+		score.DataCallID = stored.DataCallID
+
+		// Hand Save the row we just read so its no-op comparison does not
+		// fetch it again. The questionnaire PUTs on every Next click, so this
+		// is the hottest write path in the app.
+		score, err = score.Save(r.Context(), model.WithCurrentScore(stored))
+		respond(w, r, score, err)
+		return
+	}
+
+	if err := guardScoreWrite(r.Context(), user, score.FismaSystemID); err != nil {
+		respond(w, r, nil, err)
+		return
 	}
 
 	score, err = score.Save(r.Context())

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1806,6 +1806,30 @@ tests:
     expect:
       status: 403
 
+  # Same rejection on the UPDATE path, which is where ztmf-misc#263 lived.
+  # The POST case above never reached the defect: create has no stored row, so
+  # it correctly authorizes against the body. The exploit was a PUT - the
+  # handler authorized against the body's fismasystemid while the UPDATE was
+  # keyed on the path scoreid alone, so naming a system the caller does hold
+  # bought write access to a row belonging to one they do not.
+  #
+  # This ISSO is assigned to 1003; the score below belongs to 1001. Sending
+  # fismasystemid 1003 is precisely the assertion that used to be believed.
+  # Returned 204 before the fix, 403 after.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForAudit.Response.data.scoreid}}"
+    method: PUT
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1003
+        functionoptionid: 1
+        datacallid: 5
+        notes: "cross-system PUT via body-asserted fismasystemid - must be blocked"
+    expect:
+      status: 403
+
   # ISSO GET /scores reaches the scoped list path. Audit fields on each
   # returned row are validated by the integration test referenced above;
   # this case pins the HTTP-layer status + content-type contract.

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -59,8 +59,35 @@ func (s *Score) AuditInfo() (*time.Time, *AuditRef) {
 	return s.LastEditedAt, s.LastEditedBy
 }
 
-func (s *Score) Save(ctx context.Context) (*Score, error) {
+// scoreSaveConfig carries request-shape context that is not part of the
+// persisted entity.
+type scoreSaveConfig struct {
+	current *Score
+}
+
+// ScoreSaveOption configures a Score.Save call.
+type ScoreSaveOption func(*scoreSaveConfig)
+
+// WithCurrentScore hands Save the stored row the caller has already loaded, so
+// the no-op comparison does not read it a second time. The update path
+// authorizes against the stored row, which means the controller loads it on
+// every PUT; the questionnaire PUTs on each Next click, so the duplicate read
+// would land on the hottest write path in the app.
+//
+// The row passed here MUST be the one Save is about to update, read through
+// FindScoreByID. Passing a stale or unrelated row would make the no-op
+// comparison lie about whether the answer changed.
+func WithCurrentScore(current *Score) ScoreSaveOption {
+	return func(c *scoreSaveConfig) { c.current = current }
+}
+
+func (s *Score) Save(ctx context.Context, opts ...ScoreSaveOption) (*Score, error) {
 	var sqlb SqlBuilder
+
+	cfg := &scoreSaveConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
 
 	if err := s.validate(ctx); err != nil {
 		return nil, err
@@ -88,7 +115,7 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 	// controller writes 204 today but still encodes the body, so the
 	// response is observable to clients that parse 204 bodies.
 	if s.ScoreID != 0 {
-		if same, current, err := scoreUpdateIsNoOp(ctx, s); err != nil {
+		if same, current, err := scoreUpdateIsNoOp(ctx, s, cfg.current); err != nil {
 			return nil, err
 		} else if same {
 			if s.FunctionOption != nil {
@@ -118,20 +145,31 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, "done").
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	} else {
+		// fismasystemid and datacallid are deliberately NOT in the SET list.
+		// Saving an answer must never move the row to another system or
+		// another cycle: those are the two columns that decide who may write
+		// the row and which deadline applies to it, so letting a request body
+		// rewrite them turns an answer edit into a reparenting primitive.
+		// The controller authorizes an update against the stored row and pins
+		// both values onto the receiver before calling Save.
 		setCols := squirrel.Eq{
-			"fismasystemid":    s.FismaSystemID,
 			"notes":            s.Notes,
 			"functionoptionid": s.FunctionOptionID,
-			"datacallid":       s.DataCallID,
 			"status":           "done",
 		}
 		if s.NotesIsAISummary != nil {
 			setCols["notes_is_ai_summary"] = *s.NotesIsAISummary
 		}
+		// Bind the write to the row the caller was authorized against, not to
+		// the id alone. The controller loads the row and pins these two fields
+		// onto the receiver before calling Save; matching on them here means a
+		// future caller that forgets to pin cannot write a row it did not
+		// authorize - it updates zero rows and fails as ErrNoData rather than
+		// succeeding against someone else's answer.
 		sqlb = stmntBuilder.
 			Update("public.scores").
 			SetMap(setCols).
-			Where("scoreid=?", s.ScoreID).
+			Where("scoreid=? AND fismasystemid=? AND datacallid=?", s.ScoreID, s.FismaSystemID, s.DataCallID).
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	}
 
@@ -271,10 +309,16 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 // Returns ErrNotData when the row is missing so the caller can fail
 // cleanly without paying a second round trip through the UPDATE that
 // would also fail.
-func scoreUpdateIsNoOp(ctx context.Context, incoming *Score) (bool, *Score, error) {
-	current, err := FindScoreByID(ctx, incoming.ScoreID)
-	if err != nil {
-		return false, nil, err
+// A non-nil preloaded row is used as-is instead of re-reading: the update path
+// authorizes against the stored row, so the controller has already fetched it.
+func scoreUpdateIsNoOp(ctx context.Context, incoming, preloaded *Score) (bool, *Score, error) {
+	current := preloaded
+	if current == nil {
+		var err error
+		current, err = FindScoreByID(ctx, incoming.ScoreID)
+		if err != nil {
+			return false, nil, err
+		}
 	}
 
 	return scoresEqualForUpdate(current, incoming), current, nil
@@ -324,6 +368,18 @@ func scoresEqualForUpdate(current, incoming *Score) bool {
 	if current == nil || incoming == nil {
 		return false
 	}
+	// fismasystemid and datacallid are compared defensively, not because a PUT
+	// can change them: Save omits both from the UPDATE's SET list and the
+	// controller pins them from the stored row before calling Save. They stay
+	// here so a receiver that somehow disagrees with the stored row is never
+	// treated as a no-op, which would silently skip a write the caller asked
+	// for.
+	//
+	// Note what this does NOT do: a mismatch only fails the equality check, so
+	// the write proceeds as a normal partial update of the answer fields. It
+	// does not report the disagreement to the caller. Turning that into an
+	// explicit error is a deliberate follow-up rather than something this
+	// comparison is doing today.
 	if current.FismaSystemID != incoming.FismaSystemID ||
 		current.DataCallID != incoming.DataCallID ||
 		current.FunctionOptionID != incoming.FunctionOptionID {

--- a/backend/internal/model/scores_writeauthz_integration_test.go
+++ b/backend/internal/model/scores_writeauthz_integration_test.go
@@ -1,0 +1,118 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A PUT must never move a score row to another system or another data call.
+// Both columns decide who may write the row and which deadline applies to it,
+// so a request body that rewrites them turns an answer edit into a reparenting
+// primitive (ztmf-misc#263). Save omits both from the UPDATE's SET list; this
+// pins that at the model layer, independent of whatever the controller passes.
+func TestScoreSaveCannotReparentIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	fismaSystemID, functionOptionID := anyExistingFunctionOption(t, ctx)
+	dataCallID := ensureFutureDataCall(t, ctx)
+
+	// A second system and a second data call to attempt the move toward.
+	var otherSystemID int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT fismasystemid FROM fismasystems
+		WHERE fismasystemid <> $1 AND COALESCE(decommissioned,false) = false
+		LIMIT 1
+	`, fismaSystemID).Scan(&otherSystemID), "need a second system to attempt a reparent")
+	require.NotEqual(t, fismaSystemID, otherSystemID)
+
+	var otherDataCallID int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT datacallid FROM datacalls WHERE datacallid <> $1 LIMIT 1
+	`, dataCallID).Scan(&otherDataCallID), "need a second data call to attempt a move")
+	require.NotEqual(t, dataCallID, otherDataCallID)
+
+	owner := UserToContext(ctx, &User{
+		UserID:   "11111111-1111-1111-1111-111111111111",
+		Email:    "Grand.Moff@DeathStar.Empire",
+		FullName: "Grand Moff Tarkin",
+		Role:     "OWNER",
+	})
+
+	notes := "original answer"
+	created, err := (&Score{
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       dataCallID,
+		Notes:            &notes,
+	}).Save(owner)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	scoreID := created.ScoreID
+	defer func() { _, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid=$1`, scoreID) }()
+
+	// The attack shape: same scoreid, but the receiver names a different
+	// system and a different cycle, alongside a real answer change so the
+	// write is not skipped as a no-op.
+	//
+	// The UPDATE is bound to (scoreid, fismasystemid, datacallid), so a
+	// receiver disagreeing with the stored row matches nothing and fails
+	// rather than silently applying the answer half of the write. That is the
+	// model-layer defense: it holds even if a caller forgets to pin the two
+	// fields from storage, which is the mistake that made ztmf-misc#263
+	// reachable in the first place.
+	moved := "answer rewritten by the reparent attempt"
+	_, err = (&Score{
+		ScoreID:          scoreID,
+		FismaSystemID:    otherSystemID,
+		DataCallID:       otherDataCallID,
+		FunctionOptionID: functionOptionID,
+		Notes:            &moved,
+	}).Save(owner)
+	require.Error(t, err,
+		"a Save whose receiver disagrees with the stored row must fail, not partially apply")
+
+	var gotSystem, gotCall int32
+	var gotNotes *string
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT fismasystemid, datacallid, notes FROM scores WHERE scoreid=$1
+	`, scoreID).Scan(&gotSystem, &gotCall, &gotNotes))
+
+	assert.Equal(t, fismaSystemID, gotSystem,
+		"the row must not move to the system named in the request (ztmf-misc#263)")
+	assert.Equal(t, dataCallID, gotCall,
+		"the row must not move to the data call named in the request (ztmf-misc#263)")
+	require.NotNil(t, gotNotes)
+	assert.Equal(t, notes, *gotNotes,
+		"a refused reparent must leave the original answer intact, not apply the new notes")
+
+	// The legitimate shape - same row, correct parents, changed answer - still
+	// works. Without this the test above would pass against a Save that simply
+	// never updates anything.
+	legit := "answer updated legitimately"
+	_, err = (&Score{
+		ScoreID:          scoreID,
+		FismaSystemID:    fismaSystemID,
+		DataCallID:       dataCallID,
+		FunctionOptionID: functionOptionID,
+		Notes:            &legit,
+	}).Save(owner)
+	require.NoError(t, err)
+
+	require.NoError(t, conn.QueryRow(ctx, `SELECT notes FROM scores WHERE scoreid=$1`, scoreID).Scan(&gotNotes))
+	require.NotNil(t, gotNotes)
+	assert.Equal(t, legit, *gotNotes, "a correctly-parented save must still apply")
+}


### PR DESCRIPTION
Closes CMS-Enterprise/ztmf-misc#263 (internal - detail, impact, and severity rationale live there).

Stacked on #515: base is `fix/659-score-confirm-endpoint` and GitHub will retarget this to `main` when that merges. Only the top commit is new here.

## What changes

Score updates now authorize against the stored row instead of values carried in the request body, and the two parent columns become immutable on update.

- `PUT /scores/{scoreid}` loads the row, authorizes against its stored `fismasystemid`, and pins both parents onto the receiver. `POST` still authorizes against the body, which is correct there because no row exists yet - the asymmetry is deliberate.
- `fismasystemid` and `datacallid` leave the UPDATE's SET list. Saving an answer is not a reparenting operation.
- The deadline is evaluated against the cycle the row belongs to rather than one named by the caller.
- `ConfirmScore` in #515 is the shape this follows; it already loaded-then-authorized, and the two paths now agree.

## Hardening found in review

- The UPDATE is bound to `(scoreid, fismasystemid, datacallid)`, so a future caller that forgets to pin the parents updates zero rows and fails cleanly rather than writing a row it never authorized.
- Read-only tiers are rejected before the row lookup, matching `ConfirmScore` and the property pinned in `rbac_enforcement_test.go`. Without it a tier that must never reach the database could distinguish existing score ids from missing ones by the 403/404 difference.
- `Save` takes the already-loaded row via `WithCurrentScore`, so the added authorization read is offset rather than doubling reads on the questionnaire's per-Next PUT.

## Tests

- **emberfall**: the cross-system update at the HTTP layer, which is where this lived. The existing ISSO case only covered `POST`, the path this change deliberately leaves alone. Returns 403 now, 204 before. Suite 197/197.
- **integration**: the model-layer refusal, plus a correctly-parented save in the same test so it cannot pass against a `Save` that never updates anything.
- **unit**: the read-only ordering, asserted against a nonexistent scoreid so it discriminates. Verified to fail without the fix rather than assumed.

## Behavior notes for reviewers

- A receiver disagreeing with the stored row now errors instead of silently applying the answer half of the write. Stronger, and pinned by the integration test.
- For a caller who simply lacks the assignment, 404-before-403 on a missing id is unavoidable once authorization reads the stored row, and matches `ConfirmScore`.
- A client that submits a differing `fismasystemid`/`datacallid` has those values silently ignored rather than rejected. Returning 400 would be more honest to API consumers; the frontend never does this, so it is noted as a follow-up rather than changed here.
