### PR TITLE
FY2026 backend batch: ISSO name, owner contact fields, score confirm, score write authorization

### DIFF
--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -233,6 +233,47 @@ func TestSaveScore_ISSONotAssignedForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// --- ConfirmScore ---
+
+func TestConfirmScore_ReadonlyAdminForbidden(t *testing.T) {
+	// The role-only rejection must fire before the row load, preserving the
+	// "read-only tiers are blocked before any DB access" property SaveScore
+	// pins - this test runs without a database.
+	r := httptest.NewRequest("PUT", "/api/v1/scores/123/confirm", nil)
+	r = mux.SetURLVars(r, map[string]string{"scoreid": "123"})
+	r = withUser(r, readonlyAdmin)
+	w := httptest.NewRecorder()
+
+	ConfirmScore(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// guardScoreWrite is the shared authorization for SaveScore and ConfirmScore.
+// The non-admin branches are pure (no DB), so pin them here; the admin branch
+// delegates to guardManageFismaSystem (DB) and is covered by the Emberfall
+// matrix.
+func TestGuardScoreWrite_NonAdminPaths(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ReadonlyAdminForbidden", func(t *testing.T) {
+		assert.ErrorIs(t, guardScoreWrite(ctx, readonlyAdmin, 1), ErrForbidden)
+	})
+
+	t.Run("ISSOUnassignedForbidden", func(t *testing.T) {
+		assert.ErrorIs(t, guardScoreWrite(ctx, issoUser, 999), ErrForbidden)
+	})
+
+	t.Run("ISSOAssignedAllowed", func(t *testing.T) {
+		assigned := &model.User{
+			UserID:               "44444444-4444-4444-4444-444444444444",
+			Email:                "isso2@test.com",
+			Role:                 "ISSO",
+			AssignedFismaSystems: []*int32{int32Ptr(7)},
+		}
+		assert.NoError(t, guardScoreWrite(ctx, assigned, 7))
+	})
+}
+
 // --- SaveFismaSystemTargetMaturity (#398) ---
 
 func TestSaveFismaSystemTargetMaturity_ReadonlyAdminForbidden(t *testing.T) {

--- a/backend/cmd/api/internal/controller/authorization_test.go
+++ b/backend/cmd/api/internal/controller/authorization_test.go
@@ -424,6 +424,35 @@ func TestSaveFismaSystem_ReadonlyAdminForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// isso_name is writable by OpDiv-scoped admins, so it is the one field in the
+// extended set whose gate could plausibly be loosened further. These two tiers
+// are the ones a "let the ISSO fix their own name" or "read-only should be able
+// to correct a typo" change would reach for, and both must stay behind
+// SaveFismaSystem's admin gate. The gate returns before any database call.
+func TestSaveFismaSystem_ISSONameDeniedTiersForbidden(t *testing.T) {
+	for name, u := range map[string]*model.User{
+		"ISSO":                 issoUser,
+		"OPDIV_READONLY_ADMIN": opdivReadonly,
+	} {
+		t.Run(name, func(t *testing.T) {
+			body := jsonBody(t, map[string]any{
+				"fismauid":     "12345678-1234-4abc-8def-123456789abc",
+				"fismaacronym": "TEST",
+				"fismaname":    "Test System",
+				"isso_name":    "Should Never Persist",
+			})
+			r := httptest.NewRequest("PUT", "/api/v1/fismasystems/1", body)
+			r.Header.Set("Content-Type", "application/json")
+			r = mux.SetURLVars(r, map[string]string{"fismasystemid": "1"})
+			r = withUser(r, u)
+			w := httptest.NewRecorder()
+
+			SaveFismaSystem(w, r)
+			assert.Equal(t, http.StatusForbidden, w.Code, "%s must not write isso_name", name)
+		})
+	}
+}
+
 // --- DeleteFismaSystem ---
 
 func TestDeleteFismaSystem_ReadonlyAdminForbidden(t *testing.T) {

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -104,9 +104,10 @@ func GetFismaSystem(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, fismasystem, nil)
 }
 
-// clearHHSMetadata nils the 12 HHS onboarding fields on a FismaSystem.
-// Called on INSERT when the acting user lacks unscoped read access.
-func clearHHSMetadata(fs *model.FismaSystem) {
+// clearUnscopedOnlyFields nils the 11 system-attribute fields only an
+// unscoped-write admin may set. Called on INSERT when the acting user lacks
+// unscoped read access.
+func clearUnscopedOnlyFields(fs *model.FismaSystem) {
 	fs.HVA = nil
 	fs.FIPS = nil
 	fs.SystemType = nil
@@ -118,25 +119,28 @@ func clearHHSMetadata(fs *model.FismaSystem) {
 	fs.SystemOwner = nil
 	fs.SystemOwnerEmail = nil
 	fs.Legacy = nil
-	fs.ISSOName = nil
 }
 
-// copyHHSMetadata copies the 12 HHS onboarding fields from src onto dst.
-// Called on UPDATE when the acting user lacks unscoped read access so that
-// a scoped admin edit does not wipe HHS metadata they cannot see.
-func copyHHSMetadata(src, dst *model.FismaSystem) {
-	dst.HVA = src.HVA
-	dst.FIPS = src.FIPS
-	dst.SystemType = src.SystemType
-	dst.CloudSystem = src.CloudSystem
-	dst.CloudServiceModel = src.CloudServiceModel
-	dst.CloudVendor = src.CloudVendor
-	dst.SystemOperator = src.SystemOperator
-	dst.GocoCocGoGo = src.GocoCocGoGo
-	dst.SystemOwner = src.SystemOwner
-	dst.SystemOwnerEmail = src.SystemOwnerEmail
-	dst.Legacy = src.Legacy
-	dst.ISSOName = src.ISSOName
+// preserveUnscopedOnlyFields overwrites the 11 system-attribute fields on
+// incoming with the values already stored on existing. Called on UPDATE when
+// the acting user lacks unscoped read access, so a full-form PUT from a tier
+// that may not write these fields cannot wipe them.
+//
+// The set covers system attributes only. isso_name is a contact name that an
+// OpDiv-scoped admin may write on systems in their granted OpDivs, so it is
+// not part of this set and passes through from the request.
+func preserveUnscopedOnlyFields(existing, incoming *model.FismaSystem) {
+	incoming.HVA = existing.HVA
+	incoming.FIPS = existing.FIPS
+	incoming.SystemType = existing.SystemType
+	incoming.CloudSystem = existing.CloudSystem
+	incoming.CloudServiceModel = existing.CloudServiceModel
+	incoming.CloudVendor = existing.CloudVendor
+	incoming.SystemOperator = existing.SystemOperator
+	incoming.GocoCocGoGo = existing.GocoCocGoGo
+	incoming.SystemOwner = existing.SystemOwner
+	incoming.SystemOwnerEmail = existing.SystemOwnerEmail
+	incoming.Legacy = existing.Legacy
 }
 
 // guardManageFismaSystem fetches the target system and verifies the acting user
@@ -247,13 +251,19 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// HHS metadata gate: only OWNER and HHS_ADMIN may write the 11 HHS onboarding
-	// fields (HasUnscopedRead gates this; HHS_READONLY_ADMIN is already blocked by
-	// IsAdmin() above). On INSERT, clear fields for scoped actors. On UPDATE, copy
-	// stored values so a scoped admin edit does not wipe data they cannot see.
+	// Only OWNER and HHS_ADMIN may write the 11 system-attribute fields
+	// (HasUnscopedRead gates this; HHS_READONLY_ADMIN is already blocked by
+	// IsAdmin() above). Every scoped admin can READ all of them - the list and
+	// GET reads return every column and only filter rows by OpDiv - so this is
+	// partial-PUT protection, not confidentiality: a tier that may not write
+	// them must not wipe them by round-tripping a form. On INSERT the fields are
+	// cleared; on UPDATE the stored values are restored over the request.
+	//
+	// guardManageFismaSystem also authorizes the write itself, so reaching Save
+	// on the UPDATE path means the caller may manage this specific system.
 	if f.FismaSystemID == 0 {
 		if !authdUser.HasUnscopedRead() {
-			clearHHSMetadata(f)
+			clearUnscopedOnlyFields(f)
 		}
 	} else if !authdUser.HasUnscopedRead() {
 		existing, err := guardManageFismaSystem(r.Context(), authdUser, f.FismaSystemID)
@@ -261,7 +271,7 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 			respond(w, r, nil, err)
 			return
 		}
-		copyHHSMetadata(existing, f)
+		preserveUnscopedOnlyFields(existing, f)
 	}
 
 	f, err = f.Save(r.Context(), model.WithPresentBoolFields(presentBools))

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -76,7 +76,10 @@ func ListFismaSystems(w http.ResponseWriter, r *http.Request) {
 func GetFismaSystem(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
 	vars := mux.Vars(r)
-	input := model.FindFismaSystemsInput{}
+	// A display read: resolve the ISSO display name the same way the list
+	// does, so the two endpoints cannot disagree on the same system
+	// (ztmf#510). Internal fetches that feed write paths keep the raw column.
+	input := model.FindFismaSystemsInput{ResolveISSOName: true}
 
 	if v, ok := vars["fismasystemid"]; ok {
 		var fismasystemID int32
@@ -104,7 +107,7 @@ func GetFismaSystem(w http.ResponseWriter, r *http.Request) {
 	respond(w, r, fismasystem, nil)
 }
 
-// clearUnscopedOnlyFields nils the 11 system-attribute fields only an
+// clearUnscopedOnlyFields nils the 9 system-attribute fields only an
 // unscoped-write admin may set. Called on INSERT when the acting user lacks
 // unscoped read access.
 func clearUnscopedOnlyFields(fs *model.FismaSystem) {
@@ -116,19 +119,21 @@ func clearUnscopedOnlyFields(fs *model.FismaSystem) {
 	fs.CloudVendor = nil
 	fs.SystemOperator = nil
 	fs.GocoCocGoGo = nil
-	fs.SystemOwner = nil
-	fs.SystemOwnerEmail = nil
 	fs.Legacy = nil
 }
 
-// preserveUnscopedOnlyFields overwrites the 11 system-attribute fields on
+// preserveUnscopedOnlyFields overwrites the 9 system-attribute fields on
 // incoming with the values already stored on existing. Called on UPDATE when
 // the acting user lacks unscoped read access, so a full-form PUT from a tier
 // that may not write these fields cannot wipe them.
 //
-// The set covers system attributes only. isso_name is a contact name that an
-// OpDiv-scoped admin may write on systems in their granted OpDivs, so it is
-// not part of this set and passes through from the request.
+// The set covers system attributes only. The contact fields - isso_name,
+// system_owner, system_owner_email - are writable by an OpDiv-scoped admin on
+// systems in their granted OpDivs (ztmf#511, ztmf#512), so they are not part
+// of this set and pass through from the request. The owner fields matter more
+// than a display preference: unlike isso_name they have no COALESCE fallback
+// to a user record, so the stored column is the only source there is, and
+// no onboarding load refreshes them for non-CMS OpDivs.
 func preserveUnscopedOnlyFields(existing, incoming *model.FismaSystem) {
 	incoming.HVA = existing.HVA
 	incoming.FIPS = existing.FIPS
@@ -138,8 +143,6 @@ func preserveUnscopedOnlyFields(existing, incoming *model.FismaSystem) {
 	incoming.CloudVendor = existing.CloudVendor
 	incoming.SystemOperator = existing.SystemOperator
 	incoming.GocoCocGoGo = existing.GocoCocGoGo
-	incoming.SystemOwner = existing.SystemOwner
-	incoming.SystemOwnerEmail = existing.SystemOwnerEmail
 	incoming.Legacy = existing.Legacy
 }
 
@@ -251,7 +254,7 @@ func SaveFismaSystem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Only OWNER and HHS_ADMIN may write the 11 system-attribute fields
+	// Only OWNER and HHS_ADMIN may write the 9 system-attribute fields
 	// (HasUnscopedRead gates this; HHS_READONLY_ADMIN is already blocked by
 	// IsAdmin() above). Every scoped admin can READ all of them - the list and
 	// GET reads return every column and only filter rows by OpDiv - so this is

--- a/backend/cmd/api/internal/controller/fismasystems_issoname_integration_test.go
+++ b/backend/cmd/api/internal/controller/fismasystems_issoname_integration_test.go
@@ -1,0 +1,51 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The model-layer test in internal/model pins that FindFismaSystem CAN resolve
+// the ISSO display name. This one pins that GetFismaSystem actually ASKS it to.
+// Without this, dropping ResolveISSOName from the handler leaves the model test
+// green while ztmf#510 silently regresses: the single-system GET would go back
+// to returning the raw column and disagreeing with the list.
+//
+// Seed system 1002 carries isso_name NULL with an issoemail matching the
+// Admiral Piett user record, so a resolved response can only come from the
+// COALESCE fallback.
+func TestGetFismaSystemResolvesISSONameIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	r := httptest.NewRequest("GET", "/api/v1/fismasystems/1002", nil)
+	r = mux.SetURLVars(r, map[string]string{"fismasystemid": "1002"})
+	r = withUser(r, adminUser)
+	w := httptest.NewRecorder()
+
+	GetFismaSystem(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			FismaSystemID int32   `json:"fismasystemid"`
+			ISSOName      *string `json:"isso_name"`
+			ISSOEmail     *string `json:"issoemail"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, int32(1002), resp.Data.FismaSystemID)
+
+	require.NotNil(t, resp.Data.ISSOName,
+		"the single-system GET must resolve the ISSO name from the user record "+
+			"the way the list does (ztmf#510); a nil here means the handler "+
+			"stopped setting ResolveISSOName")
+	assert.Equal(t, "Admiral Piett", *resp.Data.ISSOName)
+}

--- a/backend/cmd/api/internal/controller/fismasystems_metadata_test.go
+++ b/backend/cmd/api/internal/controller/fismasystems_metadata_test.go
@@ -1,0 +1,124 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// storedSystem returns a system whose every gated field carries a distinct
+// "stored" value, standing in for the row already in the database.
+func storedSystem() *model.FismaSystem {
+	s := func(v string) *string { return &v }
+	b := func(v bool) *bool { return &v }
+	return &model.FismaSystem{
+		HVA:               b(true),
+		FIPS:              s("stored-fips"),
+		SystemType:        s("stored-type"),
+		CloudSystem:       b(true),
+		CloudServiceModel: []string{"IaaS"},
+		CloudVendor:       s("stored-vendor"),
+		SystemOperator:    s("stored-operator"),
+		GocoCocGoGo:       s("stored-goco"),
+		SystemOwner:       s("stored-owner"),
+		SystemOwnerEmail:  s("stored-owner@example.gov"),
+		Legacy:            b(true),
+		ISSOName:          s("Stored ISSO"),
+	}
+}
+
+// requestedSystem returns a system whose every gated field carries a distinct
+// "requested" value, standing in for the decoded PUT body. Every value differs
+// from storedSystem's so a copy is detectable.
+func requestedSystem() *model.FismaSystem {
+	s := func(v string) *string { return &v }
+	b := func(v bool) *bool { return &v }
+	return &model.FismaSystem{
+		HVA:               b(false),
+		FIPS:              s("requested-fips"),
+		SystemType:        s("requested-type"),
+		CloudSystem:       b(false),
+		CloudServiceModel: []string{"SaaS"},
+		CloudVendor:       s("requested-vendor"),
+		SystemOperator:    s("requested-operator"),
+		GocoCocGoGo:       s("requested-goco"),
+		SystemOwner:       s("requested-owner"),
+		SystemOwnerEmail:  s("requested-owner@example.gov"),
+		Legacy:            b(false),
+		ISSOName:          s("Requested ISSO"),
+	}
+}
+
+// The 11 system attributes are restored from the stored row so a scoped
+// admin's full-form PUT cannot wipe them, while the ISSO name they sent
+// survives to reach Save.
+func TestPreserveUnscopedOnlyFields_ISSONameStaysRequested(t *testing.T) {
+	existing, incoming := storedSystem(), requestedSystem()
+
+	preserveUnscopedOnlyFields(existing, incoming)
+
+	assert.Equal(t, existing.HVA, incoming.HVA, "hva must be restored from the stored row")
+	assert.Equal(t, existing.FIPS, incoming.FIPS, "fips must be restored from the stored row")
+	assert.Equal(t, existing.SystemType, incoming.SystemType, "system_type must be restored from the stored row")
+	assert.Equal(t, existing.CloudSystem, incoming.CloudSystem, "cloud_system must be restored from the stored row")
+	assert.Equal(t, existing.CloudServiceModel, incoming.CloudServiceModel, "cloud_service_model must be restored from the stored row")
+	assert.Equal(t, existing.CloudVendor, incoming.CloudVendor, "cloud_vendor must be restored from the stored row")
+	assert.Equal(t, existing.SystemOperator, incoming.SystemOperator, "system_operator must be restored from the stored row")
+	assert.Equal(t, existing.GocoCocGoGo, incoming.GocoCocGoGo, "goco_coco_gogo must be restored from the stored row")
+	assert.Equal(t, existing.SystemOwner, incoming.SystemOwner, "system_owner must be restored from the stored row")
+	assert.Equal(t, existing.SystemOwnerEmail, incoming.SystemOwnerEmail, "system_owner_email must be restored from the stored row")
+	assert.Equal(t, existing.Legacy, incoming.Legacy, "legacy must be restored from the stored row")
+
+	assert.Equal(t, "Requested ISSO", *incoming.ISSOName,
+		"isso_name is OpDiv-writable and must keep the value the request sent")
+}
+
+// A nil requested ISSO name means the key was omitted, which Save reads as
+// "leave the stored value alone". Restoring the stored name here would turn an
+// omission into an explicit rewrite.
+func TestPreserveUnscopedOnlyFields_OmittedISSONameStaysNil(t *testing.T) {
+	existing, incoming := storedSystem(), requestedSystem()
+	incoming.ISSOName = nil
+
+	preserveUnscopedOnlyFields(existing, incoming)
+
+	assert.Nil(t, incoming.ISSOName, "an omitted isso_name must stay nil so Save leaves the stored value untouched")
+}
+
+// On create the same 11 attributes are cleared for a scoped admin, but the ISSO
+// name they supplied has to survive or the create silently drops it.
+func TestClearUnscopedOnlyFields_ISSONameSurvives(t *testing.T) {
+	incoming := requestedSystem()
+
+	clearUnscopedOnlyFields(incoming)
+
+	assert.Nil(t, incoming.HVA, "hva must be cleared")
+	assert.Nil(t, incoming.FIPS, "fips must be cleared")
+	assert.Nil(t, incoming.SystemType, "system_type must be cleared")
+	assert.Nil(t, incoming.CloudSystem, "cloud_system must be cleared")
+	assert.Nil(t, incoming.CloudServiceModel, "cloud_service_model must be cleared")
+	assert.Nil(t, incoming.CloudVendor, "cloud_vendor must be cleared")
+	assert.Nil(t, incoming.SystemOperator, "system_operator must be cleared")
+	assert.Nil(t, incoming.GocoCocGoGo, "goco_coco_gogo must be cleared")
+	assert.Nil(t, incoming.SystemOwner, "system_owner must be cleared")
+	assert.Nil(t, incoming.SystemOwnerEmail, "system_owner_email must be cleared")
+	assert.Nil(t, incoming.Legacy, "legacy must be cleared")
+
+	assert.Equal(t, "Requested ISSO", *incoming.ISSOName,
+		"isso_name is OpDiv-writable and must survive the create-path clear")
+}
+
+// The two helpers hand-maintain the same field list, which is how isso_name
+// came to be in both. Clearing is preserving from a zero-valued row, so the
+// two must agree field for field.
+func TestUnscopedOnlyFields_ClearAndPreserveGovernSameSet(t *testing.T) {
+	cleared := requestedSystem()
+	clearUnscopedOnlyFields(cleared)
+
+	preserved := requestedSystem()
+	preserveUnscopedOnlyFields(&model.FismaSystem{}, preserved)
+
+	assert.Equal(t, cleared, preserved,
+		"clearUnscopedOnlyFields and preserveUnscopedOnlyFields must govern an identical field set")
+}

--- a/backend/cmd/api/internal/controller/fismasystems_metadata_test.go
+++ b/backend/cmd/api/internal/controller/fismasystems_metadata_test.go
@@ -50,10 +50,10 @@ func requestedSystem() *model.FismaSystem {
 	}
 }
 
-// The 11 system attributes are restored from the stored row so a scoped
-// admin's full-form PUT cannot wipe them, while the ISSO name they sent
-// survives to reach Save.
-func TestPreserveUnscopedOnlyFields_ISSONameStaysRequested(t *testing.T) {
+// The 9 system attributes are restored from the stored row so a scoped
+// admin's full-form PUT cannot wipe them, while the contact fields they sent
+// (isso_name, system_owner, system_owner_email) survive to reach Save.
+func TestPreserveUnscopedOnlyFields_ContactFieldsStayRequested(t *testing.T) {
 	existing, incoming := storedSystem(), requestedSystem()
 
 	preserveUnscopedOnlyFields(existing, incoming)
@@ -66,29 +66,36 @@ func TestPreserveUnscopedOnlyFields_ISSONameStaysRequested(t *testing.T) {
 	assert.Equal(t, existing.CloudVendor, incoming.CloudVendor, "cloud_vendor must be restored from the stored row")
 	assert.Equal(t, existing.SystemOperator, incoming.SystemOperator, "system_operator must be restored from the stored row")
 	assert.Equal(t, existing.GocoCocGoGo, incoming.GocoCocGoGo, "goco_coco_gogo must be restored from the stored row")
-	assert.Equal(t, existing.SystemOwner, incoming.SystemOwner, "system_owner must be restored from the stored row")
-	assert.Equal(t, existing.SystemOwnerEmail, incoming.SystemOwnerEmail, "system_owner_email must be restored from the stored row")
 	assert.Equal(t, existing.Legacy, incoming.Legacy, "legacy must be restored from the stored row")
 
 	assert.Equal(t, "Requested ISSO", *incoming.ISSOName,
 		"isso_name is OpDiv-writable and must keep the value the request sent")
+	assert.Equal(t, "requested-owner", *incoming.SystemOwner,
+		"system_owner is OpDiv-writable and must keep the value the request sent")
+	assert.Equal(t, "requested-owner@example.gov", *incoming.SystemOwnerEmail,
+		"system_owner_email is OpDiv-writable and must keep the value the request sent")
 }
 
-// A nil requested ISSO name means the key was omitted, which Save reads as
-// "leave the stored value alone". Restoring the stored name here would turn an
+// A nil requested contact field means the key was omitted, which Save reads as
+// "leave the stored value alone". Restoring the stored value here would turn an
 // omission into an explicit rewrite.
-func TestPreserveUnscopedOnlyFields_OmittedISSONameStaysNil(t *testing.T) {
+func TestPreserveUnscopedOnlyFields_OmittedContactFieldsStayNil(t *testing.T) {
 	existing, incoming := storedSystem(), requestedSystem()
 	incoming.ISSOName = nil
+	incoming.SystemOwner = nil
+	incoming.SystemOwnerEmail = nil
 
 	preserveUnscopedOnlyFields(existing, incoming)
 
 	assert.Nil(t, incoming.ISSOName, "an omitted isso_name must stay nil so Save leaves the stored value untouched")
+	assert.Nil(t, incoming.SystemOwner, "an omitted system_owner must stay nil so Save leaves the stored value untouched")
+	assert.Nil(t, incoming.SystemOwnerEmail, "an omitted system_owner_email must stay nil so Save leaves the stored value untouched")
 }
 
-// On create the same 11 attributes are cleared for a scoped admin, but the ISSO
-// name they supplied has to survive or the create silently drops it.
-func TestClearUnscopedOnlyFields_ISSONameSurvives(t *testing.T) {
+// On create the same 9 attributes are cleared for a scoped admin, but the
+// contact fields they supplied have to survive or the create silently drops
+// them.
+func TestClearUnscopedOnlyFields_ContactFieldsSurvive(t *testing.T) {
 	incoming := requestedSystem()
 
 	clearUnscopedOnlyFields(incoming)
@@ -101,16 +108,18 @@ func TestClearUnscopedOnlyFields_ISSONameSurvives(t *testing.T) {
 	assert.Nil(t, incoming.CloudVendor, "cloud_vendor must be cleared")
 	assert.Nil(t, incoming.SystemOperator, "system_operator must be cleared")
 	assert.Nil(t, incoming.GocoCocGoGo, "goco_coco_gogo must be cleared")
-	assert.Nil(t, incoming.SystemOwner, "system_owner must be cleared")
-	assert.Nil(t, incoming.SystemOwnerEmail, "system_owner_email must be cleared")
 	assert.Nil(t, incoming.Legacy, "legacy must be cleared")
 
 	assert.Equal(t, "Requested ISSO", *incoming.ISSOName,
 		"isso_name is OpDiv-writable and must survive the create-path clear")
+	assert.Equal(t, "requested-owner", *incoming.SystemOwner,
+		"system_owner is OpDiv-writable and must survive the create-path clear")
+	assert.Equal(t, "requested-owner@example.gov", *incoming.SystemOwnerEmail,
+		"system_owner_email is OpDiv-writable and must survive the create-path clear")
 }
 
-// The two helpers hand-maintain the same field list, which is how isso_name
-// came to be in both. Clearing is preserving from a zero-valued row, so the
+// The two helpers hand-maintain the same field list, which is how the contact
+// fields came to be in both. Clearing is preserving from a zero-valued row, so the
 // two must agree field for field.
 func TestUnscopedOnlyFields_ClearAndPreserveGovernSameSet(t *testing.T) {
 	cleared := requestedSystem()

--- a/backend/cmd/api/internal/controller/rbac_enforcement_test.go
+++ b/backend/cmd/api/internal/controller/rbac_enforcement_test.go
@@ -79,3 +79,12 @@ func TestSaveScore_OpDivReadonlyForbidden(t *testing.T) {
 	SaveScore(w, r)
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
+
+// --- ConfirmScore: read-only tiers are blocked before any DB access ---
+
+func TestConfirmScore_OpDivReadonlyForbidden(t *testing.T) {
+	r := withUser(httptest.NewRequest("PUT", "/api/v1/scores/123/confirm", nil), opdivReadonly)
+	w := httptest.NewRecorder()
+	ConfirmScore(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/backend/cmd/api/internal/controller/rbac_enforcement_test.go
+++ b/backend/cmd/api/internal/controller/rbac_enforcement_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,6 +79,31 @@ func TestSaveScore_OpDivReadonlyForbidden(t *testing.T) {
 	w := httptest.NewRecorder()
 	SaveScore(w, r)
 	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// The UPDATE path has to be pinned separately from the create path above,
+// because a PUT that authorizes against the stored row must look that row up
+// and the lookup is easy to place before the role check.
+//
+// The assertion uses a scoreid that cannot exist, which is what makes this
+// test discriminate. Rejecting on role first is a 403. Looking the row up
+// first is a 404 - and that difference is exactly the leak: a tier that must
+// never touch the database could otherwise probe which score ids exist by
+// reading the status code. Asserting 403 on an existing id would prove
+// nothing, since guardScoreWrite rejects read-only tiers a few lines later
+// either way.
+func TestSaveScore_OpDivReadonlyForbiddenOnUpdate(t *testing.T) {
+	const missingScoreID = "2147483600" // no fixture allocates anything near this
+	body := jsonBody(t, map[string]any{"fismasystemid": 1002, "functionoptionid": 1, "datacallid": 3})
+	r := httptest.NewRequest("PUT", "/api/v1/scores/"+missingScoreID, body)
+	r = mux.SetURLVars(r, map[string]string{"scoreid": missingScoreID})
+	r = withUser(r, opdivReadonly)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	SaveScore(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"a read-only tier must be rejected on role before the stored-row lookup, "+
+			"otherwise the 403/404 split reveals which score ids exist")
 }
 
 // --- ConfirmScore: read-only tiers are blocked before any DB access ---

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -79,24 +80,9 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 	}
 
-	if user.IsReadOnlyAdmin() {
-		respond(w, r, nil, ErrForbidden)
+	if err := guardScoreWrite(r.Context(), user, score.FismaSystemID); err != nil {
+		respond(w, r, nil, err)
 		return
-	}
-
-	if !user.IsAdmin() && !user.IsAssignedFismaSystem(score.FismaSystemID) {
-		respond(w, r, nil, ErrForbidden)
-		return
-	}
-
-	// OpDiv write-scope: an admin-tier writer may only score a system in an
-	// OpDiv they manage (OWNER/HHS_ADMIN any; OPDIV_ADMIN only their grants).
-	// ISSO/ISSM keep the per-system assignment path checked above.
-	if user.IsAdmin() {
-		if _, err := guardManageFismaSystem(r.Context(), user, score.FismaSystemID); err != nil {
-			respond(w, r, nil, err)
-			return
-		}
 	}
 
 	vars := mux.Vars(r)
@@ -109,6 +95,85 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 	score, err = score.Save(r.Context())
 
 	respond(w, r, score, err)
+}
+
+// guardScoreWrite is the shared authorization for every score-mutating
+// endpoint (SaveScore, ConfirmScore): read-only admins never write; ISSO/ISSM
+// must hold the per-system assignment; admin tiers must manage the system's
+// OpDiv (OWNER/HHS_ADMIN any, OPDIV_ADMIN only their grants). Extracted so the
+// confirm path cannot drift from the save path's rules.
+func guardScoreWrite(ctx context.Context, user *model.User, fismaSystemID int32) error {
+	if user.IsReadOnlyAdmin() {
+		return ErrForbidden
+	}
+
+	if !user.IsAdmin() && !user.IsAssignedFismaSystem(fismaSystemID) {
+		return ErrForbidden
+	}
+
+	if user.IsAdmin() {
+		if _, err := guardManageFismaSystem(ctx, user, fismaSystemID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ConfirmScore marks a carried-forward answer as affirmed for its data call:
+// it flips scores.status to 'done' and touches nothing else. Agreement
+// changes no answer field, so the ordinary PUT's no-op guard (correctly)
+// refuses to record it - this is the explicit act that does.
+//
+// The row is loaded FIRST and authorization runs against its own
+// fismasystemid - a client asserts nothing but the scoreid.
+//
+//	@Summary	Confirm a carried-forward score without changing it
+//	@Tags		scores
+//	@Produce	json
+//	@Security	bearerAuth
+//	@Param		scoreid	path		int	true	"Score ID"
+//	@Success	200		{object}	apiResponse[model.Score]
+//	@Failure	403		{object}	apiResponse[any]
+//	@Failure	404		{object}	apiResponse[any]
+//	@Failure	500		{object}	apiResponse[any]
+//	@Router		/scores/{scoreid}/confirm [put]
+func ConfirmScore(w http.ResponseWriter, r *http.Request) {
+	user := model.UserFromContext(r.Context())
+
+	// Role-only rejection before any DB access, preserving the pinned
+	// property from rbac_enforcement_test.go ("read-only tiers are blocked
+	// before any DB access"). guardScoreWrite re-checks this; harmless.
+	if user.IsReadOnlyAdmin() {
+		respond(w, r, nil, ErrForbidden)
+		return
+	}
+
+	var scoreID int32
+	fmt.Sscan(mux.Vars(r)["scoreid"], &scoreID)
+
+	score, err := model.FindScoreByID(r.Context(), scoreID)
+	if err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	if err := guardScoreWrite(r.Context(), user, score.FismaSystemID); err != nil {
+		respond(w, r, nil, err)
+		return
+	}
+
+	confirmed, err := score.Confirm(r.Context())
+	if err != nil {
+		log.Println(err)
+		respond(w, r, nil, err)
+		return
+	}
+
+	// respondOK, not respond: this is a PUT-as-action endpoint. The FE swaps
+	// the question's badge from the returned row rather than refetching blind,
+	// and respond() would drop the body with a 204.
+	respondOK(w, confirmed)
 }
 
 //	@Summary	Diff scores between two data calls

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -80,8 +80,14 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 	}
 
-	if err := guardScoreWrite(r.Context(), user, score.FismaSystemID); err != nil {
-		respond(w, r, nil, err)
+	// Role-only rejection before any DB access, matching ConfirmScore and
+	// preserving the property pinned in rbac_enforcement_test.go ("read-only
+	// tiers are blocked before any DB access"). Without this the update path
+	// below would look the row up first, which both breaks that invariant and
+	// lets a read-only caller tell an existing scoreid from a missing one by
+	// the 404-vs-403 difference. guardScoreWrite re-checks this; harmless.
+	if user.IsReadOnlyAdmin() {
+		respond(w, r, nil, ErrForbidden)
 		return
 	}
 
@@ -90,6 +96,47 @@ func SaveScore(w http.ResponseWriter, r *http.Request) {
 	if v, ok := vars["scoreid"]; ok {
 		fmt.Sscan(v, &scoreID)
 		score.ScoreID = scoreID
+	}
+
+	// Authorization is deliberately asymmetric between create and update.
+	//
+	// UPDATE: authorize against the STORED row, never the request body. The
+	// body's fismasystemid is a client assertion; trusting it let any caller
+	// with write access to one system reach every score row by id, since the
+	// UPDATE is keyed on scoreid alone. Load the row first and guard on what
+	// is actually there. The stored datacallid is also carried onto the
+	// receiver so the deadline is evaluated against the cycle the row belongs
+	// to rather than one the caller names.
+	//
+	// CREATE: no row exists yet, so the body's fismasystemid is the only
+	// thing to authorize against, which is correct there.
+	if score.ScoreID != 0 {
+		stored, err := model.FindScoreByID(r.Context(), score.ScoreID)
+		if err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+		if err := guardScoreWrite(r.Context(), user, stored.FismaSystemID); err != nil {
+			respond(w, r, nil, err)
+			return
+		}
+		// Both columns are immutable on update (Save omits them from the SET
+		// list); pinning them here keeps the receiver honest for the deadline
+		// check and the no-op comparison.
+		score.FismaSystemID = stored.FismaSystemID
+		score.DataCallID = stored.DataCallID
+
+		// Hand Save the row we just read so its no-op comparison does not
+		// fetch it again. The questionnaire PUTs on every Next click, so this
+		// is the hottest write path in the app.
+		score, err = score.Save(r.Context(), model.WithCurrentScore(stored))
+		respond(w, r, score, err)
+		return
+	}
+
+	if err := guardScoreWrite(r.Context(), user, score.FismaSystemID); err != nil {
+		respond(w, r, nil, err)
+		return
 	}
 
 	score, err = score.Save(r.Context())

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -170,9 +170,9 @@ func ConfirmScore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// respondOK, not respond: this is a PUT-as-action endpoint. The FE swaps
-	// the question's badge from the returned row rather than refetching blind,
-	// and respond() would drop the body with a 204.
+	// respondOK, not respond: PUT-as-action endpoints return the updated
+	// entity (the restore/reactivate convention); respond() would drop the
+	// body with a 204.
 	respondOK(w, confirmed)
 }
 

--- a/backend/cmd/api/internal/router/router.go
+++ b/backend/cmd/api/internal/router/router.go
@@ -107,6 +107,7 @@ func Handler() http.Handler {
 	router.HandleFunc("/api/v1/scores/progress", controller.GetScoresProgress).Methods("GET")
 	router.HandleFunc("/api/v1/scores", controller.SaveScore).Methods("POST")
 	router.HandleFunc("/api/v1/scores/{scoreid:[0-9]+}", controller.SaveScore).Methods("PUT")
+	router.HandleFunc("/api/v1/scores/{scoreid:[0-9]+}/confirm", controller.ConfirmScore).Methods("PUT")
 
 	router.HandleFunc("/api/v1/questions", controller.ListQuestions).Methods("GET")
 	router.HandleFunc("/api/v1/questions/{questionid:[0-9]+}", controller.GetQuestionByID).Methods("GET")

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1834,6 +1834,142 @@ tests:
       headers:
         content-type: "application/json"
 
+  # PUT /scores/{scoreid}/confirm: the explicit "this carried-forward answer
+  # is still accurate" act. Unlike the ordinary PUT it writes even when
+  # nothing changed (that is its purpose), so its authz matrix must be pinned
+  # as tightly as SaveScore's. The not_started -> done flip itself is pinned
+  # by TestConfirmScoreIntegration (emberfall cannot seed a carried-forward
+  # row); these cases pin the HTTP contract.
+  #
+  # 1. Fixture: a fresh AI-flagged score. The 201 also pins that the write
+  #    path now serves status on the response body.
+  - id: createScoreForConfirm
+    url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1001
+        functionoptionid: 3
+        datacallid: 5
+        notes: "AI summary awaiting confirmation"
+        notes_is_ai_summary: true
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            status: "done"
+            notes_is_ai_summary: true
+
+  # 2. Owner confirm: 200 with the full row (respondOK, not the ordinary
+  #    PUT's 204 - the FE swaps the badge from this body). status is done,
+  #    and notes_is_ai_summary survives: confirming an AI-drafted
+  #    justification is agreement, not authorship, so the provenance flag
+  #    must NOT be cleared the way an ordinary edit clears it.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            status: "done"
+            notes: "AI summary awaiting confirmation"
+            notes_is_ai_summary: true
+            last_edited_by:
+              email: "Test.User@nowhere.xyz"
+
+  # 3. ISSO confirm on their own assigned system (1003): allowed, and the
+  #    confirming ISSO becomes the stamped editor.
+  - url: "http://localhost:8080/api/v1/scores/{{.issoCreateScoreOwnSystem.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            status: "done"
+            last_edited_by:
+              email: "Isso.User@nowhere.xyz"
+              role: "ISSO"
+
+  # 4. ISSO confirm on a system they are NOT assigned to (1001): 403. The
+  #    authz runs against the row's own fismasystemid - there is no request
+  #    body to lie in.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 403
+
+  # 5. Read-only tiers: blocked, same as every score write.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *readonlyAdminHeaders
+    expect:
+      status: 403
+
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *opDivReadonlyHeaders
+    expect:
+      status: 403
+
+  # 6. OpDiv-scoped admin outside their grant: EMPIRE admin cannot confirm a
+  #    REBELLION system's row. The row is created by the unscoped OWNER first
+  #    (1005 = X-wing, REBELLION).
+  - id: createRebellionScoreForConfirm
+    url: http://localhost:8080/api/v1/scores
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1005
+        functionoptionid: 1
+        datacallid: 5
+        notes: "Rebellion row for the confirm scope gate"
+    expect:
+      status: 201
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            fismasystemid: 1005
+
+  - url: "http://localhost:8080/api/v1/scores/{{.createRebellionScoreForConfirm.Response.data.scoreid}}/confirm"
+    method: PUT
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 403
+
+  # 7. Missing row: 404 before any authorization signal.
+  - url: "http://localhost:8080/api/v1/scores/999999999/confirm"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 404
+
   # Questions Endpoints
   - id: createQuestion
     url: http://localhost:8080/api/v1/questions

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -164,10 +164,11 @@ updatedScoreData: &updatedScoreData
   notes: "Updated by Emberfall test"
 
 # HHS metadata anchor (12 fields). Used to exercise the RBAC write gate:
-# OWNER writes land in DB. For scoped admins the 11 system attributes are
-# stripped on create and restored on update, while isso_name is OpDiv-writable
-# and takes their value on both paths. Values are intentionally Star-Wars-themed
-# to match the fixture.
+# OWNER writes land in DB. For scoped admins the 9 system attributes are
+# stripped on create and restored on update, while the contact fields -
+# isso_name, system_owner, system_owner_email - are OpDiv-writable and take
+# their value on both paths (ztmf#511, ztmf#512). Values are intentionally
+# Star-Wars-themed to match the fixture.
 hhsExpected: &hhsExpected
   hva: true
   fips: "Moderate"
@@ -796,8 +797,9 @@ tests:
   # Test B — Scoped admin RBAC gate.
   #
   # Part 1: opDivAdmin POSTs a system with HHS fields → clearUnscopedOnlyFields
-  # strips the 11 system attributes; the created record has them null. isso_name
-  # is not in that set - an OpDiv-scoped admin may write it - so it persists.
+  # strips the 9 system attributes; the created record has them null. The
+  # contact fields (isso_name, system_owner, system_owner_email) are not in
+  # that set - an OpDiv-scoped admin may write them - so they persist.
   # opdiv_id 15 = EMPIRE OpDiv, position 15 in the seed INSERT sequence
   # (_test_data_empire.sql). If this fails with 403, the seed order changed.
   - id: createFismaSystemScopedAdmin
@@ -825,10 +827,10 @@ tests:
             cloud_vendor: null
             system_operator: null
             goco_coco_gogo: null
-            system_owner: null
-            system_owner_email: null
             legacy: null
             isso_name: "Darth Vader" # OpDiv-writable, so the POSTed value persists
+            system_owner: "Grand Moff Tarkin" # OpDiv-writable (ztmf#512)
+            system_owner_email: "tarkin@deathstar.empire" # OpDiv-writable (ztmf#512)
 
   # Part 2: OWNER sets HHS fields on system 1002 (EMPIRE OpDiv — opDivAdmin
   # holds a write grant for this system).
@@ -843,11 +845,12 @@ tests:
     expect:
       status: 204
 
-  # Part 3: opDivAdmin PUTs system 1002 with different values. The 11 system
+  # Part 3: opDivAdmin PUTs system 1002 with different values. The 9 system
   # attributes are restored from the stored row by preserveUnscopedOnlyFields;
-  # isso_name is not in that set, so the OpDiv admin's value takes effect. The
-  # isso_name sent here must differ from the value OWNER stored in Part 2, or
-  # the GET below cannot tell a successful write from a restored one.
+  # the contact fields are not in that set, so the OpDiv admin's values take
+  # effect. Every contact value sent here must differ from what OWNER stored
+  # in Part 2, or the GET below cannot tell a successful write from a
+  # restored one.
   - url: "http://localhost:8080/api/v1/fismasystems/1002"
     method: PUT
     headers:
@@ -857,14 +860,15 @@ tests:
       json:
         <<: *system1002WithHHSData
         hva: false # scoped-admin overwrite attempt; the stored value is restored
-        system_owner: "Impostor"
         isso_name: "Wilhuff Tarkin" # OpDiv-writable, so this one does take effect
+        system_owner: "Firmus Piett" # OpDiv-writable (ztmf#512), takes effect
+        system_owner_email: "piett@executor.empire" # OpDiv-writable (ztmf#512), takes effect
     expect:
       status: 204
 
-  # GET confirms OWNER's values survived the scoped admin PUT, while the
-  # OpDiv admin's isso_name landed. The explicit isso_name overrides the value
-  # carried by the hhsExpected merge key.
+  # GET confirms OWNER's system-attribute values survived the scoped admin
+  # PUT, while the OpDiv admin's contact fields landed. The explicit keys
+  # override the values carried by the hhsExpected merge key.
   - url: "http://localhost:8080/api/v1/fismasystems/1002"
     method: GET
     headers:
@@ -878,6 +882,8 @@ tests:
           data:
             <<: *hhsExpected
             isso_name: "Wilhuff Tarkin"
+            system_owner: "Firmus Piett"
+            system_owner_email: "piett@executor.empire"
 
   - url: http://localhost:8080/api/v1/fismasystems
     method: GET

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1822,6 +1822,30 @@ tests:
     expect:
       status: 403
 
+  # Same rejection on the UPDATE path, which is where ztmf-misc#263 lived.
+  # The POST case above never reached the defect: create has no stored row, so
+  # it correctly authorizes against the body. The exploit was a PUT - the
+  # handler authorized against the body's fismasystemid while the UPDATE was
+  # keyed on the path scoreid alone, so naming a system the caller does hold
+  # bought write access to a row belonging to one they do not.
+  #
+  # This ISSO is assigned to 1003; the score below belongs to 1001. Sending
+  # fismasystemid 1003 is precisely the assertion that used to be believed.
+  # Returned 204 before the fix, 403 after.
+  - url: "http://localhost:8080/api/v1/scores/{{.createScoreForAudit.Response.data.scoreid}}"
+    method: PUT
+    headers:
+      <<: *issoHeaders
+      content-type: "application/json"
+    body:
+      json:
+        fismasystemid: 1003
+        functionoptionid: 1
+        datacallid: 5
+        notes: "cross-system PUT via body-asserted fismasystemid - must be blocked"
+    expect:
+      status: 403
+
   # ISSO GET /scores reaches the scoped list path. Audit fields on each
   # returned row are validated by the integration test referenced above;
   # this case pins the HTTP-layer status + content-type contract.

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -164,8 +164,10 @@ updatedScoreData: &updatedScoreData
   notes: "Updated by Emberfall test"
 
 # HHS metadata anchor (12 fields). Used to exercise the RBAC write gate:
-# OWNER writes land in DB; scoped admins are stripped on create and preserved
-# on update. Values are intentionally Star-Wars-themed to match the fixture.
+# OWNER writes land in DB. For scoped admins the 11 system attributes are
+# stripped on create and restored on update, while isso_name is OpDiv-writable
+# and takes their value on both paths. Values are intentionally Star-Wars-themed
+# to match the fixture.
 hhsExpected: &hhsExpected
   hva: true
   fips: "Moderate"
@@ -793,8 +795,9 @@ tests:
 
   # Test B — Scoped admin RBAC gate.
   #
-  # Part 1: opDivAdmin POSTs a system with HHS fields → clearHHSMetadata
-  # strips them; created record has null HHS fields.
+  # Part 1: opDivAdmin POSTs a system with HHS fields → clearUnscopedOnlyFields
+  # strips the 11 system attributes; the created record has them null. isso_name
+  # is not in that set - an OpDiv-scoped admin may write it - so it persists.
   # opdiv_id 15 = EMPIRE OpDiv, position 15 in the seed INSERT sequence
   # (_test_data_empire.sql). If this fails with 403, the seed order changed.
   - id: createFismaSystemScopedAdmin
@@ -825,7 +828,7 @@ tests:
             system_owner: null
             system_owner_email: null
             legacy: null
-            isso_name: null
+            isso_name: "Darth Vader" # OpDiv-writable, so the POSTed value persists
 
   # Part 2: OWNER sets HHS fields on system 1002 (EMPIRE OpDiv — opDivAdmin
   # holds a write grant for this system).
@@ -840,8 +843,11 @@ tests:
     expect:
       status: 204
 
-  # Part 3: opDivAdmin PUTs system 1002 with different HHS values →
-  # copyHHSMetadata overwrites them back to the stored values.
+  # Part 3: opDivAdmin PUTs system 1002 with different values. The 11 system
+  # attributes are restored from the stored row by preserveUnscopedOnlyFields;
+  # isso_name is not in that set, so the OpDiv admin's value takes effect. The
+  # isso_name sent here must differ from the value OWNER stored in Part 2, or
+  # the GET below cannot tell a successful write from a restored one.
   - url: "http://localhost:8080/api/v1/fismasystems/1002"
     method: PUT
     headers:
@@ -850,12 +856,15 @@ tests:
     body:
       json:
         <<: *system1002WithHHSData
-        hva: false # scoped-admin overwrite attempt; copyHHSMetadata restores the stored value
+        hva: false # scoped-admin overwrite attempt; the stored value is restored
         system_owner: "Impostor"
+        isso_name: "Wilhuff Tarkin" # OpDiv-writable, so this one does take effect
     expect:
       status: 204
 
-  # GET confirms OWNER's values survived the scoped admin PUT.
+  # GET confirms OWNER's values survived the scoped admin PUT, while the
+  # OpDiv admin's isso_name landed. The explicit isso_name overrides the value
+  # carried by the hhsExpected merge key.
   - url: "http://localhost:8080/api/v1/fismasystems/1002"
     method: GET
     headers:
@@ -868,6 +877,7 @@ tests:
         json:
           data:
             <<: *hhsExpected
+            isso_name: "Wilhuff Tarkin"
 
   - url: http://localhost:8080/api/v1/fismasystems
     method: GET

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -61,6 +61,10 @@ type FismaSystem struct {
 	CloudVendor       *string  `json:"cloud_vendor" db:"cloud_vendor"`
 	SystemOperator    *string  `json:"system_operator" db:"system_operator"`
 	GocoCocGoGo       *string  `json:"goco_coco_gogo" db:"goco_coco_gogo"`
+	// SystemOwner / SystemOwnerEmail are contact fields, writable by an
+	// OpDiv-scoped admin on systems in their granted OpDivs (ztmf#512). Unlike
+	// ISSOName there is no derivation fallback: the stored column is the only
+	// source of the owner's name, so clearing it just clears it.
 	SystemOwner      *string `json:"system_owner" db:"system_owner"`
 	SystemOwnerEmail *string `json:"system_owner_email" db:"system_owner_email"`
 	Legacy           *bool   `json:"legacy" db:"legacy"`
@@ -90,6 +94,29 @@ type FindFismaSystemsInput struct {
 	// their lifecycle (mid-provisioning, all-revoked, etc.).
 	RestrictToOpDivIDs bool
 	Decommissioned     bool `schema:"decommissioned"`
+	// ResolveISSOName swaps the raw isso_name column for the COALESCE that
+	// falls back to the ISSO's user record (see resolveISSONameColumn). Set by
+	// DISPLAY reads only - the list always resolves, the single-system GET
+	// resolves when the controller asks. Internal fetches that feed write
+	// paths (guardManageFismaSystem and friends) must leave it false, or a
+	// derived name enters an entity that flows toward Save and gets persisted
+	// as a stored override (ztmf#510's acceptance constraint).
+	ResolveISSOName bool
+}
+
+// resolveISSONameColumn rewrites the isso_name entry of a column list into the
+// COALESCE that resolves a single ISSO display name: HHS systems carry
+// isso_name directly; CMS systems carry only issoemail, which maps to the
+// ISSO's user record. email is unique, so the correlated subquery returns at
+// most one row. This is THE derivation - both the list and the single-system
+// GET share it (ztmf#510), so the two reads cannot disagree.
+func resolveISSONameColumn(c []string) {
+	for i := range c {
+		if c[i] == "isso_name" {
+			c[i] = "COALESCE(fismasystems.isso_name, " +
+				"(SELECT fullname FROM users WHERE LOWER(email) = LOWER(fismasystems.issoemail) LIMIT 1)) AS isso_name"
+		}
+	}
 }
 
 func FindFismaSystems(ctx context.Context, input FindFismaSystemsInput) ([]*FismaSystem, error) {
@@ -97,19 +124,10 @@ func FindFismaSystems(ctx context.Context, input FindFismaSystemsInput) ([]*Fism
 	c := []string{"fismasystems.fismasystemid as fismasystemid"}
 	c = append(c, fismaSystemColumns[1:]...)
 
-	// Resolve a single ISSO display name for the systems table. HHS systems carry
-	// isso_name directly; CMS systems carry only issoemail, which maps to the
-	// ISSO's user record - so COALESCE yields one populated name column for both
-	// populations without a per-row lookup. email is unique, so the correlated
-	// subquery returns at most one row. Read-only: the write path never sets
-	// isso_name from this, so a resolved name is never persisted back. Applied to
-	// the list only; the single-system GET returns the stored value unchanged.
-	for i := range c {
-		if c[i] == "isso_name" {
-			c[i] = "COALESCE(fismasystems.isso_name, " +
-				"(SELECT fullname FROM users WHERE LOWER(email) = LOWER(fismasystems.issoemail) LIMIT 1)) AS isso_name"
-		}
-	}
+	// The list is always a display read, so it always resolves the ISSO
+	// display name. Read-only: the write path never sets isso_name from this,
+	// so a resolved name is never persisted back.
+	resolveISSONameColumn(c)
 	sqlb := stmntBuilder.Select(c...).From("fismasystems")
 
 	// Filter decommissioned systems
@@ -158,8 +176,14 @@ func FindFismaSystem(ctx context.Context, input FindFismaSystemsInput) (*FismaSy
 		}
 	}
 
+	c := make([]string, len(fismaSystemColumns))
+	copy(c, fismaSystemColumns)
+	if input.ResolveISSOName {
+		resolveISSONameColumn(c)
+	}
+
 	sqlb := stmntBuilder.
-		Select(fismaSystemColumns...).
+		Select(c...).
 		From("fismasystems").
 		Where("fismasystems.fismasystemid=?", input.FismaSystemID)
 

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -64,7 +64,12 @@ type FismaSystem struct {
 	SystemOwner      *string `json:"system_owner" db:"system_owner"`
 	SystemOwnerEmail *string `json:"system_owner_email" db:"system_owner_email"`
 	Legacy           *bool   `json:"legacy" db:"legacy"`
-	ISSOName         *string `json:"isso_name" db:"isso_name"`
+	// ISSOName is the ISSO's display name. Unlike the system attributes above
+	// it, an OpDiv-scoped admin may write it on systems in their granted
+	// OpDivs. NULL means no stored override: the systems list read falls back
+	// to the fullname on the user record matching issoemail, so clearing this
+	// restores that derived name.
+	ISSOName *string `json:"isso_name" db:"isso_name"`
 	// Risk-based target maturity (#398). NULL = no ISSO has asserted a target
 	// yet; the UI presents the Advanced default. Written only via
 	// SaveTargetMaturity, never through Save().
@@ -358,8 +363,8 @@ func (f *FismaSystem) Save(ctx context.Context, opts ...SaveOption) (*FismaSyste
 		// Metadata fields distinguish three request states (ztmf#442):
 		//   - omitted / null (nil pointer / nil slice) -> leave the stored value
 		//     untouched, so a partial PUT never wipes importer data (and a
-		//     scoped-admin edit, whose HHS fields copyHHSMetadata has set to the
-		//     stored values, is a no-op here);
+		//     scoped-admin edit, whose unscoped-only fields the controller has
+		//     already set to the stored values, is a no-op here);
 		//   - "" (a cleared text input) / empty slice -> write NULL, so a blank
 		//     actually clears the value rather than persisting "" / an empty array;
 		//   - a value -> write it.

--- a/backend/internal/model/fismasystems_issoname_integration_test.go
+++ b/backend/internal/model/fismasystems_issoname_integration_test.go
@@ -60,8 +60,11 @@ func TestFismaSystemISSONameResolutionIntegration(t *testing.T) {
 		require.NoError(t, err)
 		_, err = conn.Exec(ctx, "UPDATE fismasystems SET isso_name='Stored Override' WHERE fismasystemid=$1", sysID)
 		require.NoError(t, err)
+		// Restore and release in ONE cleanup: a bare defer would release the
+		// pooled connection before t.Cleanup runs the restore Exec.
 		t.Cleanup(func() {
 			_, err := conn.Exec(ctx, "UPDATE fismasystems SET isso_name=NULL WHERE fismasystemid=$1", sysID)
+			conn.Release()
 			require.NoError(t, err)
 		})
 

--- a/backend/internal/model/fismasystems_issoname_integration_test.go
+++ b/backend/internal/model/fismasystems_issoname_integration_test.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ztmf#510: the list and the single-system GET must agree on isso_name for the
+// same system, whichever way that system resolves it. Seed system 1002 (SSD-EX)
+// carries isso_name NULL with an issoemail matching the Admiral Piett user
+// record, so it exercises the fallback; an in-test stored override exercises
+// the direct column. The raw (unresolved) read is asserted too, because write
+// paths depend on it staying raw: a derived name entering an entity that flows
+// toward Save would be persisted as a stored override.
+func TestFismaSystemISSONameResolutionIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	sysID := int32(1002)
+
+	listName := func(t *testing.T) *string {
+		t.Helper()
+		rows, err := FindFismaSystems(ctx, FindFismaSystemsInput{})
+		require.NoError(t, err)
+		for _, fs := range rows {
+			if fs.FismaSystemID == sysID {
+				return fs.ISSOName
+			}
+		}
+		t.Fatalf("system %d not in list results", sysID)
+		return nil
+	}
+	singleName := func(t *testing.T, resolve bool) *string {
+		t.Helper()
+		fs, err := FindFismaSystem(ctx, FindFismaSystemsInput{FismaSystemID: &sysID, ResolveISSOName: resolve})
+		require.NoError(t, err)
+		require.NotNil(t, fs)
+		return fs.ISSOName
+	}
+
+	t.Run("FallbackSystemAgreesAcrossReads", func(t *testing.T) {
+		// seed state: isso_name NULL, issoemail -> Admiral Piett's user record
+		ln, sn := listName(t), singleName(t, true)
+		require.NotNil(t, ln, "list must resolve the fallback name")
+		require.NotNil(t, sn, "resolved single GET must resolve the fallback name")
+		assert.Equal(t, "Admiral Piett", *ln)
+		assert.Equal(t, *ln, *sn, "list and single-system GET must agree (ztmf#510)")
+
+		assert.Nil(t, singleName(t, false),
+			"the raw read must return the stored NULL - write paths depend on it")
+	})
+
+	t.Run("StoredSystemAgreesAcrossReads", func(t *testing.T) {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.Exec(ctx, "UPDATE fismasystems SET isso_name='Stored Override' WHERE fismasystemid=$1", sysID)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, err := conn.Exec(ctx, "UPDATE fismasystems SET isso_name=NULL WHERE fismasystemid=$1", sysID)
+			require.NoError(t, err)
+		})
+
+		ln, sn := listName(t), singleName(t, true)
+		require.NotNil(t, ln)
+		require.NotNil(t, sn)
+		assert.Equal(t, "Stored Override", *ln, "a stored name must win over the fallback")
+		assert.Equal(t, *ln, *sn, "list and single-system GET must agree (ztmf#510)")
+
+		raw := singleName(t, false)
+		require.NotNil(t, raw)
+		assert.Equal(t, "Stored Override", *raw)
+	})
+}

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -202,11 +202,30 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 	sqlb := stmntBuilder.
 		Update("public.scores").
 		Set("status", "done").
-		Where("scoreid=?", s.ScoreID).
+		// Keep the no-op guard in the write predicate as well as above. Two
+		// requests can both load not_started before either reaches Confirm; only
+		// the first must be allowed to update and create an audit event.
+		Where("scoreid=? AND status <> ?", s.ScoreID, "done").
 		Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 
 	confirmed, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
 	if err != nil {
+		// A conditional UPDATE that lost the race to another confirmer returns
+		// no row. Reload to distinguish that successful idempotent outcome from
+		// a score that was actually deleted, which remains ErrNoData/404.
+		if errors.Is(err, ErrNoData) {
+			current, findErr := FindScoreByID(ctx, s.ScoreID)
+			if findErr != nil {
+				return nil, findErr
+			}
+			if current.Status == "done" {
+				if at, by := lookupScoreAudit(ctx, current.ScoreID); at != nil && by != nil {
+					current.LastEditedAt = at
+					current.LastEditedBy = by
+				}
+				return current, nil
+			}
+		}
 		return confirmed, err
 	}
 

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -59,8 +59,35 @@ func (s *Score) AuditInfo() (*time.Time, *AuditRef) {
 	return s.LastEditedAt, s.LastEditedBy
 }
 
-func (s *Score) Save(ctx context.Context) (*Score, error) {
+// scoreSaveConfig carries request-shape context that is not part of the
+// persisted entity.
+type scoreSaveConfig struct {
+	current *Score
+}
+
+// ScoreSaveOption configures a Score.Save call.
+type ScoreSaveOption func(*scoreSaveConfig)
+
+// WithCurrentScore hands Save the stored row the caller has already loaded, so
+// the no-op comparison does not read it a second time. The update path
+// authorizes against the stored row, which means the controller loads it on
+// every PUT; the questionnaire PUTs on each Next click, so the duplicate read
+// would land on the hottest write path in the app.
+//
+// The row passed here MUST be the one Save is about to update, read through
+// FindScoreByID. Passing a stale or unrelated row would make the no-op
+// comparison lie about whether the answer changed.
+func WithCurrentScore(current *Score) ScoreSaveOption {
+	return func(c *scoreSaveConfig) { c.current = current }
+}
+
+func (s *Score) Save(ctx context.Context, opts ...ScoreSaveOption) (*Score, error) {
 	var sqlb SqlBuilder
+
+	cfg := &scoreSaveConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
 
 	if err := s.validate(ctx); err != nil {
 		return nil, err
@@ -88,7 +115,7 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 	// controller writes 204 today but still encodes the body, so the
 	// response is observable to clients that parse 204 bodies.
 	if s.ScoreID != 0 {
-		if same, current, err := scoreUpdateIsNoOp(ctx, s); err != nil {
+		if same, current, err := scoreUpdateIsNoOp(ctx, s, cfg.current); err != nil {
 			return nil, err
 		} else if same {
 			if s.FunctionOption != nil {
@@ -118,20 +145,31 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, "done").
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	} else {
+		// fismasystemid and datacallid are deliberately NOT in the SET list.
+		// Saving an answer must never move the row to another system or
+		// another cycle: those are the two columns that decide who may write
+		// the row and which deadline applies to it, so letting a request body
+		// rewrite them turns an answer edit into a reparenting primitive.
+		// The controller authorizes an update against the stored row and pins
+		// both values onto the receiver before calling Save.
 		setCols := squirrel.Eq{
-			"fismasystemid":    s.FismaSystemID,
 			"notes":            s.Notes,
 			"functionoptionid": s.FunctionOptionID,
-			"datacallid":       s.DataCallID,
 			"status":           "done",
 		}
 		if s.NotesIsAISummary != nil {
 			setCols["notes_is_ai_summary"] = *s.NotesIsAISummary
 		}
+		// Bind the write to the row the caller was authorized against, not to
+		// the id alone. The controller loads the row and pins these two fields
+		// onto the receiver before calling Save; matching on them here means a
+		// future caller that forgets to pin cannot write a row it did not
+		// authorize - it updates zero rows and fails as ErrNoData rather than
+		// succeeding against someone else's answer.
 		sqlb = stmntBuilder.
 			Update("public.scores").
 			SetMap(setCols).
-			Where("scoreid=?", s.ScoreID).
+			Where("scoreid=? AND fismasystemid=? AND datacallid=?", s.ScoreID, s.FismaSystemID, s.DataCallID).
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	}
 
@@ -271,10 +309,16 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 // Returns ErrNotData when the row is missing so the caller can fail
 // cleanly without paying a second round trip through the UPDATE that
 // would also fail.
-func scoreUpdateIsNoOp(ctx context.Context, incoming *Score) (bool, *Score, error) {
-	current, err := FindScoreByID(ctx, incoming.ScoreID)
-	if err != nil {
-		return false, nil, err
+// A non-nil preloaded row is used as-is instead of re-reading: the update path
+// authorizes against the stored row, so the controller has already fetched it.
+func scoreUpdateIsNoOp(ctx context.Context, incoming, preloaded *Score) (bool, *Score, error) {
+	current := preloaded
+	if current == nil {
+		var err error
+		current, err = FindScoreByID(ctx, incoming.ScoreID)
+		if err != nil {
+			return false, nil, err
+		}
 	}
 
 	return scoresEqualForUpdate(current, incoming), current, nil
@@ -324,6 +368,18 @@ func scoresEqualForUpdate(current, incoming *Score) bool {
 	if current == nil || incoming == nil {
 		return false
 	}
+	// fismasystemid and datacallid are compared defensively, not because a PUT
+	// can change them: Save omits both from the UPDATE's SET list and the
+	// controller pins them from the stored row before calling Save. They stay
+	// here so a receiver that somehow disagrees with the stored row is never
+	// treated as a no-op, which would silently skip a write the caller asked
+	// for.
+	//
+	// Note what this does NOT do: a mismatch only fails the equality check, so
+	// the write proceeds as a normal partial update of the answer fields. It
+	// does not report the disagreement to the caller. Turning that into an
+	// explicit error is a deliberate follow-up rather than something this
+	// comparison is doing today.
 	if current.FismaSystemID != incoming.FismaSystemID ||
 		current.DataCallID != incoming.DataCallID ||
 		current.FunctionOptionID != incoming.FunctionOptionID {

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -40,9 +40,16 @@ type Score struct {
 	NotesIsAISummary *bool           `json:"notes_is_ai_summary" db:"notes_is_ai_summary"`
 	FunctionOptionID int32           `json:"functionoptionid"`
 	DataCallID       int32           `json:"datacallid"`
-	FunctionOption   *FunctionOption `json:"functionoption,omitempty"`
-	LastEditedAt     *time.Time      `json:"last_edited_at,omitempty"`
-	LastEditedBy     *AuditRef       `json:"last_edited_by,omitempty"`
+	// Status is the answer's review state for its data call: 'not_started' for
+	// a row carried forward by copyPreviousScores and untouched this cycle,
+	// 'done' once saved or confirmed this cycle (ztmf#435, values pinned by
+	// migration 0048's CHECK). Exposed on the read path so the questionnaire
+	// marks carried-forward answers from the SAME fact the Data Call Progress
+	// count reads, instead of inferring it from the absence of an edit event.
+	Status         string          `json:"status"`
+	FunctionOption *FunctionOption `json:"functionoption,omitempty"`
+	LastEditedAt   *time.Time      `json:"last_edited_at,omitempty"`
+	LastEditedBy   *AuditRef       `json:"last_edited_by,omitempty"`
 }
 
 // AuditInfo satisfies Auditable. Returned pointers may be nil if the row has
@@ -109,7 +116,7 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			Insert("public.scores").
 			Columns("fismasystemid", "notes", "notes_is_ai_summary", "functionoptionid", "datacallid", "status").
 			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, "done").
-			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid")
+			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	} else {
 		setCols := squirrel.Eq{
 			"fismasystemid":    s.FismaSystemID,
@@ -125,7 +132,7 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 			Update("public.scores").
 			SetMap(setCols).
 			Where("scoreid=?", s.ScoreID).
-			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid")
+			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	}
 
 	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
@@ -156,6 +163,48 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 		}
 	}
 	return saved, nil
+}
+
+// Confirm records that the user affirmed this carried-forward answer as still
+// accurate for the current data call: it flips status to 'done' and nothing
+// else. It exists because agreement changes no answer field, and Save's no-op
+// guard (correctly) refuses to write in that case (ztmf#412/#413) - so
+// "reviewed and agreed" needs its own explicit, attributable write.
+//
+// Deliberately narrow: sets ONLY status - notably not notes_is_ai_summary,
+// since agreeing with an AI-drafted justification is not authoring it. Runs
+// through queryRow so recordEvent stamps the confirming user as the editor.
+// Idempotent on an already-'done' row.
+//
+// The receiver must be a row loaded by FindScoreByID, not a client-supplied
+// body: DataCallID drives the deadline check, and the controller authorizes
+// against the loaded FismaSystemID rather than an asserted one.
+func (s *Score) Confirm(ctx context.Context) (*Score, error) {
+	if err := s.validateDeadline(ctx); err != nil {
+		return nil, err
+	}
+
+	sqlb := stmntBuilder.
+		Update("public.scores").
+		Set("status", "done").
+		Where("scoreid=?", s.ScoreID).
+		Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
+
+	confirmed, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
+	if err != nil {
+		return confirmed, err
+	}
+
+	// Same read-back as Save: project the canonical event row rather than
+	// synthesizing a timestamp, so the response cannot advertise an editor a
+	// subsequent GET would not confirm. Both-or-neither.
+	if confirmed != nil {
+		if at, by := lookupScoreAudit(ctx, confirmed.ScoreID); at != nil && by != nil {
+			confirmed.LastEditedAt = at
+			confirmed.LastEditedBy = by
+		}
+	}
+	return confirmed, nil
 }
 
 // scoreUpdateIsNoOp reports whether the incoming Score's answer fields
@@ -189,29 +238,48 @@ func (s *Score) Save(ctx context.Context) (*Score, error) {
 // cleanly without paying a second round trip through the UPDATE that
 // would also fail.
 func scoreUpdateIsNoOp(ctx context.Context, incoming *Score) (bool, *Score, error) {
+	current, err := FindScoreByID(ctx, incoming.ScoreID)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return scoresEqualForUpdate(current, incoming), current, nil
+}
+
+// FindScoreByID reads one score row by id, on the read-only path (a plain
+// conn.QueryRow, never queryRow, so no event is recorded for a lookup).
+//
+// Shared by scoreUpdateIsNoOp, which needs the current answer fields to compare
+// against, and by ConfirmScore, which needs the row's real fismasystemid so the
+// controller can authorize against it rather than against a client-asserted one.
+//
+// Returns ErrNoData when the row is missing so callers can fail cleanly without
+// paying a second round trip through a write that would also fail.
+func FindScoreByID(ctx context.Context, scoreID int32) (*Score, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
-		return false, nil, trapError(err)
+		return nil, trapError(err)
 	}
 	defer conn.Release()
 
 	current := &Score{}
 	err = conn.QueryRow(ctx, `
 		SELECT scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) AS datecalculated,
-		       notes, notes_is_ai_summary, functionoptionid, datacallid
+		       notes, notes_is_ai_summary, functionoptionid, datacallid, status
 		FROM scores WHERE scoreid = $1
-	`, incoming.ScoreID).Scan(
+	`, scoreID).Scan(
 		&current.ScoreID, &current.FismaSystemID, &current.DateCalculated,
 		&current.Notes, &current.NotesIsAISummary, &current.FunctionOptionID, &current.DataCallID,
+		&current.Status,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			return false, nil, ErrNoData
+			return nil, ErrNoData
 		}
-		return false, nil, trapError(err)
+		return nil, trapError(err)
 	}
 
-	return scoresEqualForUpdate(current, incoming), current, nil
+	return current, nil
 }
 
 // scoresEqualForUpdate is the pure comparison used by scoreUpdateIsNoOp,
@@ -292,6 +360,14 @@ func (s *Score) validate(ctx context.Context) error {
 		return ErrNotesTooLong
 	}
 
+	return s.validateDeadline(ctx)
+}
+
+// validateDeadline rejects a write to a closed data call for anyone but an
+// admin. Extracted from validate so Confirm enforces the same rule: confirming
+// a carried-forward answer is a write to the cycle like any other, and must not
+// become a post-deadline loophole for the tiers that cannot save.
+func (s *Score) validateDeadline(ctx context.Context) error {
 	dataCall, err := FindDataCallByID(ctx, s.DataCallID)
 	if err != nil {
 		return err
@@ -371,7 +447,7 @@ type FindScoresInput struct {
 func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 
 	sqlb := stmntBuilder.
-		Select("scoreid, scores.fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, scores.notes_is_ai_summary, scores.functionoptionid, scores.datacallid").
+		Select("scoreid, scores.fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, scores.notes_is_ai_summary, scores.functionoptionid, scores.datacallid, scores.status").
 		From("scores")
 
 	if input.contains("functionoption") {
@@ -428,7 +504,7 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 
 	return query(ctx, sqlb, func(row pgx.CollectableRow) (*Score, error) {
 		score := Score{}
-		fields := []any{&score.ScoreID, &score.FismaSystemID, &score.DateCalculated, &score.Notes, &score.NotesIsAISummary, &score.FunctionOptionID, &score.DataCallID}
+		fields := []any{&score.ScoreID, &score.FismaSystemID, &score.DateCalculated, &score.Notes, &score.NotesIsAISummary, &score.FunctionOptionID, &score.DataCallID, &score.Status}
 		if input.contains("functionoption") {
 			score.FunctionOption = &FunctionOption{}
 			fields = append(fields, &score.FunctionOption.FunctionOptionID, &score.FunctionOption.FunctionID, &score.FunctionOption.Score, &score.FunctionOption.OptionName, &score.FunctionOption.Description)

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -184,6 +184,21 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 		return nil, err
 	}
 
+	// Audit-preserving no-op: once a score is done, confirming it again must
+	// not move last_edited_by / last_edited_at to the most recent caller. The
+	// controller loads this receiver through FindScoreByID immediately before
+	// calling Confirm, so its persisted Status is the source of truth. Return
+	// the current row with the same audit projection used after a real write,
+	// preserving the endpoint's idempotent 200 response without recording a
+	// second event.
+	if s.Status == "done" {
+		if at, by := lookupScoreAudit(ctx, s.ScoreID); at != nil && by != nil {
+			s.LastEditedAt = at
+			s.LastEditedBy = by
+		}
+		return s, nil
+	}
+
 	sqlb := stmntBuilder.
 		Update("public.scores").
 		Set("status", "done").

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -1289,3 +1289,192 @@ func TestFindPreviousDataCallByDeadlineIntegration(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNoData,
 		"a call before all cycles has no previous, not a future one")
 }
+
+// TestConfirmScoreIntegration pins the explicit-confirm write path behind the
+// questionnaire's "Confirm this answer is still accurate" button.
+//
+// copyPreviousScores seeds the new cycle with status = 'not_started' rows,
+// agreeing with one produces no change to the answer fields, and the ordinary
+// Save path (correctly) refuses to record agreement as a write. Confirm must:
+//   - flip status to 'done' and increment questionsupdated by exactly 1,
+//   - leave every answer field byte-identical - including notes_is_ai_summary,
+//     which the ordinary PUT forces to false on edit,
+//   - stamp the confirming user's identity and timestamp via the same
+//     recordEvent -> lookupScoreAudit path Save uses,
+//   - be idempotent on an already-'done' row,
+//   - enforce the same deadline rule as Save (non-admins cannot confirm into a
+//     closed cycle).
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestConfirmScoreIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// Same two-cycle scaffold as TestFindScoreProgressIntegration: the new
+	// cycle must be the global-latest deadline so findPreviousDataCall
+	// resolves our marker cycle as its predecessor.
+	var prevDC, newDC int32
+	var maxDeadline time.Time
+	err = conn.QueryRow(ctx, `SELECT COALESCE(MAX(deadline), NOW()) FROM datacalls`).Scan(&maxDeadline)
+	require.NoError(t, err)
+	suffix := time.Now().UnixNano()
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $3::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%sconfirm_prev_%d", integrationTestPrefix, suffix), time.Now().Add(-2*time.Hour), maxDeadline.Add(24*time.Hour)).Scan(&prevDC)
+	require.NoError(t, err)
+
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, $2::timestamptz, $3::timestamptz)
+		RETURNING datacallid
+	`, fmt.Sprintf("%sconfirm_new_%d", integrationTestPrefix, suffix), time.Now().Add(-1*time.Hour), maxDeadline.Add(48*time.Hour)).Scan(&newDC)
+	require.NoError(t, err)
+
+	// Borrow a valid, applicable (system, functionoption) pair from seeded
+	// data so the progress assertions below count our row (see the progress
+	// integration test for why applicability matters here).
+	var fismaSystemID, functionOptionID int32
+	err = conn.QueryRow(ctx, `
+		SELECT s.fismasystemid, s.functionoptionid
+		FROM scores s
+		INNER JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		INNER JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+		INNER JOIN functions f ON f.functionid = fo.functionid
+		INNER JOIN datacenterenvironments dce
+			ON dce.datacenterenvironment = fs.datacenterenvironment
+			AND dce.scoring_key = f.datacenterenvironment
+		INNER JOIN questions q ON q.questionid = f.questionid
+		WHERE fs.decommissioned = FALSE
+		LIMIT 1
+	`).Scan(&fismaSystemID, &functionOptionID)
+	require.NoError(t, err, "need one seeded score on an active system whose function is applicable to its environment")
+
+	// Prior-cycle answer flagged as an AI summary, rolled forward the way
+	// datacall creation does. The flag is the tripwire for "Confirm touched an
+	// answer field it must not".
+	notes := "confirm integration marker"
+	_, err = conn.Exec(ctx, `
+		INSERT INTO scores (fismasystemid, functionoptionid, datacallid, notes, notes_is_ai_summary)
+		VALUES ($1, $2, $3, $4, TRUE)
+	`, fismaSystemID, functionOptionID, prevDC, notes)
+	require.NoError(t, err)
+
+	if _, err := copyPreviousScores(ctx, newDC); err != nil {
+		t.Fatalf("copyPreviousScores: %v", err)
+	}
+
+	var copiedScoreID int32
+	err = conn.QueryRow(ctx, `
+		SELECT scoreid FROM scores
+		WHERE datacallid = $1 AND fismasystemid = $2 AND functionoptionid = $3
+	`, newDC, fismaSystemID, functionOptionID).Scan(&copiedScoreID)
+	require.NoError(t, err, "the copied row must exist in the new datacall")
+
+	progressFor := func() *ScoreProgress {
+		t.Helper()
+		rows, err := FindScoreProgress(ctx, FindScoreProgressInput{
+			DataCallID:    &newDC,
+			FismaSystemID: &fismaSystemID,
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		return rows[0]
+	}
+
+	// Phase 1: the carried row is not_started and counts as answered but not
+	// updated - the state the questionnaire's badge must render from alone,
+	// with no data migration.
+	carried, err := FindScoreByID(ctx, copiedScoreID)
+	require.NoError(t, err)
+	assert.Equal(t, "not_started", carried.Status,
+		"copyPreviousScores must seed the carried row as not_started")
+	assert.Equal(t, int32(0), progressFor().QuestionsUpdated,
+		"a carried-forward answer must not count as updated before it is confirmed")
+
+	// The confirmer must be a real seeded user: recordEvent writes
+	// events.userid with an FK to users and swallows the insert error on
+	// violation, so a fabricated UUID would leave no event and the identity
+	// assertion below would fail for the wrong reason.
+	var confirmerID, confirmerRole string
+	err = conn.QueryRow(ctx, `
+		SELECT userid, role FROM users ORDER BY (role = 'OWNER') DESC LIMIT 1
+	`).Scan(&confirmerID, &confirmerRole)
+	require.NoError(t, err, "need at least one seeded user to attribute the confirm to")
+	confirmerCtx := UserToContext(ctx, &User{UserID: confirmerID, Role: confirmerRole})
+
+	// Phase 2: confirm. Status flips, answer fields do not, the confirmer is
+	// stamped, progress moves by exactly one.
+	confirmed, err := carried.Confirm(confirmerCtx)
+	require.NoError(t, err, "confirming a carried-forward answer must succeed")
+	assert.Equal(t, "done", confirmed.Status)
+	assert.Equal(t, notes, derefString(confirmed.Notes),
+		"confirm must not modify the notes")
+	if assert.NotNil(t, confirmed.NotesIsAISummary, "notes_is_ai_summary must survive a confirm") {
+		assert.True(t, *confirmed.NotesIsAISummary,
+			"confirm is agreement, not authorship - the AI-summary flag must not be cleared")
+	}
+	assert.Equal(t, carried.FunctionOptionID, confirmed.FunctionOptionID)
+	if assert.NotNil(t, confirmed.LastEditedBy, "the confirming user must be stamped as the editor") {
+		assert.Equal(t, confirmerID, confirmed.LastEditedBy.UserID)
+	}
+	if assert.NotNil(t, confirmed.LastEditedAt) {
+		assert.WithinDuration(t, time.Now(), *confirmed.LastEditedAt, 5*time.Minute)
+	}
+
+	after := progressFor()
+	assert.Equal(t, int32(1), after.QuestionsUpdated,
+		"a confirmed answer must count as updated")
+	assert.Equal(t, int32(1), after.QuestionsAnswered)
+
+	// Phase 3: idempotency. Confirming a done row is a harmless re-affirmation.
+	reread, err := FindScoreByID(ctx, copiedScoreID)
+	require.NoError(t, err)
+	reconfirmed, err := reread.Confirm(confirmerCtx)
+	require.NoError(t, err, "confirming an already-done row must not error")
+	assert.Equal(t, "done", reconfirmed.Status)
+	assert.Equal(t, int32(1), progressFor().QuestionsUpdated,
+		"re-confirming must not double-count")
+
+	// Phase 4: the deadline rule. A non-admin cannot confirm into a closed
+	// cycle - same guard as Save, so confirm is not a post-deadline loophole.
+	var pastDC int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO datacalls (datacall, datecreated, deadline)
+		VALUES ($1, NOW() - INTERVAL '30 days', NOW() - INTERVAL '1 day')
+		RETURNING datacallid
+	`, fmt.Sprintf("%sconfirm_past_%d", integrationTestPrefix, suffix)).Scan(&pastDC)
+	require.NoError(t, err)
+
+	var pastScoreID int32
+	err = conn.QueryRow(ctx, `
+		INSERT INTO scores (fismasystemid, functionoptionid, datacallid, notes)
+		VALUES ($1, $2, $3, 'past-cycle row')
+		RETURNING scoreid
+	`, fismaSystemID, functionOptionID, pastDC).Scan(&pastScoreID)
+	require.NoError(t, err)
+
+	pastRow, err := FindScoreByID(ctx, pastScoreID)
+	require.NoError(t, err)
+	// No user in context = non-admin per validateDeadline.
+	_, err = pastRow.Confirm(ctx)
+	assert.ErrorIs(t, err, ErrPastDeadline,
+		"confirming into a closed cycle without admin must trip the deadline guard")
+
+	// FindScoreByID contract: a missing row is ErrNoData, which the controller
+	// maps to 404.
+	_, err = FindScoreByID(ctx, -1)
+	assert.ErrorIs(t, err, ErrNoData)
+}

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -1404,6 +1404,11 @@ func TestConfirmScoreIntegration(t *testing.T) {
 		"copyPreviousScores must seed the carried row as not_started")
 	assert.Equal(t, int32(0), progressFor().QuestionsUpdated,
 		"a carried-forward answer must not count as updated before it is confirmed")
+	// Model a concurrent request that loaded the same not_started row before
+	// the first confirmer's write. Using this stale snapshot later makes the
+	// race deterministic without scheduler-dependent goroutines.
+	staleConcurrentRead, err := FindScoreByID(ctx, copiedScoreID)
+	require.NoError(t, err)
 
 	// The confirmer must be a real seeded user: recordEvent writes
 	// events.userid with an FK to users and swallows the insert error on
@@ -1440,9 +1445,10 @@ func TestConfirmScoreIntegration(t *testing.T) {
 		"a confirmed answer must count as updated")
 	assert.Equal(t, int32(1), after.QuestionsAnswered)
 
-	// Phase 3: audit-preserving idempotency. A different user confirming the
-	// already-done row gets the same successful response, but must not create an
-	// event or replace the original confirmer as the displayed editor.
+	// Phase 3: atomic, audit-preserving idempotency. A different user whose
+	// request loaded not_started before the first write still gets the same
+	// successful response, but must not create an event or replace the original
+	// confirmer as the displayed editor.
 	eventsAfterFirstConfirm := countScoreEvents(t, ctx, conn, copiedScoreID)
 	var secondConfirmerID, secondConfirmerRole string
 	err = conn.QueryRow(ctx, `
@@ -1451,9 +1457,7 @@ func TestConfirmScoreIntegration(t *testing.T) {
 	require.NoError(t, err, "need a second seeded user to verify re-confirm does not move attribution")
 	secondConfirmerCtx := UserToContext(ctx, &User{UserID: secondConfirmerID, Role: secondConfirmerRole})
 
-	reread, err := FindScoreByID(ctx, copiedScoreID)
-	require.NoError(t, err)
-	reconfirmed, err := reread.Confirm(secondConfirmerCtx)
+	reconfirmed, err := staleConcurrentRead.Confirm(secondConfirmerCtx)
 	require.NoError(t, err, "confirming an already-done row must not error")
 	assert.Equal(t, "done", reconfirmed.Status)
 	assert.Equal(t, eventsAfterFirstConfirm, countScoreEvents(t, ctx, conn, copiedScoreID),
@@ -1468,6 +1472,15 @@ func TestConfirmScoreIntegration(t *testing.T) {
 	}
 	assert.Equal(t, int32(1), progressFor().QuestionsUpdated,
 		"re-confirming must not double-count")
+
+	// A normal retry that reads after the first write exercises the fast
+	// in-memory status guard and must preserve the same invariant.
+	freshDone, err := FindScoreByID(ctx, copiedScoreID)
+	require.NoError(t, err)
+	_, err = freshDone.Confirm(secondConfirmerCtx)
+	require.NoError(t, err)
+	assert.Equal(t, eventsAfterFirstConfirm, countScoreEvents(t, ctx, conn, copiedScoreID),
+		"a fresh retry must also remain write-free")
 
 	// Phase 4: the deadline rule. A non-admin cannot confirm into a closed
 	// cycle - same guard as Save, so confirm is not a post-deadline loophole.

--- a/backend/internal/model/scores_integration_test.go
+++ b/backend/internal/model/scores_integration_test.go
@@ -1301,7 +1301,8 @@ func TestFindPreviousDataCallByDeadlineIntegration(t *testing.T) {
 //     which the ordinary PUT forces to false on edit,
 //   - stamp the confirming user's identity and timestamp via the same
 //     recordEvent -> lookupScoreAudit path Save uses,
-//   - be idempotent on an already-'done' row,
+//   - be idempotent on an already-'done' row without recording another event
+//     or moving the displayed editor to the second confirmer,
 //   - enforce the same deadline rule as Save (non-admins cannot confirm into a
 //     closed cycle).
 //
@@ -1439,12 +1440,32 @@ func TestConfirmScoreIntegration(t *testing.T) {
 		"a confirmed answer must count as updated")
 	assert.Equal(t, int32(1), after.QuestionsAnswered)
 
-	// Phase 3: idempotency. Confirming a done row is a harmless re-affirmation.
+	// Phase 3: audit-preserving idempotency. A different user confirming the
+	// already-done row gets the same successful response, but must not create an
+	// event or replace the original confirmer as the displayed editor.
+	eventsAfterFirstConfirm := countScoreEvents(t, ctx, conn, copiedScoreID)
+	var secondConfirmerID, secondConfirmerRole string
+	err = conn.QueryRow(ctx, `
+		SELECT userid, role FROM users WHERE userid <> $1 ORDER BY userid LIMIT 1
+	`, confirmerID).Scan(&secondConfirmerID, &secondConfirmerRole)
+	require.NoError(t, err, "need a second seeded user to verify re-confirm does not move attribution")
+	secondConfirmerCtx := UserToContext(ctx, &User{UserID: secondConfirmerID, Role: secondConfirmerRole})
+
 	reread, err := FindScoreByID(ctx, copiedScoreID)
 	require.NoError(t, err)
-	reconfirmed, err := reread.Confirm(confirmerCtx)
+	reconfirmed, err := reread.Confirm(secondConfirmerCtx)
 	require.NoError(t, err, "confirming an already-done row must not error")
 	assert.Equal(t, "done", reconfirmed.Status)
+	assert.Equal(t, eventsAfterFirstConfirm, countScoreEvents(t, ctx, conn, copiedScoreID),
+		"re-confirming must not append an audit event")
+	if assert.NotNil(t, reconfirmed.LastEditedBy, "the original confirmer must remain the editor") {
+		assert.Equal(t, confirmerID, reconfirmed.LastEditedBy.UserID)
+		assert.NotEqual(t, secondConfirmerID, reconfirmed.LastEditedBy.UserID)
+	}
+	if assert.NotNil(t, reconfirmed.LastEditedAt, "the original confirmation timestamp must remain visible") &&
+		assert.NotNil(t, confirmed.LastEditedAt) {
+		assert.Equal(t, *confirmed.LastEditedAt, *reconfirmed.LastEditedAt)
+	}
 	assert.Equal(t, int32(1), progressFor().QuestionsUpdated,
 		"re-confirming must not double-count")
 

--- a/backend/internal/model/scores_writeauthz_integration_test.go
+++ b/backend/internal/model/scores_writeauthz_integration_test.go
@@ -1,0 +1,118 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A PUT must never move a score row to another system or another data call.
+// Both columns decide who may write the row and which deadline applies to it,
+// so a request body that rewrites them turns an answer edit into a reparenting
+// primitive (ztmf-misc#263). Save omits both from the UPDATE's SET list; this
+// pins that at the model layer, independent of whatever the controller passes.
+func TestScoreSaveCannotReparentIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	purgeIntegrationTestRows(t)
+	defer purgeIntegrationTestRows(t)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	fismaSystemID, functionOptionID := anyExistingFunctionOption(t, ctx)
+	dataCallID := ensureFutureDataCall(t, ctx)
+
+	// A second system and a second data call to attempt the move toward.
+	var otherSystemID int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT fismasystemid FROM fismasystems
+		WHERE fismasystemid <> $1 AND COALESCE(decommissioned,false) = false
+		LIMIT 1
+	`, fismaSystemID).Scan(&otherSystemID), "need a second system to attempt a reparent")
+	require.NotEqual(t, fismaSystemID, otherSystemID)
+
+	var otherDataCallID int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT datacallid FROM datacalls WHERE datacallid <> $1 LIMIT 1
+	`, dataCallID).Scan(&otherDataCallID), "need a second data call to attempt a move")
+	require.NotEqual(t, dataCallID, otherDataCallID)
+
+	owner := UserToContext(ctx, &User{
+		UserID:   "11111111-1111-1111-1111-111111111111",
+		Email:    "Grand.Moff@DeathStar.Empire",
+		FullName: "Grand Moff Tarkin",
+		Role:     "OWNER",
+	})
+
+	notes := "original answer"
+	created, err := (&Score{
+		FismaSystemID:    fismaSystemID,
+		FunctionOptionID: functionOptionID,
+		DataCallID:       dataCallID,
+		Notes:            &notes,
+	}).Save(owner)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	scoreID := created.ScoreID
+	defer func() { _, _ = conn.Exec(ctx, `DELETE FROM scores WHERE scoreid=$1`, scoreID) }()
+
+	// The attack shape: same scoreid, but the receiver names a different
+	// system and a different cycle, alongside a real answer change so the
+	// write is not skipped as a no-op.
+	//
+	// The UPDATE is bound to (scoreid, fismasystemid, datacallid), so a
+	// receiver disagreeing with the stored row matches nothing and fails
+	// rather than silently applying the answer half of the write. That is the
+	// model-layer defense: it holds even if a caller forgets to pin the two
+	// fields from storage, which is the mistake that made ztmf-misc#263
+	// reachable in the first place.
+	moved := "answer rewritten by the reparent attempt"
+	_, err = (&Score{
+		ScoreID:          scoreID,
+		FismaSystemID:    otherSystemID,
+		DataCallID:       otherDataCallID,
+		FunctionOptionID: functionOptionID,
+		Notes:            &moved,
+	}).Save(owner)
+	require.Error(t, err,
+		"a Save whose receiver disagrees with the stored row must fail, not partially apply")
+
+	var gotSystem, gotCall int32
+	var gotNotes *string
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT fismasystemid, datacallid, notes FROM scores WHERE scoreid=$1
+	`, scoreID).Scan(&gotSystem, &gotCall, &gotNotes))
+
+	assert.Equal(t, fismaSystemID, gotSystem,
+		"the row must not move to the system named in the request (ztmf-misc#263)")
+	assert.Equal(t, dataCallID, gotCall,
+		"the row must not move to the data call named in the request (ztmf-misc#263)")
+	require.NotNil(t, gotNotes)
+	assert.Equal(t, notes, *gotNotes,
+		"a refused reparent must leave the original answer intact, not apply the new notes")
+
+	// The legitimate shape - same row, correct parents, changed answer - still
+	// works. Without this the test above would pass against a Save that simply
+	// never updates anything.
+	legit := "answer updated legitimately"
+	_, err = (&Score{
+		ScoreID:          scoreID,
+		FismaSystemID:    fismaSystemID,
+		DataCallID:       dataCallID,
+		FunctionOptionID: functionOptionID,
+		Notes:            &legit,
+	}).Save(owner)
+	require.NoError(t, err)
+
+	require.NoError(t, conn.QueryRow(ctx, `SELECT notes FROM scores WHERE scoreid=$1`, scoreID).Scan(&gotNotes))
+	require.NotNil(t, gotNotes)
+	assert.Equal(t, legit, *gotNotes, "a correctly-parented save must still apply")
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -475,6 +475,11 @@ components:
         system_operator:
           type: string
         system_owner:
+          description: |-
+            SystemOwner / SystemOwnerEmail are contact fields, writable by an
+            OpDiv-scoped admin on systems in their granted OpDivs (ztmf#512). Unlike
+            ISSOName there is no derivation fallback: the stored column is the only
+            source of the owner's name, so clearing it just clears it.
           type: string
         system_owner_email:
           type: string

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -639,6 +639,15 @@ components:
           type: boolean
         scoreid:
           type: integer
+        status:
+          description: |-
+            Status is the answer's review state for its data call: 'not_started' for
+            a row carried forward by copyPreviousScores and untouched this cycle,
+            'done' once saved or confirmed this cycle (ztmf#435, values pinned by
+            migration 0048's CHECK). Exposed on the read path so the questionnaire
+            marks carried-forward answers from the SAME fact the Data Call Progress
+            count reads, instead of inferring it from the absence of an edit event.
+          type: string
       type: object
     model.ScoreAggregate:
       properties:
@@ -2699,6 +2708,45 @@ paths:
       security:
       - bearerAuth: []
       summary: Create or update a score
+      tags:
+      - scores
+  /scores/{scoreid}/confirm:
+    put:
+      parameters:
+      - description: Score ID
+        in: path
+        name: scoreid
+        required: true
+        schema:
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-model_Score'
+          description: OK
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Internal Server Error
+      security:
+      - bearerAuth: []
+      summary: Confirm a carried-forward score without changing it
       tags:
       - scores
   /scores/aggregate:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -451,6 +451,12 @@ components:
             (the epic rule: never coerce a missing value to false/No).
           type: boolean
         isso_name:
+          description: |-
+            ISSOName is the ISSO's display name. Unlike the system attributes above
+            it, an OpDiv-scoped admin may write it on systems in their granted
+            OpDivs. NULL means no stored override: the systems list read falls back
+            to the fullname on the user record matching issoemail, so clearing this
+            restores that derived name.
           type: string
         issoemail:
           type: string


### PR DESCRIPTION
Combines the four reviewed backend PRs into a single branch so the FY2026 work merges and deploys once instead of four times. No code changes beyond what was already reviewed - the commits are replayed as-authored, with authorship preserved.

## What is in here

| Original | Author | What it does |
|---|---|---|
| #511 | @jsos3-cms | Lets OpDiv-scoped admins write the ISSO name |
| #514 | @danielbowne | Owner contact fields OpDiv-writable; one shared isso_name derivation across both reads (closes #512, #510) |
| #515 | @costacalvin | Exposes score status on reads and adds an explicit confirm endpoint (closes ztmf-ui#659 backend half) |
| #516 | @danielbowne | Authorizes score updates against the stored row (closes CMS-Enterprise/ztmf-misc#263) |

Review state carried in: #511, #515 and #516 were approved. #514 was reviewed with no defect found - its only outstanding item was a rebase that this branch performs, and the two non-rebase follow-ups from that review are already applied.

## Why combine

`main` requires a successful DEV deployment of the PR head, and DEV is a single lane. Merging these separately means four deploy-then-merge cycles, each needing a rebase of everything above it - and #514 genuinely conflicts on three files when rebased after #511. Doing it once removes both the queue and the conflict.

## How it was assembled

Branched from #514's head (which already contained #511), then cherry-picked #515 and #516 on top. All five replayed clean, no conflicts. The two stacks touch mostly disjoint code - fismasystems versus scores - overlapping only in `emberfall_tests.yml`, `authorization_test.go` and `openapi.yaml`, all of which merged automatically.

## Verification on the combined head

- `make generate-openapi` reproduces the committed spec byte-for-byte, so the CI drift check passes
- unit and integration suites green
- emberfall **197/197**, up from 187 on main
- both stacks' distinctive cases confirmed present rather than assumed: the OpDiv-writable contact-field assertions, the confirm-endpoint cases, and the cross-system update case that returns 403

## After this merges

The four original PRs should be closed as superseded, and CMS-Enterprise/ztmf-misc#263 closed by hand since the cross-repo `Closes` does not fire.
