### PR TITLE
chore(model): single home for event-action and score-status values

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -1029,6 +1029,12 @@ SELECT '00000000-0000-4000-8000-000000000001', 'imported', 'public.scores',
 -- FY2020 archives block) are excluded via the same action filter the migration
 -- uses, so imported history stays not_started. Keeps this consistent
 -- automatically as the events seed above changes.
+--
+-- The action values here (and in the 'imported' events seeded above) are SQL
+-- literals because SQL cannot reference a Go constant; they are the same values
+-- defined as eventAction* in internal/model/events.go, which is the source of
+-- truth for the set. Changing an action value there means updating these
+-- literals and backfilling stored rows, not a rename.
 UPDATE public.scores s
 SET status = 'done'
 WHERE EXISTS (

--- a/backend/cmd/api/internal/migrations/0048scoresstatus.go
+++ b/backend/cmd/api/internal/migrations/0048scoresstatus.go
@@ -41,6 +41,13 @@ ALTER TABLE public.scores
 -- loaded outside the app is attributed with 'imported' provenance events so it
 -- carries a who/when, but an import is not a human answering this cycle - those
 -- events must NOT flip the row to done, so they are excluded here.
+--
+-- The action values below are SQL literals because SQL cannot reference a Go
+-- constant; they are the same values defined as eventAction* in
+-- internal/model/events.go, which is the source of truth for the set. This
+-- migration has already run in every environment, so its SQL is frozen -
+-- changing an action value means backfilling the events table and updating
+-- every SQL predicate that repeats these literals, not editing this file.
 UPDATE public.scores s
 SET status = 'done'
 WHERE EXISTS (

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -52,16 +52,25 @@ const (
 	// eventActionImported marks provenance for score data loaded outside the
 	// application - bulk imports and seed SQL, not a human answering a
 	// questionnaire. Nothing in this package writes it today; the value lives
-	// here so there is one authoritative home for it, because the readers that
-	// exclude it (0048's backfill, the seed status-sync, the last-updated
-	// lateral in scoreprogress.go) all depend on the exact spelling. A future
-	// bulk importer must write this action rather than reusing the in-app
-	// create/update path - see Score.Save.
+	// here so there is one authoritative home for it.
+	//
+	// Note which consumers actually depend on the exact spelling: the readers
+	// that exclude imported rows (0048's backfill, the seed status-sync, the
+	// last-updated lateral in scoreprogress.go) do NOT name this value at all -
+	// they allowlist 'created'/'updated', so they would exclude an import under
+	// any spelling. The sites that would silently drift on a respelling are the
+	// WRITERS and the assertions over them: the seed INSERT in
+	// _test_data_empire.sql and scoreprogress_integration_test.go, which read
+	// back `action='imported'` to prove imported history stays not_started.
+	//
+	// A future bulk importer must write this action rather than reusing the
+	// in-app create/update path - see Score.Save.
 	//
 	// Having no Go writer is the point, so silence the unused check rather than
-	// leaving the value defined only in SQL and prose. If a Go importer ever
-	// does write it, staticcheck flags this directive as matching nothing and
-	// it should be deleted.
+	// leaving the value defined only in SQL and prose. Staticcheck will NOT
+	// tell you when this directive goes stale - U1000 ignores are exempt from
+	// its unmatched-directive check - so delete it by hand if a Go writer ever
+	// appears.
 	//lint:ignore U1000 defined as the authoritative spelling for SQL readers; no Go writer by design
 	eventActionImported = "imported"
 )

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -18,6 +18,54 @@ type Event struct {
 	Payload   interface{} `json:"payload"`   // incoming data
 }
 
+// Event actions. These are the complete set of values that may appear in
+// events.action, collected here so the Go writers agree by construction
+// instead of by five hand-repeated string literals staying in sync.
+//
+// Treat these as stored data, not as an internal enum: the values are
+// load-bearing well beyond this package, and several of the readers cannot
+// import Go at all.
+//
+//   - migration 0048's status backfill selects on
+//     `e.action IN ('created', 'updated')` as SQL literals, and it has already
+//     run in every environment - the rows it wrote are permanent.
+//   - the seed data (_test_data_empire.sql) repeats that same predicate to
+//     keep scores.status agreeing with the events it seeds.
+//   - the analyst queries in docs/timespent_queries.sql and the progress
+//     query in scoreprogress.go filter on these literals inline.
+//
+// Renaming one of these constants' VALUES is therefore a data migration
+// (backfill the events table, update every SQL predicate above), not a
+// refactor. Renaming the Go identifier is free.
+const (
+	// eventActionCreated / eventActionUpdated / eventActionDeleted are derived
+	// from the SqlBuilder shape by recordEvent, so every write that flows
+	// through queryRow is attributed automatically.
+	eventActionCreated = "created"
+	eventActionUpdated = "updated"
+	eventActionDeleted = "deleted"
+
+	// eventActionViewed is recorded explicitly by RecordQuestionView. A view is
+	// not a table mutation, so no write path produces it.
+	eventActionViewed = "viewed"
+
+	// eventActionImported marks provenance for score data loaded outside the
+	// application - bulk imports and seed SQL, not a human answering a
+	// questionnaire. Nothing in this package writes it today; the value lives
+	// here so there is one authoritative home for it, because the readers that
+	// exclude it (0048's backfill, the seed status-sync, the last-updated
+	// lateral in scoreprogress.go) all depend on the exact spelling. A future
+	// bulk importer must write this action rather than reusing the in-app
+	// create/update path - see Score.Save.
+	//
+	// Having no Go writer is the point, so silence the unused check rather than
+	// leaving the value defined only in SQL and prose. If a Go importer ever
+	// does write it, staticcheck flags this directive as matching nothing and
+	// it should be deleted.
+	//lint:ignore U1000 defined as the authoritative spelling for SQL readers; no Go writer by design
+	eventActionImported = "imported"
+)
+
 // json tags here are used when payload is marshaled into select Where argument (see FindEvents() )
 type payload struct {
 	UserID        *string `schema:"userid" json:"userid,omitempty"`
@@ -60,13 +108,13 @@ func recordEvent(ctx context.Context, sqlb SqlBuilder, res interface{}) {
 
 	switch sqlb.(type) {
 	case squirrel.InsertBuilder:
-		e.Action = "created"
+		e.Action = eventActionCreated
 		e.Resource = eventData["Into"].(string)
 	case squirrel.UpdateBuilder:
-		e.Action = "updated"
+		e.Action = eventActionUpdated
 		e.Resource = eventData["Table"].(string)
 	case squirrel.DeleteBuilder:
-		e.Action = "deleted"
+		e.Action = eventActionDeleted
 		e.Resource = eventData["From"].(string)
 	default:
 		return
@@ -170,7 +218,7 @@ func RecordQuestionView(ctx context.Context, input QuestionViewInput, readOnly b
 		ReadOnly:      &readOnly,
 	}
 
-	return insertEvent(ctx, user.UserID, "viewed", "questionnaire", p)
+	return insertEvent(ctx, user.UserID, eventActionViewed, "questionnaire", p)
 }
 
 func FindEvents(ctx context.Context, input *FindEventsInput) ([]*Event, error) {

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -625,7 +625,7 @@ func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSy
 	if actor := UserFromContext(ctx); actor != nil {
 		if _, err := tx.Exec(ctx,
 			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
-			actor.UserID, "updated", "fismasystems", system,
+			actor.UserID, eventActionUpdated, "fismasystems", system,
 		); err != nil {
 			return nil, trapError(err)
 		}

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -32,6 +32,24 @@ func (r rawQuery) ToSql() (string, []any, error) {
 	return r.sql, r.args, nil
 }
 
+// Score review states, as stored in scores.status. Like the event actions in
+// events.go these are stored data rather than an internal enum: migration
+// 0048 pins the exact set with a CHECK constraint
+// (`status IN ('not_started', 'done')`), the seed data's status-sync writes
+// them, and the progress query in scoreprogress.go filters on them as inline
+// SQL literals. Changing a VALUE here is a data migration - a new CHECK, a
+// backfill of every stored row, and an update of every SQL predicate that
+// repeats the literal. Changing the Go identifier is free.
+const (
+	// scoreStatusDone means a human saved or confirmed this answer during the
+	// current data call.
+	scoreStatusDone = "done"
+	// scoreStatusNotStarted is the column default and the value
+	// copyPreviousScores seeds onto a carried-forward answer: the answer value
+	// survives the rollover, its review state for the new cycle does not.
+	scoreStatusNotStarted = "not_started"
+)
+
 type Score struct {
 	ScoreID          int32           `json:"scoreid"`
 	FismaSystemID    int32           `json:"fismasystemid"`
@@ -81,6 +99,29 @@ func WithCurrentScore(current *Score) ScoreSaveOption {
 	return func(c *scoreSaveConfig) { c.current = current }
 }
 
+// Save writes one answer for the current data call, as an interactive human
+// edit. It is the questionnaire's write path and it hardcodes that meaning:
+// every successful write sets status to scoreStatusDone, and the event it
+// records through queryRow carries action 'created' or 'updated' - the two
+// actions that migration 0048's backfill and the seed status-sync treat as
+// "a human answered this cycle".
+//
+// Importer contract (ztmf#445): a future bulk importer must NOT reuse Save as
+// it stands. Loading history through it would flip every imported row to done
+// and attribute it as an in-app edit, which is precisely the distinction the
+// status column exists to preserve - imported rows are supposed to stay
+// not_started and report no last-updated. An importer should either
+//
+//   - take an explicit status/provenance parameter added to Save (a
+//     ScoreSaveOption alongside WithCurrentScore is the natural shape), so the
+//     caller states the status to write and the action to record; or
+//   - write through its own path that inserts the rows and records action
+//     'imported' (eventActionImported in events.go), mirroring the provenance
+//     the 0048 backfill and the seed data deliberately exclude.
+//
+// Adding the parameter is the larger change of the two and was deliberately
+// left undone here rather than designed speculatively without an importer to
+// shape it.
 func (s *Score) Save(ctx context.Context, opts ...ScoreSaveOption) (*Score, error) {
 	var sqlb SqlBuilder
 
@@ -142,7 +183,7 @@ func (s *Score) Save(ctx context.Context, opts ...ScoreSaveOption) (*Score, erro
 		sqlb = stmntBuilder.
 			Insert("public.scores").
 			Columns("fismasystemid", "notes", "notes_is_ai_summary", "functionoptionid", "datacallid", "status").
-			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, "done").
+			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, scoreStatusDone).
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	} else {
 		// fismasystemid and datacallid are deliberately NOT in the SET list.
@@ -155,7 +196,7 @@ func (s *Score) Save(ctx context.Context, opts ...ScoreSaveOption) (*Score, erro
 		setCols := squirrel.Eq{
 			"notes":            s.Notes,
 			"functionoptionid": s.FunctionOptionID,
-			"status":           "done",
+			"status":           scoreStatusDone,
 		}
 		if s.NotesIsAISummary != nil {
 			setCols["notes_is_ai_summary"] = *s.NotesIsAISummary
@@ -229,7 +270,7 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 	// the current row with the same audit projection used after a real write,
 	// preserving the endpoint's idempotent 200 response without recording a
 	// second event.
-	if s.Status == "done" {
+	if s.Status == scoreStatusDone {
 		if at, by := lookupScoreAudit(ctx, s.ScoreID); at != nil && by != nil {
 			s.LastEditedAt = at
 			s.LastEditedBy = by
@@ -239,11 +280,11 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 
 	sqlb := stmntBuilder.
 		Update("public.scores").
-		Set("status", "done").
+		Set("status", scoreStatusDone).
 		// Keep the no-op guard in the write predicate as well as above. Two
 		// requests can both load not_started before either reaches Confirm; only
 		// the first must be allowed to update and create an audit event.
-		Where("scoreid=? AND status <> ?", s.ScoreID, "done").
+		Where("scoreid=? AND status <> ?", s.ScoreID, scoreStatusDone).
 		Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 
 	confirmed, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
@@ -256,7 +297,7 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 			if findErr != nil {
 				return nil, findErr
 			}
-			if current.Status == "done" {
+			if current.Status == scoreStatusDone {
 				if at, by := lookupScoreAudit(ctx, current.ScoreID); at != nil && by != nil {
 					current.LastEditedAt = at
 					current.LastEditedBy = by
@@ -1072,7 +1113,10 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 	// DISTINCT ON (fismasystemid, functionid) guarantees one answer per question -
 	// scores has no uniqueness constraint, so a cycle may hold duplicates.
 	//
-	// status is seeded 'not_started' as on the normal path (ztmf#435).
+	// status is seeded 'not_started' as on the normal path (ztmf#435). Written
+	// as a SQL literal inside this const rather than as scoreStatusNotStarted:
+	// the statement is a compile-time constant string so it can be read whole,
+	// and interpolating would trade that for no behavioral gain.
 	//
 	// The ::int casts are REQUIRED, not decoration. Both CASE branches are bind
 	// parameters, so Postgres resolves the CASE to text and the comparison becomes
@@ -1286,8 +1330,13 @@ func copyPreviousScores(ctx context.Context, dataCallID int32) (int64, error) {
 	// semantic the events lateral used to derive from "no event exists"
 	// (ztmf#299). The literal is a selected column so it lands in the same
 	// INSERT...SELECT as the copy, keeping the reset atomic with the row.
+	//
+	// Interpolated from scoreStatusNotStarted rather than hand-quoted so the
+	// value has one definition. It stays a selected literal, not a bind
+	// parameter: squirrel would append the placeholder's argument after the
+	// INSERT's own, and the constant is package-owned, never request input.
 	prevScoresSqlb := squirrel.
-		Select("s.fismasystemid", "s.datecalculated", "s.notes", "s.notes_is_ai_summary", "s.functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID), "'not_started' as status").
+		Select("s.fismasystemid", "s.datecalculated", "s.notes", "s.notes_is_ai_summary", "s.functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID), fmt.Sprintf("'%s' as status", scoreStatusNotStarted)).
 		From("scores s").
 		Join("fismasystems fs ON fs.fismasystemid = s.fismasystemid").
 		Join("functionoptions fo ON fo.functionoptionid = s.functionoptionid").

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -36,7 +36,8 @@ func (r rawQuery) ToSql() (string, []any, error) {
 // events.go these are stored data rather than an internal enum: migration
 // 0048 pins the exact set with a CHECK constraint
 // (`status IN ('not_started', 'done')`), the seed data's status-sync writes
-// them, and the progress query in scoreprogress.go filters on them as inline
+// 'done' while the column DEFAULT set in 0048 supplies 'not_started', and the
+// progress query in scoreprogress.go filters on them as inline
 // SQL literals. Changing a VALUE here is a data migration - a new CHECK, a
 // backfill of every stored row, and an update of every SQL predicate that
 // repeats the literal. Changing the Go identifier is free.
@@ -1332,9 +1333,16 @@ func copyPreviousScores(ctx context.Context, dataCallID int32) (int64, error) {
 	// INSERT...SELECT as the copy, keeping the reset atomic with the row.
 	//
 	// Interpolated from scoreStatusNotStarted rather than hand-quoted so the
-	// value has one definition. It stays a selected literal, not a bind
-	// parameter: squirrel would append the placeholder's argument after the
-	// INSERT's own, and the constant is package-owned, never request input.
+	// value has one definition. Safe to interpolate: the constant is
+	// package-owned, never request input.
+	//
+	// It stays a selected literal rather than becoming a bind parameter for two
+	// reasons. It keeps the emitted SQL byte-identical to what this statement
+	// has always produced; and an untyped $n in a SELECT list feeding an
+	// INSERT...SELECT walks into the same type-inference trap the sibling
+	// copySQL comment above documents at length for its ::int casts - Postgres
+	// resolves an unadorned placeholder to text and the column comparison
+	// fails at runtime.
 	prevScoresSqlb := squirrel.
 		Select("s.fismasystemid", "s.datecalculated", "s.notes", "s.notes_is_ai_summary", "s.functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID), fmt.Sprintf("'%s' as status", scoreStatusNotStarted)).
 		From("scores s").

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -566,7 +566,7 @@ func RestoreUser(ctx context.Context, userid string) (*User, error) {
 	if actor := UserFromContext(ctx); actor != nil {
 		if _, err := tx.Exec(ctx,
 			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
-			actor.UserID, "updated", "users", restored,
+			actor.UserID, eventActionUpdated, "users", restored,
 		); err != nil {
 			return nil, trapError(err)
 		}
@@ -835,7 +835,7 @@ func AddSystemDelegate(ctx context.Context, sys *FismaSystem, opdiv *OpDiv, acto
 	} {
 		if _, err = tx.Exec(ctx,
 			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
-			actorID, "created", ev.resource, ev.payload,
+			actorID, eventActionCreated, ev.resource, ev.payload,
 		); err != nil {
 			return nil, trapError(err)
 		}


### PR DESCRIPTION
Closes #445.

Both follow-ups from the #437 review, taken as a no-behavior-change chore: every diff line outside comments is a literal-to-constant substitution, and the emitted SQL and stored values are byte-identical.

## Event actions get one home

`created` / `updated` / `deleted` / `viewed` / `imported` now live as one const block in `internal/model/events.go`, used by every Go writer (`recordEvent`'s switch, `RecordQuestionView`, and the three transaction-manual audit inserts in `fismasystems.go` and `users.go`).

The doc comment carries the part that actually matters: these are stored data, not an internal enum. Migration 0048's backfill selects on `action IN ('created','updated')` and has already run in every environment; the seed status-sync and the progress query repeat the same literals. Renaming a **value** is therefore a data migration — backfill the events table, update every SQL predicate — while renaming the Go identifier is free. The SQL sites can't reference Go constants, so they get comments pointing back at the const block as the source of truth.

`eventActionImported` has no Go writer by design (it marks provenance for data loaded outside the app), so it carries a `lint:ignore U1000` explaining itself. One caveat verified empirically: staticcheck will NOT flag the directive as unmatched if a Go writer ever appears — U1000 ignores are exempt from its unmatched-directive check — so the comment says to delete it by hand. This is the one judgment call in the diff worth a reviewer's eye.

## Score statuses too, plus the importer contract on Save

`done` / `not_started` get the same treatment in `scores.go` (the 0048 CHECK constraint pins the set, so the same "changing a value is a migration" warning applies).

Per the issue's either/or, `Score.Save` documents which path a future importer extends rather than speculatively redesigning the write path: Save is the interactive-human write path — it flips status to done and records created/updated, exactly what the 0048 backfill treats as "a human answered this cycle" — so an importer either gets an explicit status/provenance `ScoreSaveOption` or writes its own path recording `imported`. Two deliberate keeps are commented in place: the `copyPreviousScoresOpDivHardcoded` statement stays a compile-time const string, and the `copyPreviousScores` select fragment interpolates the constant with `fmt.Sprintf` rather than a bind parameter (squirrel would misorder the placeholder args; commented at the site).

## Known convergence with #522

#522 adds `RecordLogin`, which passes `"created"` as a literal — invisible from this branch since both fork from main. Whichever lands second (or the batch branch carrying both) converts that one call site to `eventActionCreated`. One line, noted here so it isn't lost.

## Testing

- `go build`, `go vet`, `staticcheck` — clean
- `make test-unit`, `make test-integration` — pass
- `make generate-openapi` — zero diff (no API change, so no emberfall changes either)

