### PR TITLE
fix(#526): export the full questionnaire per system, not just answered rows

### DIFF
--- a/backend/cmd/api/internal/spreadsheet/spreadsheet.go
+++ b/backend/cmd/api/internal/spreadsheet/spreadsheet.go
@@ -34,10 +34,12 @@ func Excel(answers []*model.Answer) (*excelize.File, error) {
 		f.SetCellValue(sheet, fmt.Sprintf("D%d", row), a.Function)
 		f.SetCellValue(sheet, fmt.Sprintf("E%d", row), a.Description)
 		f.SetCellValue(sheet, fmt.Sprintf("F%d", row), a.Question)
-		f.SetCellValue(sheet, fmt.Sprintf("G%d", row), a.OptionDescription)
-		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), a.OptionName)
-		f.SetCellValue(sheet, fmt.Sprintf("I%d", row), a.Score)
-		f.SetCellValue(sheet, fmt.Sprintf("J%d", row), a.Notes)
+		f.SetCellValue(sheet, fmt.Sprintf("G%d", row), derefString(a.OptionDescription))
+		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), derefString(a.OptionName))
+		if a.Score != nil {
+			f.SetCellValue(sheet, fmt.Sprintf("I%d", row), *a.Score)
+		}
+		f.SetCellValue(sheet, fmt.Sprintf("J%d", row), derefString(a.Notes))
 		// NULL target = no explicit assertion yet; the app-wide default is
 		// Advanced, and the export says so rather than leaving readers to guess.
 		targetTier := "Advanced (default)"
@@ -53,4 +55,13 @@ func Excel(answers []*model.Answer) (*excelize.File, error) {
 	}
 
 	return f, nil
+}
+
+// derefString returns the pointed-to string, or "" when the pointer is nil, so a
+// not-started answer renders as a blank cell rather than a zero value.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/backend/cmd/api/internal/spreadsheet/spreadsheet_test.go
+++ b/backend/cmd/api/internal/spreadsheet/spreadsheet_test.go
@@ -1,0 +1,67 @@
+package spreadsheet
+
+import (
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func strptr(s string) *string { return &s }
+func intptr(i int) *int       { return &i }
+
+// TestExcelRendersNotStartedBlankVsRealZero pins the #526 distinction in the
+// output cells: a function the system never answered (nil option/score/notes)
+// renders as blank, while a function genuinely answered at score 0 renders "0".
+// The two must read differently, which is the whole point of carrying the answer
+// fields as nullable rather than coalescing an absent answer to zero.
+func TestExcelRendersNotStartedBlankVsRealZero(t *testing.T) {
+	answers := []*model.Answer{
+		{ // row 2: applicable function, never answered
+			FismaAcronym:          "SYS-NOTSTARTED",
+			DataCenterEnvironment: "Env",
+			Pillar:                "Identity",
+			Function:              "Fn",
+			Description:           "Desc",
+			Question:              "Q",
+			OptionDescription:     nil,
+			OptionName:            nil,
+			Score:                 nil,
+			Notes:                 nil,
+		},
+		{ // row 3: answered at a genuine zero
+			FismaAcronym:          "SYS-ZERO",
+			DataCenterEnvironment: "Env",
+			Pillar:                "Identity",
+			Function:              "Fn",
+			Description:           "Desc",
+			Question:              "Q",
+			OptionDescription:     strptr("Lowest tier"),
+			OptionName:            strptr("Traditional"),
+			Score:                 intptr(0),
+			Notes:                 strptr("some note"),
+		},
+	}
+
+	f, err := Excel(answers)
+	require.NoError(t, err)
+
+	get := func(cell string) string {
+		v, err := f.GetCellValue("Sheet1", cell)
+		require.NoError(t, err)
+		return v
+	}
+
+	// Not-started row: answer, tier, score, and notes cells are all blank.
+	assert.Equal(t, "", get("G2"), "not-started answer cell should be blank")
+	assert.Equal(t, "", get("H2"), "not-started tier cell should be blank")
+	assert.Equal(t, "", get("I2"), "not-started score cell should be blank, not 0")
+	assert.Equal(t, "", get("J2"), "not-started notes cell should be blank")
+
+	// Real-zero row: the score renders 0, distinguishable from the blank above.
+	assert.Equal(t, "Lowest tier", get("G3"))
+	assert.Equal(t, "Traditional", get("H3"))
+	assert.Equal(t, "0", get("I3"), "a genuine zero score must render 0, not blank")
+	assert.Equal(t, "some note", get("J3"))
+}

--- a/backend/internal/model/answers.go
+++ b/backend/internal/model/answers.go
@@ -16,10 +16,15 @@ type Answer struct {
 	Question              string
 	Function              string
 	Description           string
-	OptionDescription     string
-	OptionName            string
-	Score                 int
-	Notes                 string
+	// The selected option and its notes are nil for an applicable function the
+	// system has not answered in this data call: FindAnswers left joins scores
+	// off the questionnaire, so an unanswered function still yields a row but
+	// carries no score. The export renders these as blank, which distinguishes a
+	// never-answered function from one genuinely answered at score 0.
+	OptionDescription     *string
+	OptionName            *string
+	Score                 *int
+	Notes                 *string
 	NotesIsAISummary      *bool `db:"notes_is_ai_summary"`
 	// Per-system target maturity (#398); nil when no target has been asserted
 	// (the export renders the Advanced default in that case).
@@ -39,13 +44,14 @@ type FindAnswersInput struct {
 // this is primarily meant for use in exporting to spreadsheets
 func FindAnswers(ctx context.Context, input FindAnswersInput) ([]*Answer, error) {
 	sqlb := stmntBuilder.Select("datacalls.datacall, fismasystems.fismasystemid, fismasystems.fismaacronym, fismasystems.datacenterenvironment, fismasystems.target_maturity_tier, fismasystems.target_maturity_justification, pillars.pillar, questions.question, functions.function, functions.description, functionoptions.description AS optiondescription, functionoptions.optionname, functionoptions.score, scores.notes, scores.notes_is_ai_summary").
-		From("scores").
-		InnerJoin("datacalls ON datacalls.datacallid=scores.datacallid AND datacalls.datacallid=?", input.DataCallID).
-		InnerJoin("fismasystems ON fismasystems.fismasystemid=scores.fismasystemid").
-		InnerJoin("functionoptions ON functionoptions.functionoptionid=scores.functionoptionid").
-		InnerJoin("functions ON functions.functionid=functionoptions.functionid").
+		From("fismasystems").
+		InnerJoin("functions ON (EXISTS (SELECT 1 FROM datacenterenvironments dce WHERE dce.datacenterenvironment=fismasystems.datacenterenvironment AND dce.scoring_key=functions.datacenterenvironment) OR EXISTS (SELECT 1 FROM scores answered JOIN functionoptions answeredopt ON answeredopt.functionoptionid=answered.functionoptionid WHERE answered.fismasystemid=fismasystems.fismasystemid AND answered.datacallid=? AND answeredopt.functionid=functions.functionid))", input.DataCallID).
 		InnerJoin("questions ON questions.questionid=functions.questionid").
-		InnerJoin("pillars ON pillars.pillarid=functions.pillarid").
+		InnerJoin("pillars ON pillars.pillarid=questions.pillarid").
+		InnerJoin("datacalls ON datacalls.datacallid=?", input.DataCallID).
+		LeftJoin("scores ON scores.fismasystemid=fismasystems.fismasystemid AND scores.datacallid=? AND scores.functionoptionid IN (SELECT selected.functionoptionid FROM functionoptions selected WHERE selected.functionid=functions.functionid)", input.DataCallID).
+		LeftJoin("functionoptions ON functionoptions.functionoptionid=scores.functionoptionid").
+		Where("(fismasystems.decommissioned=FALSE OR scores.scoreid IS NOT NULL)").
 		OrderBy("fismasystems.fismasystemid, pillars.ordr, questions.ordr ASC")
 
 	if input.UserID != nil {

--- a/backend/internal/model/answers_integration_test.go
+++ b/backend/internal/model/answers_integration_test.go
@@ -1,0 +1,184 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindAnswersIntegration pins the #526 behavior against the real SQL: the
+// export is anchored on the applicable-function set, not on scores, so a system
+// that has not answered a function still appears with a blank (nil) answer, and
+// the applicable set per system matches what the questionnaire and
+// /scores/progress resolve. It also pins the decommissioned-or-answered guard:
+// a decommissioned system is included only for functions it actually answered,
+// preserving the historical rows the scores-anchored export produced without
+// padding the file with blank questionnaires for retired systems.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindAnswersIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// A never-started pair: an active system applicable to at least one function
+	// that has no score rows in some data call. This is exactly the population the
+	// old scores-anchored export dropped.
+	var neverStartedSystem, neverStartedCall int32
+	err = conn.QueryRow(ctx, `
+		SELECT fs.fismasystemid, dc.datacallid
+		FROM fismasystems fs
+		JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		JOIN functions f ON f.datacenterenvironment = dce.scoring_key
+		CROSS JOIN datacalls dc
+		WHERE fs.decommissioned = FALSE
+		  AND NOT EXISTS (SELECT 1 FROM scores s WHERE s.fismasystemid = fs.fismasystemid AND s.datacallid = dc.datacallid)
+		GROUP BY fs.fismasystemid, dc.datacallid
+		ORDER BY fs.fismasystemid, dc.datacallid
+		LIMIT 1
+	`).Scan(&neverStartedSystem, &neverStartedCall)
+	require.NoError(t, err, "seed should contain at least one active never-started (system, datacall) pair")
+
+	// How many functions apply to that system, resolved the same way the
+	// questionnaire and /scores/progress resolve them.
+	var applicableCount int
+	err = conn.QueryRow(ctx, `
+		SELECT COUNT(DISTINCT f.functionid)
+		FROM fismasystems fs
+		JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		JOIN functions f ON f.datacenterenvironment = dce.scoring_key
+		JOIN questions q ON q.questionid = f.questionid
+		JOIN pillars p ON p.pillarid = q.pillarid
+		WHERE fs.fismasystemid = $1
+	`, neverStartedSystem).Scan(&applicableCount)
+	require.NoError(t, err)
+	require.Greater(t, applicableCount, 0)
+
+	// The export for that call, scoped to the never-started system.
+	rows, err := FindAnswers(ctx, FindAnswersInput{
+		DataCallID:     neverStartedCall,
+		FismaSystemIDs: []*int32{&neverStartedSystem},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, rows, applicableCount,
+		"a never-started system should contribute one row per applicable function, matching /scores/progress")
+	for _, r := range rows {
+		assert.Equal(t, neverStartedSystem, r.FismaSystemID)
+		assert.Nil(t, r.Score, "a never-started function must carry a nil score, not a coalesced zero")
+		assert.Nil(t, r.OptionName, "a never-started function must carry a nil option")
+		assert.Nil(t, r.Notes, "a never-started function must carry nil notes")
+	}
+
+	// Regression guard: an answered system in the same call still exports its
+	// selected options. Find one that has scores in this call.
+	var answeredSystem int32
+	err = conn.QueryRow(ctx, `
+		SELECT DISTINCT s.fismasystemid
+		FROM scores s
+		JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		WHERE s.datacallid = $1 AND fs.decommissioned = FALSE
+		LIMIT 1
+	`, neverStartedCall).Scan(&answeredSystem)
+	if err == nil {
+		answeredRows, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID:     neverStartedCall,
+			FismaSystemIDs: []*int32{&answeredSystem},
+		})
+		require.NoError(t, err)
+		var withAnswer int
+		for _, r := range answeredRows {
+			if r.Score != nil {
+				withAnswer++
+				assert.NotNil(t, r.OptionName, "an answered row should carry its selected option")
+			}
+		}
+		assert.Greater(t, withAnswer, 0, "an answered system should still export its answered functions")
+	}
+
+	// Orphaned answers (the reason FindAnswers keys off applicable-OR-answered,
+	// not applicable alone): an active system whose answers reference functions no
+	// longer applicable to its current environment must still export those answers,
+	// not vanish. Find an active system with scores whose applicable set does not
+	// cover every answered function.
+	var orphanSystem, orphanCall int32
+	var orphanAnswered int
+	err = conn.QueryRow(ctx, `
+		SELECT s.fismasystemid, s.datacallid, COUNT(DISTINCT fo.functionid) AS answered
+		FROM scores s
+		JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+		JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		WHERE fs.decommissioned = FALSE
+		  AND NOT EXISTS (
+		      SELECT 1 FROM datacenterenvironments dce
+		      JOIN functions af ON af.datacenterenvironment = dce.scoring_key
+		      WHERE dce.datacenterenvironment = fs.datacenterenvironment AND af.functionid = fo.functionid)
+		GROUP BY s.fismasystemid, s.datacallid
+		ORDER BY s.fismasystemid, s.datacallid
+		LIMIT 1
+	`).Scan(&orphanSystem, &orphanCall, &orphanAnswered)
+	if err == nil {
+		orphanRows, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID:     orphanCall,
+			FismaSystemIDs: []*int32{&orphanSystem},
+		})
+		require.NoError(t, err)
+		var answered int
+		for _, r := range orphanRows {
+			if r.Score != nil {
+				answered++
+			}
+		}
+		assert.GreaterOrEqual(t, answered, orphanAnswered,
+			"an active system's orphaned answers (functions no longer applicable) must still export, not drop")
+	} else {
+		t.Log("no active system with orphaned answers in seed; skipping the orphaned-answer assertion")
+	}
+
+	// Decommissioned-or-answered guard: a decommissioned system is included only
+	// for functions it actually answered. Find a decommissioned system with
+	// scores in some call and assert its export equals its answered-function
+	// count, all rows non-nil.
+	var decomSystem, decomCall int32
+	err = conn.QueryRow(ctx, `
+		SELECT fs.fismasystemid, s.datacallid
+		FROM fismasystems fs
+		JOIN scores s ON s.fismasystemid = fs.fismasystemid
+		WHERE fs.decommissioned = TRUE
+		GROUP BY fs.fismasystemid, s.datacallid
+		ORDER BY fs.fismasystemid, s.datacallid
+		LIMIT 1
+	`).Scan(&decomSystem, &decomCall)
+	if err == nil {
+		var answeredFns int
+		err = conn.QueryRow(ctx, `
+			SELECT COUNT(DISTINCT fo.functionid)
+			FROM scores s
+			JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+			WHERE s.fismasystemid = $1 AND s.datacallid = $2
+		`, decomSystem, decomCall).Scan(&answeredFns)
+		require.NoError(t, err)
+
+		decomRows, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID:     decomCall,
+			FismaSystemIDs: []*int32{&decomSystem},
+		})
+		require.NoError(t, err)
+		assert.Len(t, decomRows, answeredFns,
+			"a decommissioned system should export only its answered functions, not a full blank questionnaire")
+		for _, r := range decomRows {
+			assert.NotNil(t, r.Score, "a decommissioned system's exported rows must all be answered rows")
+		}
+	} else {
+		t.Log("no decommissioned system with scores in seed; skipping the decommissioned-guard assertion")
+	}
+}


### PR DESCRIPTION
## What and why

The data call export was anchored on the `scores` table, so a system with no score rows for the call contributed nothing to the xlsx and no warning said so. After the HHS onboarding and FY26 inventory load that hides most of an OpDiv's inventory from the export. This re-anchors `FindAnswers` on the questionnaire: per system, every function either applicable to its environment or answered by it in the call, left joined to scores. An unanswered applicable function now exports as a blank row instead of being absent.

Closes #526. Frontend half is CMS-Enterprise/ztmf-ui#678.

## Changes

- `FindAnswers` drives from `fismasystems` and the applicable-or-answered function set, left joining scores, replacing the scores-anchored inner-join chain. Applicability is resolved through the `datacenterenvironments` scoring vocabulary with pillars taken through questions, matching the questionnaire and `/scores/progress` exactly.
- `Answer.OptionDescription`, `OptionName`, `Score`, and `Notes` become pointers, nil for an unanswered function; the spreadsheet renders nil as a blank cell, so a never-answered function is distinguishable from one genuinely answered at score 0.
- Two guards keep the file a superset of the old output: decommissioned systems appear only for functions they actually answered, and answered-but-no-longer-applicable functions (orphaned by an environment change) are retained rather than dropped.

## Behavior

A call's export now covers every participating system as a full questionnaire, blank where unanswered, rather than only systems with scores. Fully-answered, decommissioned, and env-orphaned systems keep exactly the rows they produced before. Scope (OpDiv/user) behavior is unchanged.

## Tests

- Unit: the blank-vs-real-zero rendering distinction.
- Integration: never-started inclusion with a per-system count matching `/scores/progress`, the answered-row regression, orphaned-answer retention, and the decommissioned guard, all against the seeded DB.
- Verified live against the dev stack: a never-started system returns its blank questionnaire and an env-orphaned system keeps its answers.
- `make test-unit`, `make test-integration`, `make test-e2e` green; no openapi drift.

Snyk and deploy checks show red on fork PRs (no repo secrets); those are re-run by maintainers after pulling the branch.
