### PR TITLE
fix(monitoring): require 3-of-6 windows on the login auth-failure alarm

### DIFF
--- a/infrastructure/monitoring-login-auth.tf
+++ b/infrastructure/monitoring-login-auth.tf
@@ -63,12 +63,22 @@ resource "aws_cloudwatch_metric_alarm" "ztmf_login_elb_auth_error" {
 
 # ELBAuthFailure: the IdP response was REJECTED by the ALB (invalid id_token,
 # issuer/audience mismatch, or missing/invalid authorization code - i.e. a
-# redirect-URI or consent problem at the IdP). >0 in a 5-min window is
-# actionable and tells Batch 2 exactly what to look for in the IdP console.
+# redirect-URI or consent problem at the IdP).
+#
+# 3-of-6 rather than a single >0 window: five weeks of history (Jul-Aug 2026)
+# showed ~3 fires/week, every one a lone failure surrounded by successful
+# logins - back-button onto the callback, canceled login - and each costing an
+# ALARM + OK email pair to the shared inbox. A real problem is never a
+# singleton: a misconfigured IdP app or a user who cannot get in produces
+# repeated failures, which lands 3 breaching 5-min windows inside 30 minutes
+# and still pages well within one working session. The companion
+# ELBAuthError alarm above deliberately stays on a single window: ALB-side
+# auth breakage is rare and severe, and it fired zero times in the same span.
 resource "aws_cloudwatch_metric_alarm" "ztmf_login_elb_auth_failure" {
   alarm_name          = "ztmf-login-elb-auth-failure-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "6"
+  datapoints_to_alarm = "3"
   metric_name         = "ELBAuthFailure"
   namespace           = "AWS/ApplicationELB"
   period              = "300"


### PR DESCRIPTION
Tunes the prod login auth-failure alarm from "any single failure in a 5-minute window" to **3 breaching windows out of 6** (30 minutes).

## Why

Five weeks of alarm history (Jul 1 - Aug 5): ~3 ALARM transitions per week, every single one a lone `ELBAuthFailure` datapoint surrounded by healthy `ELBAuthSuccess` traffic — the most recent had 12 successful logins in the same hour. That pattern is a user hitting back onto the OIDC callback or abandoning a login, not a configuration problem, and each occurrence sends an ALARM + OK email pair to the shared inbox. At data-call traffic levels this only gets louder, and the alert loses its meaning right when we need it watching the Entra rollout.

A real problem — a misconfigured IdP app, a user who cannot get in and keeps retrying — produces repeated failures. Those land 3 breaching 5-minute windows inside half an hour and still page well within one working session. Singletons never fire.

The companion `ELBAuthError` alarm (ALB-side auth breakage: IdP unreachable, bad client secret) deliberately keeps its single-window trigger: that class is rare and severe, and it fired zero times over the same five weeks.

## What changed

`evaluation_periods` 1 → 6, `datapoints_to_alarm` 3 (new). Threshold, period, statistic, missing-data handling, and both notification routes unchanged. Dev and prod both pick it up via `var.environment`.

## Deploy note

Holding as draft until the current backend batch merges — marking ready triggers the DEV apply and the lane is busy today.
