### PR TITLE
fix(#513): read only in-app edits for score-progress last-updated

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -1001,11 +1001,11 @@ SELECT DISTINCT ON (s.scoreid)
 -- Import provenance for the FY2020 archives cycle (datacallid 6): a service
 -- account plus one 'imported' event per archived score, mirroring how
 -- externally-loaded history is attributed in real environments (ztmf#435). These
--- give the archived rows a who/when (last-updated shows the import instead of
--- blank) but use action 'imported', which the status-sync below deliberately
--- excludes - so the archived answers keep status 'not_started' despite carrying
--- events. This is the shape that proves imported != updated: answers present,
--- provenance present, never 'done'.
+-- give the archived rows a who/when in the audit log but use action 'imported',
+-- which both the status-sync below and the score-progress last-updated lateral
+-- deliberately exclude - so the archived answers keep status 'not_started' and
+-- report no last-updated, despite carrying events. This is the shape that proves
+-- imported != updated: answers present, provenance present, never 'done'.
 INSERT INTO public.users (userid, email, fullname, role, deleted, identity_provider)
 VALUES ('00000000-0000-4000-8000-000000000001', 'svc-importer@empire.test',
         'Imperial Archives Import Service', 'HHS_READONLY_ADMIN', false, 'okta')

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -21,11 +21,11 @@ import (
 //     chip. A carried-forward answer does not count until re-saved (ztmf#299).
 //   - QuestionsAnswered ("has an answer at all") is the completion signal a
 //     PAST call needs. A closed cycle stops accumulating updates, and history
-//     imported from outside the app never had any (no events to backfill), so
-//     QuestionsUpdated says nothing about whether a historical call was in
-//     fact complete - QuestionsAnswered does (ztmf-ui#537). Cycles genuinely
-//     worked in-app keep their backfilled updated counts; accurate history,
-//     just not a completion signal.
+//     loaded from outside the app never counts as updated even where it
+//     carries provenance events, so QuestionsUpdated says nothing about
+//     whether a historical call was in fact complete - QuestionsAnswered does
+//     (ztmf-ui#537). Cycles genuinely worked in-app keep their backfilled
+//     updated counts; accurate history, just not a completion signal.
 //
 // Both are now read from persisted state (scores.status and score-row
 // presence) rather than reconstructed from the events audit log; see
@@ -52,9 +52,14 @@ type ScoreProgress struct {
 	// events audit log.
 	QuestionsUpdated int32 `json:"questionsupdated"`
 	// LastUpdatedAt is the most recent edit event across the system's answers
-	// in this data call; nil when nothing has been touched this cycle. This is
-	// a legitimately observational use of the events table (audit timeline),
-	// kept even though the counts no longer read events.
+	// in this data call; nil when nothing has been touched this cycle. Only
+	// in-app edit actions count, the same ones the status backfill treats as a
+	// genuine answer (0048): provenance attached by an out-of-band load records
+	// who and when the data arrived, but an import is not someone answering
+	// this cycle, so it must not surface as an update here when it does not
+	// count as one in QuestionsUpdated. This is a legitimately observational
+	// use of the events table (audit timeline), kept even though the counts no
+	// longer read events.
 	LastUpdatedAt *time.Time `json:"lastupdatedat,omitempty"`
 	// UpdatedSinceStart is derivable (QuestionsUpdated > 0) but kept because
 	// it answers the ticket's literal question - "has this system updated
@@ -107,7 +112,8 @@ func (i FindScoreProgressInput) validate() error {
 // scores.status for updated - so a dropped/failed event write no longer moves
 // the numbers. A LEFT lateral onto events remains only for LastUpdatedAt (an
 // audit timeline, not a count) and is served by the events_score_audit_idx
-// partial index.
+// partial index; that index keys on scoreid and createdat only, so the
+// lateral's action filter is applied on top of the descent rather than by it.
 func FindScoreProgress(ctx context.Context, input FindScoreProgressInput) ([]*ScoreProgress, error) {
 	if err := input.validate(); err != nil {
 		return nil, err
@@ -205,16 +211,20 @@ updated AS (
                                          AND dce.scoring_key = f.datacenterenvironment
     INNER JOIN questions q ON q.questionid = f.questionid
     INNER JOIN pillars p ON p.pillarid = q.pillarid
-    -- One newest event per score row (LIMIT 1 keeps the lateral on the
+    -- One newest in-app edit per score row (LIMIT 1 keeps the lateral on the
     -- index fast path); the outer MAX then picks the newest across the
     -- system's rows. LEFT now (not the old filtering INNER): it feeds only
     -- LastUpdatedAt, an audit timeline - a row with no event still counts
     -- toward the numerators via status/presence and simply contributes no
-    -- timestamp.
+    -- timestamp. The action allowlist mirrors the status backfill (0048) so
+    -- last-updated and questionsupdated read the same events: provenance
+    -- attached by an out-of-band load is not an edit, and a row carrying only
+    -- such events reports no last-updated rather than the load's timestamp.
     LEFT JOIN LATERAL (
         SELECT createdat
         FROM events
         WHERE resource = 'public.scores'
+          AND action IN ('created', 'updated')
           AND (payload->>'scoreid')::int = s.scoreid
         ORDER BY createdat DESC
         LIMIT 1

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -457,3 +457,81 @@ func TestImportedScoresKeepProvenanceWithoutDoneStatusIntegration(t *testing.T) 
 	assert.Equal(t, total, withImported, "every archived row must carry an 'imported' provenance event")
 	assert.Equal(t, 0, withEdit, "archived rows must have no created/updated events (import is not an edit)")
 }
+
+// TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration pins ztmf#513
+// through the real FindScoreProgress path: a score row whose only events are
+// out-of-band provenance ('imported') reports NO last-updated, matching the
+// status backfill that already refuses to call such a row done. Before the
+// action filter the lateral took the newest event of any action, so these rows
+// reported the load's timestamp while questionsupdated stayed 0 - last-updated
+// and questionsupdated disagreed about the same events.
+//
+// The systems under test are resolved from the events table rather than
+// hardcoded, so the test cannot pass vacuously against a data call that simply
+// has no events at all.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	const archivesDataCallID int32 = 6
+
+	// Systems in the archives call holding at least one answer whose only
+	// provenance is an 'imported' event and no in-app edit. These are exactly
+	// the rows the lateral used to date from the import. Decommissioned systems
+	// are filtered out here to mirror FindScoreProgress' own scope - they never
+	// appear in its result, so counting them as expected would fail the sweep
+	// below for a reason that has nothing to do with last-updated.
+	rows, err := conn.Query(ctx, `
+		SELECT DISTINCT s.fismasystemid
+		FROM public.scores s
+		INNER JOIN public.fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		WHERE s.datacallid = $1
+		  AND fs.decommissioned = FALSE
+		  AND EXISTS (SELECT 1 FROM public.events e
+		      WHERE e.resource='public.scores' AND e.action='imported'
+		        AND (e.payload->>'scoreid')::int = s.scoreid)
+		  AND NOT EXISTS (SELECT 1 FROM public.events e
+		      WHERE e.resource='public.scores' AND e.action IN ('created','updated')
+		        AND (e.payload->>'scoreid')::int = s.scoreid)
+	`, archivesDataCallID)
+	require.NoError(t, err)
+	importedOnly := map[int32]bool{}
+	for rows.Next() {
+		var id int32
+		require.NoError(t, rows.Scan(&id))
+		importedOnly[id] = true
+	}
+	rows.Close()
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, importedOnly, "fixture must seed at least one imported-only system in the archives call")
+
+	dcID := archivesDataCallID
+	progress, err := FindScoreProgress(ctx, FindScoreProgressInput{DataCallID: &dcID})
+	require.NoError(t, err)
+
+	checked := 0
+	for _, p := range progress {
+		if !importedOnly[p.FismaSystemID] {
+			continue
+		}
+		checked++
+		assert.Nil(t, p.LastUpdatedAt,
+			"system %d carries only imported provenance, so last-updated must be nil rather than the load's timestamp", p.FismaSystemID)
+		assert.Equal(t, int32(0), p.QuestionsUpdated,
+			"system %d has no in-app edits in this call", p.FismaSystemID)
+		assert.False(t, p.UpdatedSinceStart,
+			"system %d must not read as updated since the call started", p.FismaSystemID)
+		assert.Greater(t, p.QuestionsAnswered, int32(0),
+			"system %d must still report its imported answers - the filter changes last-updated, not the counts", p.FismaSystemID)
+	}
+	assert.Equal(t, len(importedOnly), checked, "every imported-only system must appear in the progress result")
+}

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -64,6 +64,7 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	assert.Contains(t, sql, "FILTER (WHERE s.status = 'done')", "updated is the answered set filtered to genuinely-saved rows via the persisted status column")
 	assert.Contains(t, sql, "LEFT JOIN LATERAL", "the events lateral is now LEFT (audit timeline only), not the filter for the count")
 	assert.Contains(t, sql, "resource = 'public.scores'", "the lateral must read score events for lastupdatedat")
+	assert.Contains(t, sql, "action IN ('created', 'updated')", "lastupdatedat reads only in-app edits, the same actions the status backfill (0048) counts - imported provenance must not surface as an update")
 	assert.Contains(t, sql, "LEFT JOIN expected", "unmapped-environment systems must still return a row")
 	assert.Contains(t, sql, "LEFT JOIN updated", "zero-activity systems must still return a row")
 	assert.Contains(t, sql, "COALESCE(u.questionsanswered, 0)", "zero-activity systems report 0 answered, not NULL")

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -706,9 +706,14 @@ components:
         lastupdatedat:
           description: |-
             LastUpdatedAt is the most recent edit event across the system's answers
-            in this data call; nil when nothing has been touched this cycle. This is
-            a legitimately observational use of the events table (audit timeline),
-            kept even though the counts no longer read events.
+            in this data call; nil when nothing has been touched this cycle. Only
+            in-app edit actions count, the same ones the status backfill treats as a
+            genuine answer (0048): provenance attached by an out-of-band load records
+            who and when the data arrived, but an import is not someone answering
+            this cycle, so it must not surface as an update here when it does not
+            count as one in QuestionsUpdated. This is a legitimately observational
+            use of the events table (audit timeline), kept even though the counts no
+            longer read events.
           type: string
         questionsanswered:
           description: |-


### PR DESCRIPTION
Closes #513.

`LastUpdatedAt` on the score-progress query took the newest `events` row of any action, while the status backfill in `0048scoresstatus.go` counts only `created` and `updated`. A score row whose only provenance is an out-of-band load therefore reported the load's timestamp while `questionsupdated` stayed 0, so the two read the same events and disagreed about them.

The lateral now carries the same action allowlist. An allowlist rather than a `<> 'imported'` exclusion, so a `deleted` event, or any action added later, cannot bump the timestamp either.

## The comments were the other half of the ticket

`scoreprogress.go` described history loaded from outside the app as carrying no events at all, while `0048scoresstatus.go` described it as carrying `imported` provenance events. Both statements are about environments rather than about the code, and neither is checkable from this repo, so I rewrote the `scoreprogress.go` side to state the rule instead: imported provenance is not an edit, whether or not a given environment records it. That holds either way and is what the query now enforces.

`0048scoresstatus.go` is untouched. It is the side already stating that rule, and it is an applied migration.

## Scope beyond the ticket's file list

`openapi.yaml` is a regeneration, not a hand edit. swag sources the `lastupdatedat` description from the struct field comment, so editing that comment moves the spec. Description text only, no schema or contract change, and `redocly lint` is clean at the usual 8 warnings with 2 explicitly ignored.

`_test_data_empire.sql` is a comment-only change. The data is unchanged, and it remains the fixture this fix is tested against. The old comment justified the imported events by saying last-updated shows the import instead of blank, which is the behavior being removed here, so it would have documented the opposite of the code.

## Visible behavior

A row whose entire event history is non-edit now reports no `lastupdatedat` instead of the load's timestamp. The field is `omitempty`, so it is absent rather than null. On the dashboard such a row's tooltip stops reading "Last updated <import date>" and falls through to its state-based text, and in `aggregateScores.ts` its `lastUpdatedMs` becomes -1, which puts it back in the tie where the has-score tie-break decides. That is the invariant the comment at `aggregateScores.ts:95` says the chosen-call logic depends on.

Rows with a genuine in-app edit are unaffected, since the edit is the newest matching event either way. The counts do not move at all; this changes only the timestamp.

## Tests

New `TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration` drives the real `FindScoreProgress` path and asserts an imported-only system reports a nil `LastUpdatedAt` while still reporting its answers. It resolves its subject systems from the events table rather than hardcoding ids, so it cannot pass vacuously against a data call that simply has no events, and it mirrors the query's own exclusion of decommissioned systems. Verified to fail against the unfixed lateral, where it returns the import timestamp rather than nil.

`TestBuildScoreProgressSQL_Shape` gains one assertion pinning the action filter. The existing `TestImportedScoresKeepProvenanceWithoutDoneStatusIntegration` is unchanged and still passes; it pins the status half.

## Gate

`make test-unit` green across all 12 packages, run with `-count=1` rather than from cache. `make test-integration` green. `make test-e2e` ran 197 with 0 failures. Pre-commit and pre-push hooks both green, no `--no-verify`.

Snyk and the deploy checks will show red here: this is a fork PR and those jobs need org secrets. Expected, and they pass once the branch is pulled in-repo.
