### PR TITLE
feat(users): expose last_seen on the users list

### DIFF
--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -176,6 +176,15 @@ func SessionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	SetSessionCookie(w, token)
+
+	// Record the login. Fire-and-forget by design: the session is already
+	// minted and the cookie already set, so failing the redirect over an audit
+	// write would deny a user access for a bookkeeping problem. Logged, not
+	// returned - the same trade recordEvent makes for write-derived events.
+	if err := model.RecordLogin(r.Context(), user.UserID); err != nil {
+		log.Printf("login: failed to record session event for %s: %s\n", user.UserID, err)
+	}
+
 	http.Redirect(w, r, "/", http.StatusFound)
 }
 

--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -177,10 +177,14 @@ func SessionHandler(w http.ResponseWriter, r *http.Request) {
 
 	SetSessionCookie(w, token)
 
-	// Record the login. Fire-and-forget by design: the session is already
-	// minted and the cookie already set, so failing the redirect over an audit
-	// write would deny a user access for a bookkeeping problem. Logged, not
-	// returned - the same trade recordEvent makes for write-derived events.
+	// Record the login. Fire-and-forget by design: the session is minted and
+	// the Set-Cookie header staged, so failing the redirect over an audit write
+	// would deny a user access for a bookkeeping problem. Logged, not returned -
+	// the same trade recordEvent makes for write-derived events.
+	//
+	// The failure direction is the safe one: a dropped write makes an active
+	// account look stale, which costs a needless review, and can never make a
+	// stale account look active.
 	if err := model.RecordLogin(r.Context(), user.UserID); err != nil {
 		log.Printf("login: failed to record session event for %s: %s\n", user.UserID, err)
 	}

--- a/backend/cmd/api/internal/migrations/0054eventsuserindex.go
+++ b/backend/cmd/api/internal/migrations/0054eventsuserindex.go
@@ -1,0 +1,27 @@
+package migrations
+
+func init() {
+	appendMigration(
+		"add per-user index on events for last-seen lookups",
+		`
+-- The users list derives last_seen as MAX(events.createdat) per user, one
+-- correlated subquery per row, the same shape the existing assignedopdivids
+-- subquery uses. events carries no userid index today: it has one on
+-- (resource, createdat) and a partial one on the scoreid expression, neither
+-- of which serves a lookup keyed on userid.
+--
+-- Without this the subquery is a sequential scan of events per user row. At
+-- roughly 200k events and 1,250 users that is a full scan per row on a page
+-- an admin loads routinely, which is exactly the regression 0037 was written
+-- to avoid for the score audit lateral.
+--
+-- createdat DESC alongside userid so the MAX is an index-only descent to the
+-- first matching entry rather than an aggregate over the whole partition.
+-- Not partial: unlike the score audit index there is no single resource worth
+-- narrowing to, since last_seen deliberately counts activity of any kind.
+CREATE INDEX IF NOT EXISTS events_user_activity_idx
+    ON public.events (userid, createdat DESC);
+`,
+		`DROP INDEX IF EXISTS events_user_activity_idx;`,
+	)
+}

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -173,6 +173,30 @@ func RecordQuestionView(ctx context.Context, input QuestionViewInput, readOnly b
 	return insertEvent(ctx, user.UserID, "viewed", "questionnaire", p)
 }
 
+// RecordLogin appends a "session / created" event for a user who has just
+// completed authentication and been issued a session.
+//
+// Every other event in the log is a side effect of a write, so activity was
+// only ever visible for users who CHANGED something. That left a specific blind
+// spot: a privileged account that signs in and only reads looked identical to
+// one that had never signed in at all, which is exactly the pair you need to
+// tell apart to find a stale account.
+//
+// The caller is the post-OIDC session handler, not a request behind
+// auth.Middleware, so the user is passed explicitly rather than read from
+// context - at this point in the flow the session that would carry it has only
+// just been minted.
+//
+// The payload is deliberately just the userid: the identity provider is already
+// on the user row, and the interesting facts here are who and when, both of
+// which the event row itself carries.
+func RecordLogin(ctx context.Context, userID string) error {
+	if userID == "" {
+		return nil
+	}
+	return insertEvent(ctx, userID, "created", "session", payload{UserID: &userID})
+}
+
 func FindEvents(ctx context.Context, input *FindEventsInput) ([]*Event, error) {
 
 	sqlb := stmntBuilder.

--- a/backend/internal/model/events_login_integration_test.go
+++ b/backend/internal/model/events_login_integration_test.go
@@ -2,9 +2,11 @@ package model
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,9 +44,13 @@ func TestRecordLoginIntegration(t *testing.T) {
 		  AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.userid = u.userid)
 		LIMIT 1
 	`).Scan(&userID)
-	if err != nil {
+	// Only "no such user" is a skip. Letting any error skip would turn a dead
+	// connection or a renamed column into a green run in which RecordLogin was
+	// never called at all.
+	if errors.Is(err, pgx.ErrNoRows) {
 		t.Skip("fixture has no user without events")
 	}
+	require.NoError(t, err)
 
 	before, err := FindUsers(ctx, &FindUsersInput{})
 	require.NoError(t, err)
@@ -87,13 +93,15 @@ func TestRecordLoginIntegration(t *testing.T) {
 	t.Run("EmptyUserIsANoOp", func(t *testing.T) {
 		// Defensive: never fabricate an event with no initiator, mirroring how
 		// recordEvent skips when there is no user in context.
+		// Scoped to this user rather than counting the table: an unscoped count
+		// only holds because the test DB is ephemeral, and would go flaky the
+		// moment anyone pointed this at a shared one.
+		const countSessions = `SELECT count(*) FROM public.events WHERE resource='session' AND userid=$1`
 		var before int
-		require.NoError(t, conn.QueryRow(ctx,
-			`SELECT count(*) FROM public.events WHERE resource='session'`).Scan(&before))
+		require.NoError(t, conn.QueryRow(ctx, countSessions, userID).Scan(&before))
 		require.NoError(t, RecordLogin(ctx, ""))
 		var after int
-		require.NoError(t, conn.QueryRow(ctx,
-			`SELECT count(*) FROM public.events WHERE resource='session'`).Scan(&after))
+		require.NoError(t, conn.QueryRow(ctx, countSessions, userID).Scan(&after))
 		assert.Equal(t, before, after, "an empty user id must write nothing")
 	})
 }

--- a/backend/internal/model/events_login_integration_test.go
+++ b/backend/internal/model/events_login_integration_test.go
@@ -1,0 +1,99 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RecordLogin is what makes LastSeen mean "last signed in" rather than "last
+// changed something". Before it, activity was only visible for users who wrote
+// data, so an account that signed in and only read was indistinguishable from
+// one that had never signed in - the exact pair you need to separate to find a
+// stale privileged account.
+func TestRecordLoginIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	// Registered before the skip below so the connection is returned on every
+	// exit path. Not a deferred release: deferred calls run BEFORE t.Cleanup,
+	// which would pull the connection out from under the DELETE registered
+	// later.
+	var userID string
+	t.Cleanup(func() {
+		if userID != "" {
+			_, _ = conn.Exec(ctx,
+				`DELETE FROM public.events WHERE userid=$1 AND resource='session'`, userID)
+		}
+		conn.Release()
+	})
+
+	// A user who has recorded nothing, so the assertions below cannot be
+	// satisfied by pre-existing activity.
+	err = conn.QueryRow(ctx, `
+		SELECT u.userid FROM public.users u
+		WHERE NOT COALESCE(u.deleted,false)
+		  AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.userid = u.userid)
+		LIMIT 1
+	`).Scan(&userID)
+	if err != nil {
+		t.Skip("fixture has no user without events")
+	}
+
+	before, err := FindUsers(ctx, &FindUsersInput{})
+	require.NoError(t, err)
+	for _, u := range before {
+		if u.UserID == userID {
+			require.Nil(t, u.LastSeen, "precondition: this user must start with no activity")
+		}
+	}
+
+	require.NoError(t, RecordLogin(ctx, userID))
+
+	t.Run("WritesASessionEvent", func(t *testing.T) {
+		var action, resource, payloadUser string
+		require.NoError(t, conn.QueryRow(ctx, `
+			SELECT action, resource, payload->>'userid'
+			FROM public.events WHERE userid=$1 AND resource='session'
+			ORDER BY createdat DESC LIMIT 1
+		`, userID).Scan(&action, &resource, &payloadUser))
+		assert.Equal(t, "created", action)
+		assert.Equal(t, "session", resource)
+		assert.Equal(t, userID, payloadUser, "payload should identify the user who signed in")
+	})
+
+	t.Run("SurfacesAsLastSeenWithoutAnyWrite", func(t *testing.T) {
+		// The point of the change: signing in alone now moves last_seen. This
+		// user still has not created or updated a single record.
+		after, err := FindUsers(ctx, &FindUsersInput{})
+		require.NoError(t, err)
+		var found *User
+		for _, u := range after {
+			if u.UserID == userID {
+				found = u
+			}
+		}
+		require.NotNil(t, found)
+		assert.NotNil(t, found.LastSeen,
+			"a login with no subsequent write must still register as activity")
+	})
+
+	t.Run("EmptyUserIsANoOp", func(t *testing.T) {
+		// Defensive: never fabricate an event with no initiator, mirroring how
+		// recordEvent skips when there is no user in context.
+		var before int
+		require.NoError(t, conn.QueryRow(ctx,
+			`SELECT count(*) FROM public.events WHERE resource='session'`).Scan(&before))
+		require.NoError(t, RecordLogin(ctx, ""))
+		var after int
+		require.NoError(t, conn.QueryRow(ctx,
+			`SELECT count(*) FROM public.events WHERE resource='session'`).Scan(&after))
+		assert.Equal(t, before, after, "an empty user id must write nothing")
+	})
+}

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -25,16 +25,20 @@ type User struct {
 	// the past is denied at authentication (see IsExpired and the auth middleware),
 	// while the row and its assignments are retained for renewal and audit.
 	AccessExpiresAt *time.Time `json:"access_expires_at" db:"access_expires_at"`
-	// LastSeen is the most recent action this user recorded in the events audit
-	// log. Derived on read, never stored, so it needs no backfill and cannot
-	// drift from the log it summarises.
+	// LastSeen is the most recent activity this user recorded in the events
+	// audit log, including logins (see RecordLogin). Derived on read, never
+	// stored, so it needs no backfill and cannot drift from the log it
+	// summarises.
 	//
-	// It is deliberately "last recorded action", NOT "last login": ZTMF records
-	// no authentication event, so a user who signs in and never opens a
-	// questionnaire or saves anything leaves no trace and reports null. Null
-	// therefore means "has taken no action we record" - most often an account
-	// provisioned by a bulk load whose owner has not engaged - rather than
-	// proof they have never signed in. Read it as a floor on engagement.
+	// Signing in counts, so a user who logs in and only reads is now
+	// distinguishable from one who has never signed in at all - the pair that
+	// matters for spotting a stale privileged account, and that used to look
+	// identical because every event was a side effect of a write.
+	//
+	// Null means no recorded activity of any kind. For an account created
+	// before login events existed, null means "nothing since then", not
+	// "never" - the log is not retrospective. That ambiguity ages out as
+	// people sign in.
 	//
 	// No omitempty: a never-used account is the case this field exists to
 	// identify, and omitting the key there would make the answer indistinguishable

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -25,6 +25,21 @@ type User struct {
 	// the past is denied at authentication (see IsExpired and the auth middleware),
 	// while the row and its assignments are retained for renewal and audit.
 	AccessExpiresAt *time.Time `json:"access_expires_at" db:"access_expires_at"`
+	// LastSeen is the most recent action this user recorded in the events audit
+	// log. Derived on read, never stored, so it needs no backfill and cannot
+	// drift from the log it summarises.
+	//
+	// It is deliberately "last recorded action", NOT "last login": ZTMF records
+	// no authentication event, so a user who signs in and never opens a
+	// questionnaire or saves anything leaves no trace and reports null. Null
+	// therefore means "has taken no action we record" - most often an account
+	// provisioned by a bulk load whose owner has not engaged - rather than
+	// proof they have never signed in. Read it as a floor on engagement.
+	//
+	// No omitempty: a never-used account is the case this field exists to
+	// identify, and omitting the key there would make the answer indistinguishable
+	// from the field not being served at all. Null is the answer, so it ships.
+	LastSeen *time.Time `json:"last_seen" db:"last_seen"`
 }
 
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
@@ -425,6 +440,11 @@ func FindUsers(ctx context.Context, fui *FindUsersInput) ([]*User, error) {
 			"users.identity_provider",
 			"users.access_expires_at",
 			"(SELECT ARRAY_AGG(opdiv_id) FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids",
+			// Same correlated-subquery shape as assignedopdivids above. Served
+			// by events_user_activity_idx (0054) as an index-only descent to
+			// the newest entry, so this stays a few milliseconds across the
+			// whole list rather than a sequential scan of events per row.
+			"(SELECT MAX(createdat) FROM public.events WHERE events.userid = users.userid) AS last_seen",
 		).
 		From("public.users").
 		Where("deleted=?", fui.Deleted)
@@ -468,6 +488,13 @@ func FindUserByEmail(ctx context.Context, email string) (*User, error) {
 }
 
 func findUser(ctx context.Context, where string, args []any) (*User, error) {
+	// last_seen is selected as a literal NULL rather than derived. This runs in
+	// the auth middleware on every authenticated request, so the correlated
+	// subquery FindUsers uses would be paid on every call to serve a field only
+	// the users list renders. The column still has to appear: this path scans
+	// strictly by name, so omitting it fails the scan outright rather than
+	// leaving the field nil.
+	//
 	// Load assignments via correlated subqueries instead of LEFT JOIN +
 	// ARRAY_AGG so the row count stays at one per user. A LEFT JOIN to both
 	// junctions would produce an N*M cross-product (N system grants times
@@ -483,6 +510,7 @@ func findUser(ctx context.Context, where string, args []any) (*User, error) {
 			"users.deleted",
 			"users.identity_provider",
 			"users.access_expires_at",
+			"NULL::timestamptz AS last_seen",
 			"(SELECT ARRAY_AGG(fismasystemid) FROM users_fismasystems WHERE userid = users.userid) AS assignedfismasystems",
 			"(SELECT ARRAY_AGG(opdiv_id)      FROM users_opdivs       WHERE userid = users.userid) AS assignedopdivids",
 		).

--- a/backend/internal/model/users_lastseen_integration_test.go
+++ b/backend/internal/model/users_lastseen_integration_test.go
@@ -2,9 +2,11 @@ package model
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,9 +65,12 @@ func TestFindUsersLastSeenIntegration(t *testing.T) {
 			  AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.userid = u.userid)
 			LIMIT 1
 		`).Scan(&userID)
-		if err != nil {
+		// Only the empty result is a skip; any other error is a real failure
+		// and must not be laundered into a green run.
+		if errors.Is(err, pgx.ErrNoRows) {
 			t.Skip("fixture has no user without events; nothing to assert here")
 		}
+		require.NoError(t, err)
 
 		u, ok := byID[userID]
 		require.True(t, ok)

--- a/backend/internal/model/users_lastseen_integration_test.go
+++ b/backend/internal/model/users_lastseen_integration_test.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// LastSeen answers "has this account ever been used" for the users list. It is
+// derived on read from the events audit log rather than stored, so these tests
+// pin the derivation against real event rows: a user with activity reports the
+// newest one, a user with none reports nil, and the single-user path (which
+// runs in the auth middleware on every request) deliberately does not pay for
+// the lookup at all.
+func TestFindUsersLastSeenIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	users, err := FindUsers(ctx, &FindUsersInput{})
+	require.NoError(t, err)
+	require.NotEmpty(t, users, "seeded database should have users")
+
+	byID := map[string]*User{}
+	for _, u := range users {
+		byID[u.UserID] = u
+	}
+
+	t.Run("MatchesNewestEventForUsersWithActivity", func(t *testing.T) {
+		// Resolve the subject from the events table rather than hardcoding an
+		// id, so the test cannot pass vacuously against a fixture with no
+		// events at all.
+		var userID string
+		err := conn.QueryRow(ctx, `
+			SELECT userid FROM public.events
+			GROUP BY userid ORDER BY count(*) DESC LIMIT 1
+		`).Scan(&userID)
+		require.NoError(t, err, "fixture must contain at least one event")
+
+		u, ok := byID[userID]
+		require.True(t, ok, "the busiest event author should appear in the users list")
+		require.NotNil(t, u.LastSeen, "a user with events must report a last_seen")
+
+		var expected any
+		require.NoError(t, conn.QueryRow(ctx,
+			`SELECT MAX(createdat) FROM public.events WHERE userid = $1`, userID).Scan(&expected))
+		assert.Equal(t, expected, *u.LastSeen,
+			"last_seen must be the newest event for that user, not any other row")
+	})
+
+	t.Run("NilForUsersWithNoActivity", func(t *testing.T) {
+		var userID string
+		err := conn.QueryRow(ctx, `
+			SELECT u.userid FROM public.users u
+			WHERE NOT COALESCE(u.deleted,false)
+			  AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.userid = u.userid)
+			LIMIT 1
+		`).Scan(&userID)
+		if err != nil {
+			t.Skip("fixture has no user without events; nothing to assert here")
+		}
+
+		u, ok := byID[userID]
+		require.True(t, ok)
+		assert.Nil(t, u.LastSeen,
+			"a user who has recorded no action must report null, not a zero time")
+	})
+
+	t.Run("SingleUserPathSkipsTheLookup", func(t *testing.T) {
+		// findUser runs in the auth middleware on every authenticated request,
+		// so it must not pay for a correlated subquery that only the list view
+		// renders. Lax scanning leaves the field nil; this pins that choice so
+		// a later "make it consistent" edit is a deliberate one.
+		var userID string
+		require.NoError(t, conn.QueryRow(ctx, `
+			SELECT userid FROM public.events GROUP BY userid ORDER BY count(*) DESC LIMIT 1
+		`).Scan(&userID))
+
+		one, err := FindUserByID(ctx, userID)
+		require.NoError(t, err)
+		require.NotNil(t, one)
+		assert.Nil(t, one.LastSeen,
+			"findUser must not populate last_seen; it is a list-only field")
+	})
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -808,6 +808,23 @@ components:
           type: string
         identity_provider:
           type: string
+        last_seen:
+          description: |-
+            LastSeen is the most recent action this user recorded in the events audit
+            log. Derived on read, never stored, so it needs no backfill and cannot
+            drift from the log it summarises.
+
+            It is deliberately "last recorded action", NOT "last login": ZTMF records
+            no authentication event, so a user who signs in and never opens a
+            questionnaire or saves anything leaves no trace and reports null. Null
+            therefore means "has taken no action we record" - most often an account
+            provisioned by a bulk load whose owner has not engaged - rather than
+            proof they have never signed in. Read it as a floor on engagement.
+
+            No omitempty: a never-used account is the case this field exists to
+            identify, and omitting the key there would make the answer indistinguishable
+            from the field not being served at all. Null is the answer, so it ships.
+          type: string
         role:
           type: string
         userid:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -810,16 +810,20 @@ components:
           type: string
         last_seen:
           description: |-
-            LastSeen is the most recent action this user recorded in the events audit
-            log. Derived on read, never stored, so it needs no backfill and cannot
-            drift from the log it summarises.
+            LastSeen is the most recent activity this user recorded in the events
+            audit log, including logins (see RecordLogin). Derived on read, never
+            stored, so it needs no backfill and cannot drift from the log it
+            summarises.
 
-            It is deliberately "last recorded action", NOT "last login": ZTMF records
-            no authentication event, so a user who signs in and never opens a
-            questionnaire or saves anything leaves no trace and reports null. Null
-            therefore means "has taken no action we record" - most often an account
-            provisioned by a bulk load whose owner has not engaged - rather than
-            proof they have never signed in. Read it as a floor on engagement.
+            Signing in counts, so a user who logs in and only reads is now
+            distinguishable from one who has never signed in at all - the pair that
+            matters for spotting a stale privileged account, and that used to look
+            identical because every event was a side effect of a write.
+
+            Null means no recorded activity of any kind. For an account created
+            before login events existed, null means "nothing since then", not
+            "never" - the log is not retrospective. That ambiguity ages out as
+            people sign in.
 
             No omitempty: a never-used account is the case this field exists to
             identify, and omitting the key there would make the answer indistinguishable


### PR DESCRIPTION
**This is the backend piece only.** It exposes the data; how it gets shown is deliberately left open. Filed separately as CMS-Enterprise/ztmf-ui#675 so the team can decide the presentation. Until then the field is queryable through `/api/v1/users`, which is enough to answer the question that prompted this.

## What prompted it

There is currently no way to tell whether a provisioned account has ever been used. `users` has no `last_login` column, so "has this person shown up" can only be answered by querying the events log by hand — which is what we have been doing during the FY2026 call. With ~1,250 provisioned respondents and most accounts created by a bulk load rather than by signup, that question comes up constantly.

## What this adds

Two halves that meet in the middle:

**A writer.** `RecordLogin` appends a `session / created` event when the post-OIDC session handler mints a cookie. Until now every event in the log was a side effect of a *write*, so activity was only visible for users who changed something — and a privileged account that signs in and only reads looked identical to one that had never signed in at all. That is the exact pair you need to separate to find a stale account, and it was the one pair the log could not distinguish.

It is fire-and-forget: the session already exists and the cookie is already set by that point, so failing the redirect over an audit write would deny a user access for a bookkeeping problem. Logged rather than returned, matching what `recordEvent` already does for write-derived events. An empty user id writes nothing.

**A reader.** `last_seen` on the users list: the newest `events` row for that user, derived on read rather than stored. Nothing to backfill, and it cannot drift from the log it summarises. Because it is `MAX(createdat)` over *all* events, logins land in it for free — no change to the query.

The remaining caveat is narrower than it was: the log is not retrospective, so null on an account that predates this means "nothing since then", not "never". That ambiguity ages out as people sign in. The field comment says so plainly.

## Migration 0054 — the part not to skip

`events` had no `userid` index. It carries one on `(resource, createdat)` and a partial one on the scoreid expression, neither of which serves a lookup keyed on `userid`.

Without an index the correlated subquery is a sequential scan of `events` per user row — roughly 200k events against 1,250 users, on a page administrators load routinely. That is precisely the regression migration 0037 was written to avoid for the score audit lateral. 0054 adds `(userid, createdat DESC)` so the `MAX` is an index-only descent to the first matching entry rather than an aggregate over the whole partition.

Not partial: unlike the score audit index there is no single resource worth narrowing to, because `last_seen` deliberately counts activity of any kind.

## `findUser` selects a literal NULL, and that is load-bearing

`findUser` backs `FindUserByID` / `FindUserByEmail`, which run in the **auth middleware on every authenticated request**. It must not pay for a correlated subquery that only the list view renders.

But the column still has to appear there. That path scans strictly by name (`pgx.RowToStructByName`), so omitting it fails the scan outright rather than leaving the field nil — which would have broken every authenticated request. My first pass did exactly that, on the assumption the path scanned laxly; the integration test below caught it before it left the branch.

## Tests

Both suites resolve their subjects from the database rather than hardcoding ids, so neither can pass vacuously against a fixture that happens to lack the relevant rows.

`TestFindUsersLastSeenIntegration`:
- a user with activity reports the newest event for that user, checked against a direct `MAX(createdat)`
- a user with no activity reports nil rather than a zero time
- `findUser` does **not** populate the field, pinning the hot-path exclusion so a later "make it consistent" edit has to be deliberate

`TestRecordLoginIntegration` runs against a user chosen for having *no* events at all, so the assertions cannot be satisfied by pre-existing activity:
- the event lands with the right action, resource, and payload
- it surfaces as `last_seen` **without that user ever writing anything** — the whole point of the change
- an empty user id is a no-op, so we never fabricate an event with no initiator

## Review notes

`last_seen` intentionally has no `omitempty`. A never-used account is the case this field exists to identify, and omitting the key there would make the answer indistinguishable from the field not being served at all. Null is the answer, so it ships. (Caught in review — the first version had `omitempty` and silently dropped the field for exactly the population it was built to surface.)

Suites: unit, integration, and emberfall 197/197 all green. `make generate-openapi` committed.
