### PR TITLE
Code freeze batch: backend approved fixes (score-progress last-updated)

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -1001,11 +1001,11 @@ SELECT DISTINCT ON (s.scoreid)
 -- Import provenance for the FY2020 archives cycle (datacallid 6): a service
 -- account plus one 'imported' event per archived score, mirroring how
 -- externally-loaded history is attributed in real environments (ztmf#435). These
--- give the archived rows a who/when (last-updated shows the import instead of
--- blank) but use action 'imported', which the status-sync below deliberately
--- excludes - so the archived answers keep status 'not_started' despite carrying
--- events. This is the shape that proves imported != updated: answers present,
--- provenance present, never 'done'.
+-- give the archived rows a who/when in the audit log but use action 'imported',
+-- which both the status-sync below and the score-progress last-updated lateral
+-- deliberately exclude - so the archived answers keep status 'not_started' and
+-- report no last-updated, despite carrying events. This is the shape that proves
+-- imported != updated: answers present, provenance present, never 'done'.
 INSERT INTO public.users (userid, email, fullname, role, deleted, identity_provider)
 VALUES ('00000000-0000-4000-8000-000000000001', 'svc-importer@empire.test',
         'Imperial Archives Import Service', 'HHS_READONLY_ADMIN', false, 'okta')

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -21,11 +21,11 @@ import (
 //     chip. A carried-forward answer does not count until re-saved (ztmf#299).
 //   - QuestionsAnswered ("has an answer at all") is the completion signal a
 //     PAST call needs. A closed cycle stops accumulating updates, and history
-//     imported from outside the app never had any (no events to backfill), so
-//     QuestionsUpdated says nothing about whether a historical call was in
-//     fact complete - QuestionsAnswered does (ztmf-ui#537). Cycles genuinely
-//     worked in-app keep their backfilled updated counts; accurate history,
-//     just not a completion signal.
+//     loaded from outside the app never counts as updated even where it
+//     carries provenance events, so QuestionsUpdated says nothing about
+//     whether a historical call was in fact complete - QuestionsAnswered does
+//     (ztmf-ui#537). Cycles genuinely worked in-app keep their backfilled
+//     updated counts; accurate history, just not a completion signal.
 //
 // Both are now read from persisted state (scores.status and score-row
 // presence) rather than reconstructed from the events audit log; see
@@ -52,9 +52,14 @@ type ScoreProgress struct {
 	// events audit log.
 	QuestionsUpdated int32 `json:"questionsupdated"`
 	// LastUpdatedAt is the most recent edit event across the system's answers
-	// in this data call; nil when nothing has been touched this cycle. This is
-	// a legitimately observational use of the events table (audit timeline),
-	// kept even though the counts no longer read events.
+	// in this data call; nil when nothing has been touched this cycle. Only
+	// in-app edit actions count, the same ones the status backfill treats as a
+	// genuine answer (0048): provenance attached by an out-of-band load records
+	// who and when the data arrived, but an import is not someone answering
+	// this cycle, so it must not surface as an update here when it does not
+	// count as one in QuestionsUpdated. This is a legitimately observational
+	// use of the events table (audit timeline), kept even though the counts no
+	// longer read events.
 	LastUpdatedAt *time.Time `json:"lastupdatedat,omitempty"`
 	// UpdatedSinceStart is derivable (QuestionsUpdated > 0) but kept because
 	// it answers the ticket's literal question - "has this system updated
@@ -107,7 +112,8 @@ func (i FindScoreProgressInput) validate() error {
 // scores.status for updated - so a dropped/failed event write no longer moves
 // the numbers. A LEFT lateral onto events remains only for LastUpdatedAt (an
 // audit timeline, not a count) and is served by the events_score_audit_idx
-// partial index.
+// partial index; that index keys on scoreid and createdat only, so the
+// lateral's action filter is applied on top of the descent rather than by it.
 func FindScoreProgress(ctx context.Context, input FindScoreProgressInput) ([]*ScoreProgress, error) {
 	if err := input.validate(); err != nil {
 		return nil, err
@@ -205,16 +211,20 @@ updated AS (
                                          AND dce.scoring_key = f.datacenterenvironment
     INNER JOIN questions q ON q.questionid = f.questionid
     INNER JOIN pillars p ON p.pillarid = q.pillarid
-    -- One newest event per score row (LIMIT 1 keeps the lateral on the
+    -- One newest in-app edit per score row (LIMIT 1 keeps the lateral on the
     -- index fast path); the outer MAX then picks the newest across the
     -- system's rows. LEFT now (not the old filtering INNER): it feeds only
     -- LastUpdatedAt, an audit timeline - a row with no event still counts
     -- toward the numerators via status/presence and simply contributes no
-    -- timestamp.
+    -- timestamp. The action allowlist mirrors the status backfill (0048) so
+    -- last-updated and questionsupdated read the same events: provenance
+    -- attached by an out-of-band load is not an edit, and a row carrying only
+    -- such events reports no last-updated rather than the load's timestamp.
     LEFT JOIN LATERAL (
         SELECT createdat
         FROM events
         WHERE resource = 'public.scores'
+          AND action IN ('created', 'updated')
           AND (payload->>'scoreid')::int = s.scoreid
         ORDER BY createdat DESC
         LIMIT 1

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -457,3 +457,81 @@ func TestImportedScoresKeepProvenanceWithoutDoneStatusIntegration(t *testing.T) 
 	assert.Equal(t, total, withImported, "every archived row must carry an 'imported' provenance event")
 	assert.Equal(t, 0, withEdit, "archived rows must have no created/updated events (import is not an edit)")
 }
+
+// TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration pins ztmf#513
+// through the real FindScoreProgress path: a score row whose only events are
+// out-of-band provenance ('imported') reports NO last-updated, matching the
+// status backfill that already refuses to call such a row done. Before the
+// action filter the lateral took the newest event of any action, so these rows
+// reported the load's timestamp while questionsupdated stayed 0 - last-updated
+// and questionsupdated disagreed about the same events.
+//
+// The systems under test are resolved from the events table rather than
+// hardcoded, so the test cannot pass vacuously against a data call that simply
+// has no events at all.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	const archivesDataCallID int32 = 6
+
+	// Systems in the archives call holding at least one answer whose only
+	// provenance is an 'imported' event and no in-app edit. These are exactly
+	// the rows the lateral used to date from the import. Decommissioned systems
+	// are filtered out here to mirror FindScoreProgress' own scope - they never
+	// appear in its result, so counting them as expected would fail the sweep
+	// below for a reason that has nothing to do with last-updated.
+	rows, err := conn.Query(ctx, `
+		SELECT DISTINCT s.fismasystemid
+		FROM public.scores s
+		INNER JOIN public.fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		WHERE s.datacallid = $1
+		  AND fs.decommissioned = FALSE
+		  AND EXISTS (SELECT 1 FROM public.events e
+		      WHERE e.resource='public.scores' AND e.action='imported'
+		        AND (e.payload->>'scoreid')::int = s.scoreid)
+		  AND NOT EXISTS (SELECT 1 FROM public.events e
+		      WHERE e.resource='public.scores' AND e.action IN ('created','updated')
+		        AND (e.payload->>'scoreid')::int = s.scoreid)
+	`, archivesDataCallID)
+	require.NoError(t, err)
+	importedOnly := map[int32]bool{}
+	for rows.Next() {
+		var id int32
+		require.NoError(t, rows.Scan(&id))
+		importedOnly[id] = true
+	}
+	rows.Close()
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, importedOnly, "fixture must seed at least one imported-only system in the archives call")
+
+	dcID := archivesDataCallID
+	progress, err := FindScoreProgress(ctx, FindScoreProgressInput{DataCallID: &dcID})
+	require.NoError(t, err)
+
+	checked := 0
+	for _, p := range progress {
+		if !importedOnly[p.FismaSystemID] {
+			continue
+		}
+		checked++
+		assert.Nil(t, p.LastUpdatedAt,
+			"system %d carries only imported provenance, so last-updated must be nil rather than the load's timestamp", p.FismaSystemID)
+		assert.Equal(t, int32(0), p.QuestionsUpdated,
+			"system %d has no in-app edits in this call", p.FismaSystemID)
+		assert.False(t, p.UpdatedSinceStart,
+			"system %d must not read as updated since the call started", p.FismaSystemID)
+		assert.Greater(t, p.QuestionsAnswered, int32(0),
+			"system %d must still report its imported answers - the filter changes last-updated, not the counts", p.FismaSystemID)
+	}
+	assert.Equal(t, len(importedOnly), checked, "every imported-only system must appear in the progress result")
+}

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -64,6 +64,7 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	assert.Contains(t, sql, "FILTER (WHERE s.status = 'done')", "updated is the answered set filtered to genuinely-saved rows via the persisted status column")
 	assert.Contains(t, sql, "LEFT JOIN LATERAL", "the events lateral is now LEFT (audit timeline only), not the filter for the count")
 	assert.Contains(t, sql, "resource = 'public.scores'", "the lateral must read score events for lastupdatedat")
+	assert.Contains(t, sql, "action IN ('created', 'updated')", "lastupdatedat reads only in-app edits, the same actions the status backfill (0048) counts - imported provenance must not surface as an update")
 	assert.Contains(t, sql, "LEFT JOIN expected", "unmapped-environment systems must still return a row")
 	assert.Contains(t, sql, "LEFT JOIN updated", "zero-activity systems must still return a row")
 	assert.Contains(t, sql, "COALESCE(u.questionsanswered, 0)", "zero-activity systems report 0 answered, not NULL")

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -706,9 +706,14 @@ components:
         lastupdatedat:
           description: |-
             LastUpdatedAt is the most recent edit event across the system's answers
-            in this data call; nil when nothing has been touched this cycle. This is
-            a legitimately observational use of the events table (audit timeline),
-            kept even though the counts no longer read events.
+            in this data call; nil when nothing has been touched this cycle. Only
+            in-app edit actions count, the same ones the status backfill treats as a
+            genuine answer (0048): provenance attached by an out-of-band load records
+            who and when the data arrived, but an import is not someone answering
+            this cycle, so it must not surface as an update here when it does not
+            count as one in QuestionsUpdated. This is a legitimately observational
+            use of the events table (audit timeline), kept even though the counts no
+            longer read events.
           type: string
         questionsanswered:
           description: |-


### PR DESCRIPTION
Backend counterpart to the frontend freeze batch in CMS-Enterprise/ztmf-ui#674. Running batch of approved work, draft until the remaining approvals land, then converted manually.

Closes #513

## What is in it

| Source | Author | Change | Closes |
| --- | --- | --- | --- |
| #519 | @voidspooks | Read only in-app edits for score-progress last-updated | #513 |

@voidspooks' commit is carried unchanged from his fork: same content, his authorship, and the signature still verifies. Nothing was rewritten or re-signed.

This supersedes #520, which was opened as a standalone rehome before the batch approach was settled. Same branch content, renamed so the freeze artifacts match across the two repositories.

## Why this is more than the ticket described

`LastUpdatedAt` took the newest `events` row of any action, while the status backfill in `0048scoresstatus.go` counts only `created` and `updated`. So a row whose only provenance was an out-of-band load reported the load's timestamp while `questionsupdated` stayed 0.

Review surfaced a second case nobody had stated: because the filter was absent entirely, a row with a **genuine in-app edit** could have its displayed timestamp overwritten by a **later** import. An ISSO's real edit could be relabelled with an ETL run's timestamp. That case is not bounded to closed cycles the way the reported symptom is, so the fix is worth more than its description claims.

The allowlist is applied in the `WHERE`, so the descent picks the newest matching event regardless of how imports interleave. Verified in both orderings rather than by example.

## CI proof, which is the point of bringing this in-repo

A fork PR cannot reach org secrets, so on #519 the Snyk jobs, the deploy, and the integration tests never ran. In-repo they do, and all eleven checks pass on the identical commit (run `30941730744`):

| Check | Result |
| --- | --- |
| Analysis / snyk test | pass, 22s |
| Analysis / snyk code test | pass, 37s |
| Analysis / snyk iac test | pass, 34s |
| Analysis / openapi spec up to date | pass, 41s |
| Analysis / lint go | pass, 1m8s |
| Analysis / lint terraform | pass, 7s |
| Analysis / detect backend changes | pass, 5s |
| Check for Changes | pass, 7s |
| Backend / Integration Tests | pass, 1m36s |
| Backend / Build and Smoke Test | pass, 2m24s |
| Infrastructure / Deploy | pass, 3m15s |

The openapi drift check passing matters specifically: `openapi.yaml` here is a regeneration, since swag sources the `lastupdatedat` description from the struct comment. Two independent reviews confirmed it regenerates byte-for-byte identical to what is committed, and CI now agrees.

## Review already done, recorded because it happened off the PR

Reviewed against live data and cleared. Confirmed rather than assumed: the action allowlist exactly matches the `0048` backfill, the audit index keys only on scoreid and createdat so the filter rides on top of the index descent as the author noted, the spec regenerates identically, and the new integration test genuinely fails with the filter removed and passes with it.

**Blast radius is historical only.** The affected rows are imported-only ones in closed cycles, and no system in the open FY2026 data call is affected, so nothing changes for anyone mid-data-call. Exact figures were kept off this public PR and can be recorded internally.

A second independent pass reproduced all of it, including emberfall at `Ran: 197 / Failed: 0`, and confirmed the cross-repo claim: a nil last-updated feeds the `-1` tie-break in ztmf-ui's `aggregateScores.ts`, which is already pinned there by a passing test naming the imported-call case explicitly.

## Non-blocking notes carried forward

For an imported-only row the lateral now matches nothing and scans that row's events rather than short-circuiting at `LIMIT 1`. Bounded per row, but worth eyeballing an archives-year dashboard load rather than assuming it is free.

`('created', 'updated')` is now written literally in four places: the migration, this query, and two raw SQL fragments in the integration test. Two independent SQL fragments disagreeing about which actions count is exactly what produced the original bug, so a shared Go constant would close that off. Can follow separately.

## How this branch is maintained

Members are reviewed work. **The approval lives on this batch, not on the member PRs**, and it is collected once the queue is final rather than per addition, because any push here dismisses an approval already given. So a member PR sitting at `REVIEW_REQUIRED` is expected and is not a gap: during the freeze the batch is the thing that gets approved and merged, and the member is the thing that got reviewed. Each member's review is recorded on this PR so the trail does not depend on where the conversation happened.

Additions are appended, never reordered, which keeps the push a fast-forward, avoids re-hashing contributors' commits, and preserves the record of what joined when.

This PR stays a draft while the queue fills. That is deliberate, not an oversight: it means no CI has run here yet, since draft PRs skip both the analysis and deploy jobs.

After merge, #519 closes without merging, so its own `Closes #513` never fires. That is why the keyword is declared here.

