### PR TITLE
fix(#513): read only in-app edits for score-progress last-updated (rehome of #519)

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -1001,11 +1001,11 @@ SELECT DISTINCT ON (s.scoreid)
 -- Import provenance for the FY2020 archives cycle (datacallid 6): a service
 -- account plus one 'imported' event per archived score, mirroring how
 -- externally-loaded history is attributed in real environments (ztmf#435). These
--- give the archived rows a who/when (last-updated shows the import instead of
--- blank) but use action 'imported', which the status-sync below deliberately
--- excludes - so the archived answers keep status 'not_started' despite carrying
--- events. This is the shape that proves imported != updated: answers present,
--- provenance present, never 'done'.
+-- give the archived rows a who/when in the audit log but use action 'imported',
+-- which both the status-sync below and the score-progress last-updated lateral
+-- deliberately exclude - so the archived answers keep status 'not_started' and
+-- report no last-updated, despite carrying events. This is the shape that proves
+-- imported != updated: answers present, provenance present, never 'done'.
 INSERT INTO public.users (userid, email, fullname, role, deleted, identity_provider)
 VALUES ('00000000-0000-4000-8000-000000000001', 'svc-importer@empire.test',
         'Imperial Archives Import Service', 'HHS_READONLY_ADMIN', false, 'okta')

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -21,11 +21,11 @@ import (
 //     chip. A carried-forward answer does not count until re-saved (ztmf#299).
 //   - QuestionsAnswered ("has an answer at all") is the completion signal a
 //     PAST call needs. A closed cycle stops accumulating updates, and history
-//     imported from outside the app never had any (no events to backfill), so
-//     QuestionsUpdated says nothing about whether a historical call was in
-//     fact complete - QuestionsAnswered does (ztmf-ui#537). Cycles genuinely
-//     worked in-app keep their backfilled updated counts; accurate history,
-//     just not a completion signal.
+//     loaded from outside the app never counts as updated even where it
+//     carries provenance events, so QuestionsUpdated says nothing about
+//     whether a historical call was in fact complete - QuestionsAnswered does
+//     (ztmf-ui#537). Cycles genuinely worked in-app keep their backfilled
+//     updated counts; accurate history, just not a completion signal.
 //
 // Both are now read from persisted state (scores.status and score-row
 // presence) rather than reconstructed from the events audit log; see
@@ -52,9 +52,14 @@ type ScoreProgress struct {
 	// events audit log.
 	QuestionsUpdated int32 `json:"questionsupdated"`
 	// LastUpdatedAt is the most recent edit event across the system's answers
-	// in this data call; nil when nothing has been touched this cycle. This is
-	// a legitimately observational use of the events table (audit timeline),
-	// kept even though the counts no longer read events.
+	// in this data call; nil when nothing has been touched this cycle. Only
+	// in-app edit actions count, the same ones the status backfill treats as a
+	// genuine answer (0048): provenance attached by an out-of-band load records
+	// who and when the data arrived, but an import is not someone answering
+	// this cycle, so it must not surface as an update here when it does not
+	// count as one in QuestionsUpdated. This is a legitimately observational
+	// use of the events table (audit timeline), kept even though the counts no
+	// longer read events.
 	LastUpdatedAt *time.Time `json:"lastupdatedat,omitempty"`
 	// UpdatedSinceStart is derivable (QuestionsUpdated > 0) but kept because
 	// it answers the ticket's literal question - "has this system updated
@@ -107,7 +112,8 @@ func (i FindScoreProgressInput) validate() error {
 // scores.status for updated - so a dropped/failed event write no longer moves
 // the numbers. A LEFT lateral onto events remains only for LastUpdatedAt (an
 // audit timeline, not a count) and is served by the events_score_audit_idx
-// partial index.
+// partial index; that index keys on scoreid and createdat only, so the
+// lateral's action filter is applied on top of the descent rather than by it.
 func FindScoreProgress(ctx context.Context, input FindScoreProgressInput) ([]*ScoreProgress, error) {
 	if err := input.validate(); err != nil {
 		return nil, err
@@ -205,16 +211,20 @@ updated AS (
                                          AND dce.scoring_key = f.datacenterenvironment
     INNER JOIN questions q ON q.questionid = f.questionid
     INNER JOIN pillars p ON p.pillarid = q.pillarid
-    -- One newest event per score row (LIMIT 1 keeps the lateral on the
+    -- One newest in-app edit per score row (LIMIT 1 keeps the lateral on the
     -- index fast path); the outer MAX then picks the newest across the
     -- system's rows. LEFT now (not the old filtering INNER): it feeds only
     -- LastUpdatedAt, an audit timeline - a row with no event still counts
     -- toward the numerators via status/presence and simply contributes no
-    -- timestamp.
+    -- timestamp. The action allowlist mirrors the status backfill (0048) so
+    -- last-updated and questionsupdated read the same events: provenance
+    -- attached by an out-of-band load is not an edit, and a row carrying only
+    -- such events reports no last-updated rather than the load's timestamp.
     LEFT JOIN LATERAL (
         SELECT createdat
         FROM events
         WHERE resource = 'public.scores'
+          AND action IN ('created', 'updated')
           AND (payload->>'scoreid')::int = s.scoreid
         ORDER BY createdat DESC
         LIMIT 1

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -457,3 +457,81 @@ func TestImportedScoresKeepProvenanceWithoutDoneStatusIntegration(t *testing.T) 
 	assert.Equal(t, total, withImported, "every archived row must carry an 'imported' provenance event")
 	assert.Equal(t, 0, withEdit, "archived rows must have no created/updated events (import is not an edit)")
 }
+
+// TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration pins ztmf#513
+// through the real FindScoreProgress path: a score row whose only events are
+// out-of-band provenance ('imported') reports NO last-updated, matching the
+// status backfill that already refuses to call such a row done. Before the
+// action filter the lateral took the newest event of any action, so these rows
+// reported the load's timestamp while questionsupdated stayed 0 - last-updated
+// and questionsupdated disagreed about the same events.
+//
+// The systems under test are resolved from the events table rather than
+// hardcoded, so the test cannot pass vacuously against a data call that simply
+// has no events at all.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	const archivesDataCallID int32 = 6
+
+	// Systems in the archives call holding at least one answer whose only
+	// provenance is an 'imported' event and no in-app edit. These are exactly
+	// the rows the lateral used to date from the import. Decommissioned systems
+	// are filtered out here to mirror FindScoreProgress' own scope - they never
+	// appear in its result, so counting them as expected would fail the sweep
+	// below for a reason that has nothing to do with last-updated.
+	rows, err := conn.Query(ctx, `
+		SELECT DISTINCT s.fismasystemid
+		FROM public.scores s
+		INNER JOIN public.fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		WHERE s.datacallid = $1
+		  AND fs.decommissioned = FALSE
+		  AND EXISTS (SELECT 1 FROM public.events e
+		      WHERE e.resource='public.scores' AND e.action='imported'
+		        AND (e.payload->>'scoreid')::int = s.scoreid)
+		  AND NOT EXISTS (SELECT 1 FROM public.events e
+		      WHERE e.resource='public.scores' AND e.action IN ('created','updated')
+		        AND (e.payload->>'scoreid')::int = s.scoreid)
+	`, archivesDataCallID)
+	require.NoError(t, err)
+	importedOnly := map[int32]bool{}
+	for rows.Next() {
+		var id int32
+		require.NoError(t, rows.Scan(&id))
+		importedOnly[id] = true
+	}
+	rows.Close()
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, importedOnly, "fixture must seed at least one imported-only system in the archives call")
+
+	dcID := archivesDataCallID
+	progress, err := FindScoreProgress(ctx, FindScoreProgressInput{DataCallID: &dcID})
+	require.NoError(t, err)
+
+	checked := 0
+	for _, p := range progress {
+		if !importedOnly[p.FismaSystemID] {
+			continue
+		}
+		checked++
+		assert.Nil(t, p.LastUpdatedAt,
+			"system %d carries only imported provenance, so last-updated must be nil rather than the load's timestamp", p.FismaSystemID)
+		assert.Equal(t, int32(0), p.QuestionsUpdated,
+			"system %d has no in-app edits in this call", p.FismaSystemID)
+		assert.False(t, p.UpdatedSinceStart,
+			"system %d must not read as updated since the call started", p.FismaSystemID)
+		assert.Greater(t, p.QuestionsAnswered, int32(0),
+			"system %d must still report its imported answers - the filter changes last-updated, not the counts", p.FismaSystemID)
+	}
+	assert.Equal(t, len(importedOnly), checked, "every imported-only system must appear in the progress result")
+}

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -64,6 +64,7 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	assert.Contains(t, sql, "FILTER (WHERE s.status = 'done')", "updated is the answered set filtered to genuinely-saved rows via the persisted status column")
 	assert.Contains(t, sql, "LEFT JOIN LATERAL", "the events lateral is now LEFT (audit timeline only), not the filter for the count")
 	assert.Contains(t, sql, "resource = 'public.scores'", "the lateral must read score events for lastupdatedat")
+	assert.Contains(t, sql, "action IN ('created', 'updated')", "lastupdatedat reads only in-app edits, the same actions the status backfill (0048) counts - imported provenance must not surface as an update")
 	assert.Contains(t, sql, "LEFT JOIN expected", "unmapped-environment systems must still return a row")
 	assert.Contains(t, sql, "LEFT JOIN updated", "zero-activity systems must still return a row")
 	assert.Contains(t, sql, "COALESCE(u.questionsanswered, 0)", "zero-activity systems report 0 answered, not NULL")

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -706,9 +706,14 @@ components:
         lastupdatedat:
           description: |-
             LastUpdatedAt is the most recent edit event across the system's answers
-            in this data call; nil when nothing has been touched this cycle. This is
-            a legitimately observational use of the events table (audit timeline),
-            kept even though the counts no longer read events.
+            in this data call; nil when nothing has been touched this cycle. Only
+            in-app edit actions count, the same ones the status backfill treats as a
+            genuine answer (0048): provenance attached by an out-of-band load records
+            who and when the data arrived, but an import is not someone answering
+            this cycle, so it must not surface as an update here when it does not
+            count as one in QuestionsUpdated. This is a legitimately observational
+            use of the events table (audit timeline), kept even though the counts no
+            longer read events.
           type: string
         questionsanswered:
           description: |-


### PR DESCRIPTION
Rehome of #519 by @voidspooks, brought in-repo so the Snyk and deploy gates can actually run. The commit is his, unchanged and still signed. Original PR stays open until this merges.

Closes #513

## What it fixes

`LastUpdatedAt` on the score-progress query took the newest `events` row of any action, while the status backfill in `0048scoresstatus.go` counts only `created` and `updated`. A score row whose only provenance was an out-of-band load therefore reported the load's timestamp while `questionsupdated` stayed 0: the two read the same events and disagreed about them.

The lateral now carries the same action allowlist. An allowlist rather than excluding `imported`, so a `deleted` action, or any action added later, cannot bump the timestamp either.

The comment rewrite is the other half of the original ticket. `scoreprogress.go` described externally loaded history as carrying no events, while `0048scoresstatus.go` described it as carrying `imported` provenance events. Both are claims about environments rather than about the code, so the `scoreprogress.go` side now states the rule the query enforces: imported provenance is not an edit, whether or not a given environment records it. The migration is untouched, being both applied and already correct on that point.

`openapi.yaml` is a regeneration. swag sources the `lastupdatedat` description from the struct comment, so editing the comment moves the spec. Description text only. `_test_data_empire.sql` is comment-only: the old comment justified the imported events by saying last-updated shows the import rather than blank, which is the behavior being removed.

## Review already done, recorded here because it happened off the PR

Independent review checked this against live data and cleared it. Confirmed rather than assumed: the action allowlist exactly matches the 0048 backfill, the audit index keys only on scoreid and createdat so the filter rides on top of the index descent as the author noted, `openapi.yaml` regenerates byte-for-byte identical to what is committed, and the new integration test genuinely fails with the filter removed and passes with it. Integration suite green.

**Blast radius is historical only.** The affected rows are imported-only ones in closed cycles. No system in the open FY2026 data call is affected, so nothing can change for anyone mid-data-call. Exact figures were kept off this public PR and can be recorded internally if useful.

## Two non-blocking notes from that review

For an imported-only row the lateral now matches nothing and scans that row's events rather than short-circuiting at `LIMIT 1`. Bounded per row, but worth eyeballing an archives-year dashboard load rather than assuming it is free.

The author's claim that a nil last-updated feeds the `-1` tie-break in `aggregateScores.ts` is a cross-repo behavioral claim currently supported only by backend tests. Cheap to confirm on dev once CI here is green, and worth doing because the neighbouring invariant in that same function turned out to be upheld by a backend guarantee rather than by the frontend logic.

## Tests

New `TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration` drives the real `FindScoreProgress` path and asserts an imported-only system reports a nil `LastUpdatedAt` while still reporting its answers. It resolves its subject systems from the events table rather than hardcoding ids, so it cannot pass vacuously against a data call with no events. `TestBuildScoreProgressSQL_Shape` gains an assertion pinning the action filter. The existing imported-provenance test is unchanged and still pins the status half.

Rows with a genuine in-app edit are unaffected, since the edit is the newest matching event either way. No counts move; this changes only the timestamp.
