### PR TITLE
Code freeze batch 2 (backend): last_seen, event-action constants, full-questionnaire export

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -1029,6 +1029,12 @@ SELECT '00000000-0000-4000-8000-000000000001', 'imported', 'public.scores',
 -- FY2020 archives block) are excluded via the same action filter the migration
 -- uses, so imported history stays not_started. Keeps this consistent
 -- automatically as the events seed above changes.
+--
+-- The action values here (and in the 'imported' events seeded above) are SQL
+-- literals because SQL cannot reference a Go constant; they are the same values
+-- defined as eventAction* in internal/model/events.go, which is the source of
+-- truth for the set. Changing an action value there means updating these
+-- literals and backfilling stored rows, not a rename.
 UPDATE public.scores s
 SET status = 'done'
 WHERE EXISTS (

--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -176,6 +176,15 @@ func SessionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	SetSessionCookie(w, token)
+
+	// Record the login. Fire-and-forget by design: the session is already
+	// minted and the cookie already set, so failing the redirect over an audit
+	// write would deny a user access for a bookkeeping problem. Logged, not
+	// returned - the same trade recordEvent makes for write-derived events.
+	if err := model.RecordLogin(r.Context(), user.UserID); err != nil {
+		log.Printf("login: failed to record session event for %s: %s\n", user.UserID, err)
+	}
+
 	http.Redirect(w, r, "/", http.StatusFound)
 }
 

--- a/backend/cmd/api/internal/auth/session.go
+++ b/backend/cmd/api/internal/auth/session.go
@@ -177,10 +177,14 @@ func SessionHandler(w http.ResponseWriter, r *http.Request) {
 
 	SetSessionCookie(w, token)
 
-	// Record the login. Fire-and-forget by design: the session is already
-	// minted and the cookie already set, so failing the redirect over an audit
-	// write would deny a user access for a bookkeeping problem. Logged, not
-	// returned - the same trade recordEvent makes for write-derived events.
+	// Record the login. Fire-and-forget by design: the session is minted and
+	// the Set-Cookie header staged, so failing the redirect over an audit write
+	// would deny a user access for a bookkeeping problem. Logged, not returned -
+	// the same trade recordEvent makes for write-derived events.
+	//
+	// The failure direction is the safe one: a dropped write makes an active
+	// account look stale, which costs a needless review, and can never make a
+	// stale account look active.
 	if err := model.RecordLogin(r.Context(), user.UserID); err != nil {
 		log.Printf("login: failed to record session event for %s: %s\n", user.UserID, err)
 	}

--- a/backend/cmd/api/internal/migrations/0048scoresstatus.go
+++ b/backend/cmd/api/internal/migrations/0048scoresstatus.go
@@ -41,6 +41,13 @@ ALTER TABLE public.scores
 -- loaded outside the app is attributed with 'imported' provenance events so it
 -- carries a who/when, but an import is not a human answering this cycle - those
 -- events must NOT flip the row to done, so they are excluded here.
+--
+-- The action values below are SQL literals because SQL cannot reference a Go
+-- constant; they are the same values defined as eventAction* in
+-- internal/model/events.go, which is the source of truth for the set. This
+-- migration has already run in every environment, so its SQL is frozen -
+-- changing an action value means backfilling the events table and updating
+-- every SQL predicate that repeats these literals, not editing this file.
 UPDATE public.scores s
 SET status = 'done'
 WHERE EXISTS (

--- a/backend/cmd/api/internal/migrations/0054eventsuserindex.go
+++ b/backend/cmd/api/internal/migrations/0054eventsuserindex.go
@@ -1,0 +1,27 @@
+package migrations
+
+func init() {
+	appendMigration(
+		"add per-user index on events for last-seen lookups",
+		`
+-- The users list derives last_seen as MAX(events.createdat) per user, one
+-- correlated subquery per row, the same shape the existing assignedopdivids
+-- subquery uses. events carries no userid index today: it has one on
+-- (resource, createdat) and a partial one on the scoreid expression, neither
+-- of which serves a lookup keyed on userid.
+--
+-- Without this the subquery is a sequential scan of events per user row. At
+-- roughly 200k events and 1,250 users that is a full scan per row on a page
+-- an admin loads routinely, which is exactly the regression 0037 was written
+-- to avoid for the score audit lateral.
+--
+-- createdat DESC alongside userid so the MAX is an index-only descent to the
+-- first matching entry rather than an aggregate over the whole partition.
+-- Not partial: unlike the score audit index there is no single resource worth
+-- narrowing to, since last_seen deliberately counts activity of any kind.
+CREATE INDEX IF NOT EXISTS events_user_activity_idx
+    ON public.events (userid, createdat DESC);
+`,
+		`DROP INDEX IF EXISTS events_user_activity_idx;`,
+	)
+}

--- a/backend/cmd/api/internal/spreadsheet/spreadsheet.go
+++ b/backend/cmd/api/internal/spreadsheet/spreadsheet.go
@@ -34,10 +34,12 @@ func Excel(answers []*model.Answer) (*excelize.File, error) {
 		f.SetCellValue(sheet, fmt.Sprintf("D%d", row), a.Function)
 		f.SetCellValue(sheet, fmt.Sprintf("E%d", row), a.Description)
 		f.SetCellValue(sheet, fmt.Sprintf("F%d", row), a.Question)
-		f.SetCellValue(sheet, fmt.Sprintf("G%d", row), a.OptionDescription)
-		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), a.OptionName)
-		f.SetCellValue(sheet, fmt.Sprintf("I%d", row), a.Score)
-		f.SetCellValue(sheet, fmt.Sprintf("J%d", row), a.Notes)
+		f.SetCellValue(sheet, fmt.Sprintf("G%d", row), derefString(a.OptionDescription))
+		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), derefString(a.OptionName))
+		if a.Score != nil {
+			f.SetCellValue(sheet, fmt.Sprintf("I%d", row), *a.Score)
+		}
+		f.SetCellValue(sheet, fmt.Sprintf("J%d", row), derefString(a.Notes))
 		// NULL target = no explicit assertion yet; the app-wide default is
 		// Advanced, and the export says so rather than leaving readers to guess.
 		targetTier := "Advanced (default)"
@@ -53,4 +55,13 @@ func Excel(answers []*model.Answer) (*excelize.File, error) {
 	}
 
 	return f, nil
+}
+
+// derefString returns the pointed-to string, or "" when the pointer is nil, so a
+// not-started answer renders as a blank cell rather than a zero value.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/backend/cmd/api/internal/spreadsheet/spreadsheet_test.go
+++ b/backend/cmd/api/internal/spreadsheet/spreadsheet_test.go
@@ -1,0 +1,67 @@
+package spreadsheet
+
+import (
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func strptr(s string) *string { return &s }
+func intptr(i int) *int       { return &i }
+
+// TestExcelRendersNotStartedBlankVsRealZero pins the #526 distinction in the
+// output cells: a function the system never answered (nil option/score/notes)
+// renders as blank, while a function genuinely answered at score 0 renders "0".
+// The two must read differently, which is the whole point of carrying the answer
+// fields as nullable rather than coalescing an absent answer to zero.
+func TestExcelRendersNotStartedBlankVsRealZero(t *testing.T) {
+	answers := []*model.Answer{
+		{ // row 2: applicable function, never answered
+			FismaAcronym:          "SYS-NOTSTARTED",
+			DataCenterEnvironment: "Env",
+			Pillar:                "Identity",
+			Function:              "Fn",
+			Description:           "Desc",
+			Question:              "Q",
+			OptionDescription:     nil,
+			OptionName:            nil,
+			Score:                 nil,
+			Notes:                 nil,
+		},
+		{ // row 3: answered at a genuine zero
+			FismaAcronym:          "SYS-ZERO",
+			DataCenterEnvironment: "Env",
+			Pillar:                "Identity",
+			Function:              "Fn",
+			Description:           "Desc",
+			Question:              "Q",
+			OptionDescription:     strptr("Lowest tier"),
+			OptionName:            strptr("Traditional"),
+			Score:                 intptr(0),
+			Notes:                 strptr("some note"),
+		},
+	}
+
+	f, err := Excel(answers)
+	require.NoError(t, err)
+
+	get := func(cell string) string {
+		v, err := f.GetCellValue("Sheet1", cell)
+		require.NoError(t, err)
+		return v
+	}
+
+	// Not-started row: answer, tier, score, and notes cells are all blank.
+	assert.Equal(t, "", get("G2"), "not-started answer cell should be blank")
+	assert.Equal(t, "", get("H2"), "not-started tier cell should be blank")
+	assert.Equal(t, "", get("I2"), "not-started score cell should be blank, not 0")
+	assert.Equal(t, "", get("J2"), "not-started notes cell should be blank")
+
+	// Real-zero row: the score renders 0, distinguishable from the blank above.
+	assert.Equal(t, "Lowest tier", get("G3"))
+	assert.Equal(t, "Traditional", get("H3"))
+	assert.Equal(t, "0", get("I3"), "a genuine zero score must render 0, not blank")
+	assert.Equal(t, "some note", get("J3"))
+}

--- a/backend/internal/model/answers.go
+++ b/backend/internal/model/answers.go
@@ -16,10 +16,15 @@ type Answer struct {
 	Question              string
 	Function              string
 	Description           string
-	OptionDescription     string
-	OptionName            string
-	Score                 int
-	Notes                 string
+	// The selected option and its notes are nil for an applicable function the
+	// system has not answered in this data call: FindAnswers left joins scores
+	// off the questionnaire, so an unanswered function still yields a row but
+	// carries no score. The export renders these as blank, which distinguishes a
+	// never-answered function from one genuinely answered at score 0.
+	OptionDescription     *string
+	OptionName            *string
+	Score                 *int
+	Notes                 *string
 	NotesIsAISummary      *bool `db:"notes_is_ai_summary"`
 	// Per-system target maturity (#398); nil when no target has been asserted
 	// (the export renders the Advanced default in that case).
@@ -39,13 +44,14 @@ type FindAnswersInput struct {
 // this is primarily meant for use in exporting to spreadsheets
 func FindAnswers(ctx context.Context, input FindAnswersInput) ([]*Answer, error) {
 	sqlb := stmntBuilder.Select("datacalls.datacall, fismasystems.fismasystemid, fismasystems.fismaacronym, fismasystems.datacenterenvironment, fismasystems.target_maturity_tier, fismasystems.target_maturity_justification, pillars.pillar, questions.question, functions.function, functions.description, functionoptions.description AS optiondescription, functionoptions.optionname, functionoptions.score, scores.notes, scores.notes_is_ai_summary").
-		From("scores").
-		InnerJoin("datacalls ON datacalls.datacallid=scores.datacallid AND datacalls.datacallid=?", input.DataCallID).
-		InnerJoin("fismasystems ON fismasystems.fismasystemid=scores.fismasystemid").
-		InnerJoin("functionoptions ON functionoptions.functionoptionid=scores.functionoptionid").
-		InnerJoin("functions ON functions.functionid=functionoptions.functionid").
+		From("fismasystems").
+		InnerJoin("functions ON (EXISTS (SELECT 1 FROM datacenterenvironments dce WHERE dce.datacenterenvironment=fismasystems.datacenterenvironment AND dce.scoring_key=functions.datacenterenvironment) OR EXISTS (SELECT 1 FROM scores answered JOIN functionoptions answeredopt ON answeredopt.functionoptionid=answered.functionoptionid WHERE answered.fismasystemid=fismasystems.fismasystemid AND answered.datacallid=? AND answeredopt.functionid=functions.functionid))", input.DataCallID).
 		InnerJoin("questions ON questions.questionid=functions.questionid").
-		InnerJoin("pillars ON pillars.pillarid=functions.pillarid").
+		InnerJoin("pillars ON pillars.pillarid=questions.pillarid").
+		InnerJoin("datacalls ON datacalls.datacallid=?", input.DataCallID).
+		LeftJoin("scores ON scores.fismasystemid=fismasystems.fismasystemid AND scores.datacallid=? AND scores.functionoptionid IN (SELECT selected.functionoptionid FROM functionoptions selected WHERE selected.functionid=functions.functionid)", input.DataCallID).
+		LeftJoin("functionoptions ON functionoptions.functionoptionid=scores.functionoptionid").
+		Where("(fismasystems.decommissioned=FALSE OR scores.scoreid IS NOT NULL)").
 		OrderBy("fismasystems.fismasystemid, pillars.ordr, questions.ordr ASC")
 
 	if input.UserID != nil {

--- a/backend/internal/model/answers_integration_test.go
+++ b/backend/internal/model/answers_integration_test.go
@@ -1,0 +1,184 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindAnswersIntegration pins the #526 behavior against the real SQL: the
+// export is anchored on the applicable-function set, not on scores, so a system
+// that has not answered a function still appears with a blank (nil) answer, and
+// the applicable set per system matches what the questionnaire and
+// /scores/progress resolve. It also pins the decommissioned-or-answered guard:
+// a decommissioned system is included only for functions it actually answered,
+// preserving the historical rows the scores-anchored export produced without
+// padding the file with blank questionnaires for retired systems.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindAnswersIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// A never-started pair: an active system applicable to at least one function
+	// that has no score rows in some data call. This is exactly the population the
+	// old scores-anchored export dropped.
+	var neverStartedSystem, neverStartedCall int32
+	err = conn.QueryRow(ctx, `
+		SELECT fs.fismasystemid, dc.datacallid
+		FROM fismasystems fs
+		JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		JOIN functions f ON f.datacenterenvironment = dce.scoring_key
+		CROSS JOIN datacalls dc
+		WHERE fs.decommissioned = FALSE
+		  AND NOT EXISTS (SELECT 1 FROM scores s WHERE s.fismasystemid = fs.fismasystemid AND s.datacallid = dc.datacallid)
+		GROUP BY fs.fismasystemid, dc.datacallid
+		ORDER BY fs.fismasystemid, dc.datacallid
+		LIMIT 1
+	`).Scan(&neverStartedSystem, &neverStartedCall)
+	require.NoError(t, err, "seed should contain at least one active never-started (system, datacall) pair")
+
+	// How many functions apply to that system, resolved the same way the
+	// questionnaire and /scores/progress resolve them.
+	var applicableCount int
+	err = conn.QueryRow(ctx, `
+		SELECT COUNT(DISTINCT f.functionid)
+		FROM fismasystems fs
+		JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		JOIN functions f ON f.datacenterenvironment = dce.scoring_key
+		JOIN questions q ON q.questionid = f.questionid
+		JOIN pillars p ON p.pillarid = q.pillarid
+		WHERE fs.fismasystemid = $1
+	`, neverStartedSystem).Scan(&applicableCount)
+	require.NoError(t, err)
+	require.Greater(t, applicableCount, 0)
+
+	// The export for that call, scoped to the never-started system.
+	rows, err := FindAnswers(ctx, FindAnswersInput{
+		DataCallID:     neverStartedCall,
+		FismaSystemIDs: []*int32{&neverStartedSystem},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, rows, applicableCount,
+		"a never-started system should contribute one row per applicable function, matching /scores/progress")
+	for _, r := range rows {
+		assert.Equal(t, neverStartedSystem, r.FismaSystemID)
+		assert.Nil(t, r.Score, "a never-started function must carry a nil score, not a coalesced zero")
+		assert.Nil(t, r.OptionName, "a never-started function must carry a nil option")
+		assert.Nil(t, r.Notes, "a never-started function must carry nil notes")
+	}
+
+	// Regression guard: an answered system in the same call still exports its
+	// selected options. Find one that has scores in this call.
+	var answeredSystem int32
+	err = conn.QueryRow(ctx, `
+		SELECT DISTINCT s.fismasystemid
+		FROM scores s
+		JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		WHERE s.datacallid = $1 AND fs.decommissioned = FALSE
+		LIMIT 1
+	`, neverStartedCall).Scan(&answeredSystem)
+	if err == nil {
+		answeredRows, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID:     neverStartedCall,
+			FismaSystemIDs: []*int32{&answeredSystem},
+		})
+		require.NoError(t, err)
+		var withAnswer int
+		for _, r := range answeredRows {
+			if r.Score != nil {
+				withAnswer++
+				assert.NotNil(t, r.OptionName, "an answered row should carry its selected option")
+			}
+		}
+		assert.Greater(t, withAnswer, 0, "an answered system should still export its answered functions")
+	}
+
+	// Orphaned answers (the reason FindAnswers keys off applicable-OR-answered,
+	// not applicable alone): an active system whose answers reference functions no
+	// longer applicable to its current environment must still export those answers,
+	// not vanish. Find an active system with scores whose applicable set does not
+	// cover every answered function.
+	var orphanSystem, orphanCall int32
+	var orphanAnswered int
+	err = conn.QueryRow(ctx, `
+		SELECT s.fismasystemid, s.datacallid, COUNT(DISTINCT fo.functionid) AS answered
+		FROM scores s
+		JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+		JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		WHERE fs.decommissioned = FALSE
+		  AND NOT EXISTS (
+		      SELECT 1 FROM datacenterenvironments dce
+		      JOIN functions af ON af.datacenterenvironment = dce.scoring_key
+		      WHERE dce.datacenterenvironment = fs.datacenterenvironment AND af.functionid = fo.functionid)
+		GROUP BY s.fismasystemid, s.datacallid
+		ORDER BY s.fismasystemid, s.datacallid
+		LIMIT 1
+	`).Scan(&orphanSystem, &orphanCall, &orphanAnswered)
+	if err == nil {
+		orphanRows, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID:     orphanCall,
+			FismaSystemIDs: []*int32{&orphanSystem},
+		})
+		require.NoError(t, err)
+		var answered int
+		for _, r := range orphanRows {
+			if r.Score != nil {
+				answered++
+			}
+		}
+		assert.GreaterOrEqual(t, answered, orphanAnswered,
+			"an active system's orphaned answers (functions no longer applicable) must still export, not drop")
+	} else {
+		t.Log("no active system with orphaned answers in seed; skipping the orphaned-answer assertion")
+	}
+
+	// Decommissioned-or-answered guard: a decommissioned system is included only
+	// for functions it actually answered. Find a decommissioned system with
+	// scores in some call and assert its export equals its answered-function
+	// count, all rows non-nil.
+	var decomSystem, decomCall int32
+	err = conn.QueryRow(ctx, `
+		SELECT fs.fismasystemid, s.datacallid
+		FROM fismasystems fs
+		JOIN scores s ON s.fismasystemid = fs.fismasystemid
+		WHERE fs.decommissioned = TRUE
+		GROUP BY fs.fismasystemid, s.datacallid
+		ORDER BY fs.fismasystemid, s.datacallid
+		LIMIT 1
+	`).Scan(&decomSystem, &decomCall)
+	if err == nil {
+		var answeredFns int
+		err = conn.QueryRow(ctx, `
+			SELECT COUNT(DISTINCT fo.functionid)
+			FROM scores s
+			JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+			WHERE s.fismasystemid = $1 AND s.datacallid = $2
+		`, decomSystem, decomCall).Scan(&answeredFns)
+		require.NoError(t, err)
+
+		decomRows, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID:     decomCall,
+			FismaSystemIDs: []*int32{&decomSystem},
+		})
+		require.NoError(t, err)
+		assert.Len(t, decomRows, answeredFns,
+			"a decommissioned system should export only its answered functions, not a full blank questionnaire")
+		for _, r := range decomRows {
+			assert.NotNil(t, r.Score, "a decommissioned system's exported rows must all be answered rows")
+		}
+	} else {
+		t.Log("no decommissioned system with scores in seed; skipping the decommissioned-guard assertion")
+	}
+}

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -52,16 +52,25 @@ const (
 	// eventActionImported marks provenance for score data loaded outside the
 	// application - bulk imports and seed SQL, not a human answering a
 	// questionnaire. Nothing in this package writes it today; the value lives
-	// here so there is one authoritative home for it, because the readers that
-	// exclude it (0048's backfill, the seed status-sync, the last-updated
-	// lateral in scoreprogress.go) all depend on the exact spelling. A future
-	// bulk importer must write this action rather than reusing the in-app
-	// create/update path - see Score.Save.
+	// here so there is one authoritative home for it.
+	//
+	// Note which consumers actually depend on the exact spelling: the readers
+	// that exclude imported rows (0048's backfill, the seed status-sync, the
+	// last-updated lateral in scoreprogress.go) do NOT name this value at all -
+	// they allowlist 'created'/'updated', so they would exclude an import under
+	// any spelling. The sites that would silently drift on a respelling are the
+	// WRITERS and the assertions over them: the seed INSERT in
+	// _test_data_empire.sql and scoreprogress_integration_test.go, which read
+	// back `action='imported'` to prove imported history stays not_started.
+	//
+	// A future bulk importer must write this action rather than reusing the
+	// in-app create/update path - see Score.Save.
 	//
 	// Having no Go writer is the point, so silence the unused check rather than
-	// leaving the value defined only in SQL and prose. If a Go importer ever
-	// does write it, staticcheck flags this directive as matching nothing and
-	// it should be deleted.
+	// leaving the value defined only in SQL and prose. Staticcheck will NOT
+	// tell you when this directive goes stale - U1000 ignores are exempt from
+	// its unmatched-directive check - so delete it by hand if a Go writer ever
+	// appears.
 	//lint:ignore U1000 defined as the authoritative spelling for SQL readers; no Go writer by design
 	eventActionImported = "imported"
 )

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -18,6 +18,54 @@ type Event struct {
 	Payload   interface{} `json:"payload"`   // incoming data
 }
 
+// Event actions. These are the complete set of values that may appear in
+// events.action, collected here so the Go writers agree by construction
+// instead of by five hand-repeated string literals staying in sync.
+//
+// Treat these as stored data, not as an internal enum: the values are
+// load-bearing well beyond this package, and several of the readers cannot
+// import Go at all.
+//
+//   - migration 0048's status backfill selects on
+//     `e.action IN ('created', 'updated')` as SQL literals, and it has already
+//     run in every environment - the rows it wrote are permanent.
+//   - the seed data (_test_data_empire.sql) repeats that same predicate to
+//     keep scores.status agreeing with the events it seeds.
+//   - the analyst queries in docs/timespent_queries.sql and the progress
+//     query in scoreprogress.go filter on these literals inline.
+//
+// Renaming one of these constants' VALUES is therefore a data migration
+// (backfill the events table, update every SQL predicate above), not a
+// refactor. Renaming the Go identifier is free.
+const (
+	// eventActionCreated / eventActionUpdated / eventActionDeleted are derived
+	// from the SqlBuilder shape by recordEvent, so every write that flows
+	// through queryRow is attributed automatically.
+	eventActionCreated = "created"
+	eventActionUpdated = "updated"
+	eventActionDeleted = "deleted"
+
+	// eventActionViewed is recorded explicitly by RecordQuestionView. A view is
+	// not a table mutation, so no write path produces it.
+	eventActionViewed = "viewed"
+
+	// eventActionImported marks provenance for score data loaded outside the
+	// application - bulk imports and seed SQL, not a human answering a
+	// questionnaire. Nothing in this package writes it today; the value lives
+	// here so there is one authoritative home for it, because the readers that
+	// exclude it (0048's backfill, the seed status-sync, the last-updated
+	// lateral in scoreprogress.go) all depend on the exact spelling. A future
+	// bulk importer must write this action rather than reusing the in-app
+	// create/update path - see Score.Save.
+	//
+	// Having no Go writer is the point, so silence the unused check rather than
+	// leaving the value defined only in SQL and prose. If a Go importer ever
+	// does write it, staticcheck flags this directive as matching nothing and
+	// it should be deleted.
+	//lint:ignore U1000 defined as the authoritative spelling for SQL readers; no Go writer by design
+	eventActionImported = "imported"
+)
+
 // json tags here are used when payload is marshaled into select Where argument (see FindEvents() )
 type payload struct {
 	UserID        *string `schema:"userid" json:"userid,omitempty"`
@@ -60,13 +108,13 @@ func recordEvent(ctx context.Context, sqlb SqlBuilder, res interface{}) {
 
 	switch sqlb.(type) {
 	case squirrel.InsertBuilder:
-		e.Action = "created"
+		e.Action = eventActionCreated
 		e.Resource = eventData["Into"].(string)
 	case squirrel.UpdateBuilder:
-		e.Action = "updated"
+		e.Action = eventActionUpdated
 		e.Resource = eventData["Table"].(string)
 	case squirrel.DeleteBuilder:
-		e.Action = "deleted"
+		e.Action = eventActionDeleted
 		e.Resource = eventData["From"].(string)
 	default:
 		return
@@ -170,7 +218,7 @@ func RecordQuestionView(ctx context.Context, input QuestionViewInput, readOnly b
 		ReadOnly:      &readOnly,
 	}
 
-	return insertEvent(ctx, user.UserID, "viewed", "questionnaire", p)
+	return insertEvent(ctx, user.UserID, eventActionViewed, "questionnaire", p)
 }
 
 // RecordLogin appends a "session / created" event for a user who has just

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -173,6 +173,30 @@ func RecordQuestionView(ctx context.Context, input QuestionViewInput, readOnly b
 	return insertEvent(ctx, user.UserID, "viewed", "questionnaire", p)
 }
 
+// RecordLogin appends a "session / created" event for a user who has just
+// completed authentication and been issued a session.
+//
+// Every other event in the log is a side effect of a write, so activity was
+// only ever visible for users who CHANGED something. That left a specific blind
+// spot: a privileged account that signs in and only reads looked identical to
+// one that had never signed in at all, which is exactly the pair you need to
+// tell apart to find a stale account.
+//
+// The caller is the post-OIDC session handler, not a request behind
+// auth.Middleware, so the user is passed explicitly rather than read from
+// context - at this point in the flow the session that would carry it has only
+// just been minted.
+//
+// The payload is deliberately just the userid: the identity provider is already
+// on the user row, and the interesting facts here are who and when, both of
+// which the event row itself carries.
+func RecordLogin(ctx context.Context, userID string) error {
+	if userID == "" {
+		return nil
+	}
+	return insertEvent(ctx, userID, "created", "session", payload{UserID: &userID})
+}
+
 func FindEvents(ctx context.Context, input *FindEventsInput) ([]*Event, error) {
 
 	sqlb := stmntBuilder.

--- a/backend/internal/model/events_login_integration_test.go
+++ b/backend/internal/model/events_login_integration_test.go
@@ -2,9 +2,11 @@ package model
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,9 +44,13 @@ func TestRecordLoginIntegration(t *testing.T) {
 		  AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.userid = u.userid)
 		LIMIT 1
 	`).Scan(&userID)
-	if err != nil {
+	// Only "no such user" is a skip. Letting any error skip would turn a dead
+	// connection or a renamed column into a green run in which RecordLogin was
+	// never called at all.
+	if errors.Is(err, pgx.ErrNoRows) {
 		t.Skip("fixture has no user without events")
 	}
+	require.NoError(t, err)
 
 	before, err := FindUsers(ctx, &FindUsersInput{})
 	require.NoError(t, err)
@@ -87,13 +93,15 @@ func TestRecordLoginIntegration(t *testing.T) {
 	t.Run("EmptyUserIsANoOp", func(t *testing.T) {
 		// Defensive: never fabricate an event with no initiator, mirroring how
 		// recordEvent skips when there is no user in context.
+		// Scoped to this user rather than counting the table: an unscoped count
+		// only holds because the test DB is ephemeral, and would go flaky the
+		// moment anyone pointed this at a shared one.
+		const countSessions = `SELECT count(*) FROM public.events WHERE resource='session' AND userid=$1`
 		var before int
-		require.NoError(t, conn.QueryRow(ctx,
-			`SELECT count(*) FROM public.events WHERE resource='session'`).Scan(&before))
+		require.NoError(t, conn.QueryRow(ctx, countSessions, userID).Scan(&before))
 		require.NoError(t, RecordLogin(ctx, ""))
 		var after int
-		require.NoError(t, conn.QueryRow(ctx,
-			`SELECT count(*) FROM public.events WHERE resource='session'`).Scan(&after))
+		require.NoError(t, conn.QueryRow(ctx, countSessions, userID).Scan(&after))
 		assert.Equal(t, before, after, "an empty user id must write nothing")
 	})
 }

--- a/backend/internal/model/events_login_integration_test.go
+++ b/backend/internal/model/events_login_integration_test.go
@@ -1,0 +1,99 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RecordLogin is what makes LastSeen mean "last signed in" rather than "last
+// changed something". Before it, activity was only visible for users who wrote
+// data, so an account that signed in and only read was indistinguishable from
+// one that had never signed in - the exact pair you need to separate to find a
+// stale privileged account.
+func TestRecordLoginIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	// Registered before the skip below so the connection is returned on every
+	// exit path. Not a deferred release: deferred calls run BEFORE t.Cleanup,
+	// which would pull the connection out from under the DELETE registered
+	// later.
+	var userID string
+	t.Cleanup(func() {
+		if userID != "" {
+			_, _ = conn.Exec(ctx,
+				`DELETE FROM public.events WHERE userid=$1 AND resource='session'`, userID)
+		}
+		conn.Release()
+	})
+
+	// A user who has recorded nothing, so the assertions below cannot be
+	// satisfied by pre-existing activity.
+	err = conn.QueryRow(ctx, `
+		SELECT u.userid FROM public.users u
+		WHERE NOT COALESCE(u.deleted,false)
+		  AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.userid = u.userid)
+		LIMIT 1
+	`).Scan(&userID)
+	if err != nil {
+		t.Skip("fixture has no user without events")
+	}
+
+	before, err := FindUsers(ctx, &FindUsersInput{})
+	require.NoError(t, err)
+	for _, u := range before {
+		if u.UserID == userID {
+			require.Nil(t, u.LastSeen, "precondition: this user must start with no activity")
+		}
+	}
+
+	require.NoError(t, RecordLogin(ctx, userID))
+
+	t.Run("WritesASessionEvent", func(t *testing.T) {
+		var action, resource, payloadUser string
+		require.NoError(t, conn.QueryRow(ctx, `
+			SELECT action, resource, payload->>'userid'
+			FROM public.events WHERE userid=$1 AND resource='session'
+			ORDER BY createdat DESC LIMIT 1
+		`, userID).Scan(&action, &resource, &payloadUser))
+		assert.Equal(t, "created", action)
+		assert.Equal(t, "session", resource)
+		assert.Equal(t, userID, payloadUser, "payload should identify the user who signed in")
+	})
+
+	t.Run("SurfacesAsLastSeenWithoutAnyWrite", func(t *testing.T) {
+		// The point of the change: signing in alone now moves last_seen. This
+		// user still has not created or updated a single record.
+		after, err := FindUsers(ctx, &FindUsersInput{})
+		require.NoError(t, err)
+		var found *User
+		for _, u := range after {
+			if u.UserID == userID {
+				found = u
+			}
+		}
+		require.NotNil(t, found)
+		assert.NotNil(t, found.LastSeen,
+			"a login with no subsequent write must still register as activity")
+	})
+
+	t.Run("EmptyUserIsANoOp", func(t *testing.T) {
+		// Defensive: never fabricate an event with no initiator, mirroring how
+		// recordEvent skips when there is no user in context.
+		var before int
+		require.NoError(t, conn.QueryRow(ctx,
+			`SELECT count(*) FROM public.events WHERE resource='session'`).Scan(&before))
+		require.NoError(t, RecordLogin(ctx, ""))
+		var after int
+		require.NoError(t, conn.QueryRow(ctx,
+			`SELECT count(*) FROM public.events WHERE resource='session'`).Scan(&after))
+		assert.Equal(t, before, after, "an empty user id must write nothing")
+	})
+}

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -625,7 +625,7 @@ func ReactivateFismaSystem(ctx context.Context, input ReactivateInput) (*FismaSy
 	if actor := UserFromContext(ctx); actor != nil {
 		if _, err := tx.Exec(ctx,
 			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
-			actor.UserID, "updated", "fismasystems", system,
+			actor.UserID, eventActionUpdated, "fismasystems", system,
 		); err != nil {
 			return nil, trapError(err)
 		}

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -32,6 +32,24 @@ func (r rawQuery) ToSql() (string, []any, error) {
 	return r.sql, r.args, nil
 }
 
+// Score review states, as stored in scores.status. Like the event actions in
+// events.go these are stored data rather than an internal enum: migration
+// 0048 pins the exact set with a CHECK constraint
+// (`status IN ('not_started', 'done')`), the seed data's status-sync writes
+// them, and the progress query in scoreprogress.go filters on them as inline
+// SQL literals. Changing a VALUE here is a data migration - a new CHECK, a
+// backfill of every stored row, and an update of every SQL predicate that
+// repeats the literal. Changing the Go identifier is free.
+const (
+	// scoreStatusDone means a human saved or confirmed this answer during the
+	// current data call.
+	scoreStatusDone = "done"
+	// scoreStatusNotStarted is the column default and the value
+	// copyPreviousScores seeds onto a carried-forward answer: the answer value
+	// survives the rollover, its review state for the new cycle does not.
+	scoreStatusNotStarted = "not_started"
+)
+
 type Score struct {
 	ScoreID          int32           `json:"scoreid"`
 	FismaSystemID    int32           `json:"fismasystemid"`
@@ -81,6 +99,29 @@ func WithCurrentScore(current *Score) ScoreSaveOption {
 	return func(c *scoreSaveConfig) { c.current = current }
 }
 
+// Save writes one answer for the current data call, as an interactive human
+// edit. It is the questionnaire's write path and it hardcodes that meaning:
+// every successful write sets status to scoreStatusDone, and the event it
+// records through queryRow carries action 'created' or 'updated' - the two
+// actions that migration 0048's backfill and the seed status-sync treat as
+// "a human answered this cycle".
+//
+// Importer contract (ztmf#445): a future bulk importer must NOT reuse Save as
+// it stands. Loading history through it would flip every imported row to done
+// and attribute it as an in-app edit, which is precisely the distinction the
+// status column exists to preserve - imported rows are supposed to stay
+// not_started and report no last-updated. An importer should either
+//
+//   - take an explicit status/provenance parameter added to Save (a
+//     ScoreSaveOption alongside WithCurrentScore is the natural shape), so the
+//     caller states the status to write and the action to record; or
+//   - write through its own path that inserts the rows and records action
+//     'imported' (eventActionImported in events.go), mirroring the provenance
+//     the 0048 backfill and the seed data deliberately exclude.
+//
+// Adding the parameter is the larger change of the two and was deliberately
+// left undone here rather than designed speculatively without an importer to
+// shape it.
 func (s *Score) Save(ctx context.Context, opts ...ScoreSaveOption) (*Score, error) {
 	var sqlb SqlBuilder
 
@@ -142,7 +183,7 @@ func (s *Score) Save(ctx context.Context, opts ...ScoreSaveOption) (*Score, erro
 		sqlb = stmntBuilder.
 			Insert("public.scores").
 			Columns("fismasystemid", "notes", "notes_is_ai_summary", "functionoptionid", "datacallid", "status").
-			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, "done").
+			Values(s.FismaSystemID, s.Notes, derefBool(s.NotesIsAISummary), s.FunctionOptionID, s.DataCallID, scoreStatusDone).
 			Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 	} else {
 		// fismasystemid and datacallid are deliberately NOT in the SET list.
@@ -155,7 +196,7 @@ func (s *Score) Save(ctx context.Context, opts ...ScoreSaveOption) (*Score, erro
 		setCols := squirrel.Eq{
 			"notes":            s.Notes,
 			"functionoptionid": s.FunctionOptionID,
-			"status":           "done",
+			"status":           scoreStatusDone,
 		}
 		if s.NotesIsAISummary != nil {
 			setCols["notes_is_ai_summary"] = *s.NotesIsAISummary
@@ -229,7 +270,7 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 	// the current row with the same audit projection used after a real write,
 	// preserving the endpoint's idempotent 200 response without recording a
 	// second event.
-	if s.Status == "done" {
+	if s.Status == scoreStatusDone {
 		if at, by := lookupScoreAudit(ctx, s.ScoreID); at != nil && by != nil {
 			s.LastEditedAt = at
 			s.LastEditedBy = by
@@ -239,11 +280,11 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 
 	sqlb := stmntBuilder.
 		Update("public.scores").
-		Set("status", "done").
+		Set("status", scoreStatusDone).
 		// Keep the no-op guard in the write predicate as well as above. Two
 		// requests can both load not_started before either reaches Confirm; only
 		// the first must be allowed to update and create an audit event.
-		Where("scoreid=? AND status <> ?", s.ScoreID, "done").
+		Where("scoreid=? AND status <> ?", s.ScoreID, scoreStatusDone).
 		Suffix("RETURNING scoreid, fismasystemid, EXTRACT(EPOCH FROM datecalculated) as datecalculated, notes, notes_is_ai_summary, functionoptionid, datacallid, status")
 
 	confirmed, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Score])
@@ -256,7 +297,7 @@ func (s *Score) Confirm(ctx context.Context) (*Score, error) {
 			if findErr != nil {
 				return nil, findErr
 			}
-			if current.Status == "done" {
+			if current.Status == scoreStatusDone {
 				if at, by := lookupScoreAudit(ctx, current.ScoreID); at != nil && by != nil {
 					current.LastEditedAt = at
 					current.LastEditedBy = by
@@ -1072,7 +1113,10 @@ func copyPreviousScoresOpDivHardcoded(ctx context.Context, dataCallID int32) (co
 	// DISTINCT ON (fismasystemid, functionid) guarantees one answer per question -
 	// scores has no uniqueness constraint, so a cycle may hold duplicates.
 	//
-	// status is seeded 'not_started' as on the normal path (ztmf#435).
+	// status is seeded 'not_started' as on the normal path (ztmf#435). Written
+	// as a SQL literal inside this const rather than as scoreStatusNotStarted:
+	// the statement is a compile-time constant string so it can be read whole,
+	// and interpolating would trade that for no behavioral gain.
 	//
 	// The ::int casts are REQUIRED, not decoration. Both CASE branches are bind
 	// parameters, so Postgres resolves the CASE to text and the comparison becomes
@@ -1286,8 +1330,13 @@ func copyPreviousScores(ctx context.Context, dataCallID int32) (int64, error) {
 	// semantic the events lateral used to derive from "no event exists"
 	// (ztmf#299). The literal is a selected column so it lands in the same
 	// INSERT...SELECT as the copy, keeping the reset atomic with the row.
+	//
+	// Interpolated from scoreStatusNotStarted rather than hand-quoted so the
+	// value has one definition. It stays a selected literal, not a bind
+	// parameter: squirrel would append the placeholder's argument after the
+	// INSERT's own, and the constant is package-owned, never request input.
 	prevScoresSqlb := squirrel.
-		Select("s.fismasystemid", "s.datecalculated", "s.notes", "s.notes_is_ai_summary", "s.functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID), "'not_started' as status").
+		Select("s.fismasystemid", "s.datecalculated", "s.notes", "s.notes_is_ai_summary", "s.functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID), fmt.Sprintf("'%s' as status", scoreStatusNotStarted)).
 		From("scores s").
 		Join("fismasystems fs ON fs.fismasystemid = s.fismasystemid").
 		Join("functionoptions fo ON fo.functionoptionid = s.functionoptionid").

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -36,7 +36,8 @@ func (r rawQuery) ToSql() (string, []any, error) {
 // events.go these are stored data rather than an internal enum: migration
 // 0048 pins the exact set with a CHECK constraint
 // (`status IN ('not_started', 'done')`), the seed data's status-sync writes
-// them, and the progress query in scoreprogress.go filters on them as inline
+// 'done' while the column DEFAULT set in 0048 supplies 'not_started', and the
+// progress query in scoreprogress.go filters on them as inline
 // SQL literals. Changing a VALUE here is a data migration - a new CHECK, a
 // backfill of every stored row, and an update of every SQL predicate that
 // repeats the literal. Changing the Go identifier is free.
@@ -1332,9 +1333,16 @@ func copyPreviousScores(ctx context.Context, dataCallID int32) (int64, error) {
 	// INSERT...SELECT as the copy, keeping the reset atomic with the row.
 	//
 	// Interpolated from scoreStatusNotStarted rather than hand-quoted so the
-	// value has one definition. It stays a selected literal, not a bind
-	// parameter: squirrel would append the placeholder's argument after the
-	// INSERT's own, and the constant is package-owned, never request input.
+	// value has one definition. Safe to interpolate: the constant is
+	// package-owned, never request input.
+	//
+	// It stays a selected literal rather than becoming a bind parameter for two
+	// reasons. It keeps the emitted SQL byte-identical to what this statement
+	// has always produced; and an untyped $n in a SELECT list feeding an
+	// INSERT...SELECT walks into the same type-inference trap the sibling
+	// copySQL comment above documents at length for its ::int casts - Postgres
+	// resolves an unadorned placeholder to text and the column comparison
+	// fails at runtime.
 	prevScoresSqlb := squirrel.
 		Select("s.fismasystemid", "s.datecalculated", "s.notes", "s.notes_is_ai_summary", "s.functionoptionid", fmt.Sprintf("%d as latestdatacallid", dataCallID), fmt.Sprintf("'%s' as status", scoreStatusNotStarted)).
 		From("scores s").

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -25,16 +25,20 @@ type User struct {
 	// the past is denied at authentication (see IsExpired and the auth middleware),
 	// while the row and its assignments are retained for renewal and audit.
 	AccessExpiresAt *time.Time `json:"access_expires_at" db:"access_expires_at"`
-	// LastSeen is the most recent action this user recorded in the events audit
-	// log. Derived on read, never stored, so it needs no backfill and cannot
-	// drift from the log it summarises.
+	// LastSeen is the most recent activity this user recorded in the events
+	// audit log, including logins (see RecordLogin). Derived on read, never
+	// stored, so it needs no backfill and cannot drift from the log it
+	// summarises.
 	//
-	// It is deliberately "last recorded action", NOT "last login": ZTMF records
-	// no authentication event, so a user who signs in and never opens a
-	// questionnaire or saves anything leaves no trace and reports null. Null
-	// therefore means "has taken no action we record" - most often an account
-	// provisioned by a bulk load whose owner has not engaged - rather than
-	// proof they have never signed in. Read it as a floor on engagement.
+	// Signing in counts, so a user who logs in and only reads is now
+	// distinguishable from one who has never signed in at all - the pair that
+	// matters for spotting a stale privileged account, and that used to look
+	// identical because every event was a side effect of a write.
+	//
+	// Null means no recorded activity of any kind. For an account created
+	// before login events existed, null means "nothing since then", not
+	// "never" - the log is not retrospective. That ambiguity ages out as
+	// people sign in.
 	//
 	// No omitempty: a never-used account is the case this field exists to
 	// identify, and omitting the key there would make the answer indistinguishable

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -25,6 +25,21 @@ type User struct {
 	// the past is denied at authentication (see IsExpired and the auth middleware),
 	// while the row and its assignments are retained for renewal and audit.
 	AccessExpiresAt *time.Time `json:"access_expires_at" db:"access_expires_at"`
+	// LastSeen is the most recent action this user recorded in the events audit
+	// log. Derived on read, never stored, so it needs no backfill and cannot
+	// drift from the log it summarises.
+	//
+	// It is deliberately "last recorded action", NOT "last login": ZTMF records
+	// no authentication event, so a user who signs in and never opens a
+	// questionnaire or saves anything leaves no trace and reports null. Null
+	// therefore means "has taken no action we record" - most often an account
+	// provisioned by a bulk load whose owner has not engaged - rather than
+	// proof they have never signed in. Read it as a floor on engagement.
+	//
+	// No omitempty: a never-used account is the case this field exists to
+	// identify, and omitting the key there would make the answer indistinguishable
+	// from the field not being served at all. Null is the answer, so it ships.
+	LastSeen *time.Time `json:"last_seen" db:"last_seen"`
 }
 
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
@@ -425,6 +440,11 @@ func FindUsers(ctx context.Context, fui *FindUsersInput) ([]*User, error) {
 			"users.identity_provider",
 			"users.access_expires_at",
 			"(SELECT ARRAY_AGG(opdiv_id) FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids",
+			// Same correlated-subquery shape as assignedopdivids above. Served
+			// by events_user_activity_idx (0054) as an index-only descent to
+			// the newest entry, so this stays a few milliseconds across the
+			// whole list rather than a sequential scan of events per row.
+			"(SELECT MAX(createdat) FROM public.events WHERE events.userid = users.userid) AS last_seen",
 		).
 		From("public.users").
 		Where("deleted=?", fui.Deleted)
@@ -468,6 +488,13 @@ func FindUserByEmail(ctx context.Context, email string) (*User, error) {
 }
 
 func findUser(ctx context.Context, where string, args []any) (*User, error) {
+	// last_seen is selected as a literal NULL rather than derived. This runs in
+	// the auth middleware on every authenticated request, so the correlated
+	// subquery FindUsers uses would be paid on every call to serve a field only
+	// the users list renders. The column still has to appear: this path scans
+	// strictly by name, so omitting it fails the scan outright rather than
+	// leaving the field nil.
+	//
 	// Load assignments via correlated subqueries instead of LEFT JOIN +
 	// ARRAY_AGG so the row count stays at one per user. A LEFT JOIN to both
 	// junctions would produce an N*M cross-product (N system grants times
@@ -483,6 +510,7 @@ func findUser(ctx context.Context, where string, args []any) (*User, error) {
 			"users.deleted",
 			"users.identity_provider",
 			"users.access_expires_at",
+			"NULL::timestamptz AS last_seen",
 			"(SELECT ARRAY_AGG(fismasystemid) FROM users_fismasystems WHERE userid = users.userid) AS assignedfismasystems",
 			"(SELECT ARRAY_AGG(opdiv_id)      FROM users_opdivs       WHERE userid = users.userid) AS assignedopdivids",
 		).

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -598,7 +598,7 @@ func RestoreUser(ctx context.Context, userid string) (*User, error) {
 	if actor := UserFromContext(ctx); actor != nil {
 		if _, err := tx.Exec(ctx,
 			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
-			actor.UserID, "updated", "users", restored,
+			actor.UserID, eventActionUpdated, "users", restored,
 		); err != nil {
 			return nil, trapError(err)
 		}
@@ -867,7 +867,7 @@ func AddSystemDelegate(ctx context.Context, sys *FismaSystem, opdiv *OpDiv, acto
 	} {
 		if _, err = tx.Exec(ctx,
 			"INSERT INTO events (userid, action, resource, payload) VALUES ($1, $2, $3, $4)",
-			actorID, "created", ev.resource, ev.payload,
+			actorID, eventActionCreated, ev.resource, ev.payload,
 		); err != nil {
 			return nil, trapError(err)
 		}

--- a/backend/internal/model/users_lastseen_integration_test.go
+++ b/backend/internal/model/users_lastseen_integration_test.go
@@ -2,9 +2,11 @@ package model
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,9 +65,12 @@ func TestFindUsersLastSeenIntegration(t *testing.T) {
 			  AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.userid = u.userid)
 			LIMIT 1
 		`).Scan(&userID)
-		if err != nil {
+		// Only the empty result is a skip; any other error is a real failure
+		// and must not be laundered into a green run.
+		if errors.Is(err, pgx.ErrNoRows) {
 			t.Skip("fixture has no user without events; nothing to assert here")
 		}
+		require.NoError(t, err)
 
 		u, ok := byID[userID]
 		require.True(t, ok)

--- a/backend/internal/model/users_lastseen_integration_test.go
+++ b/backend/internal/model/users_lastseen_integration_test.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// LastSeen answers "has this account ever been used" for the users list. It is
+// derived on read from the events audit log rather than stored, so these tests
+// pin the derivation against real event rows: a user with activity reports the
+// newest one, a user with none reports nil, and the single-user path (which
+// runs in the auth middleware on every request) deliberately does not pay for
+// the lookup at all.
+func TestFindUsersLastSeenIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	users, err := FindUsers(ctx, &FindUsersInput{})
+	require.NoError(t, err)
+	require.NotEmpty(t, users, "seeded database should have users")
+
+	byID := map[string]*User{}
+	for _, u := range users {
+		byID[u.UserID] = u
+	}
+
+	t.Run("MatchesNewestEventForUsersWithActivity", func(t *testing.T) {
+		// Resolve the subject from the events table rather than hardcoding an
+		// id, so the test cannot pass vacuously against a fixture with no
+		// events at all.
+		var userID string
+		err := conn.QueryRow(ctx, `
+			SELECT userid FROM public.events
+			GROUP BY userid ORDER BY count(*) DESC LIMIT 1
+		`).Scan(&userID)
+		require.NoError(t, err, "fixture must contain at least one event")
+
+		u, ok := byID[userID]
+		require.True(t, ok, "the busiest event author should appear in the users list")
+		require.NotNil(t, u.LastSeen, "a user with events must report a last_seen")
+
+		var expected any
+		require.NoError(t, conn.QueryRow(ctx,
+			`SELECT MAX(createdat) FROM public.events WHERE userid = $1`, userID).Scan(&expected))
+		assert.Equal(t, expected, *u.LastSeen,
+			"last_seen must be the newest event for that user, not any other row")
+	})
+
+	t.Run("NilForUsersWithNoActivity", func(t *testing.T) {
+		var userID string
+		err := conn.QueryRow(ctx, `
+			SELECT u.userid FROM public.users u
+			WHERE NOT COALESCE(u.deleted,false)
+			  AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.userid = u.userid)
+			LIMIT 1
+		`).Scan(&userID)
+		if err != nil {
+			t.Skip("fixture has no user without events; nothing to assert here")
+		}
+
+		u, ok := byID[userID]
+		require.True(t, ok)
+		assert.Nil(t, u.LastSeen,
+			"a user who has recorded no action must report null, not a zero time")
+	})
+
+	t.Run("SingleUserPathSkipsTheLookup", func(t *testing.T) {
+		// findUser runs in the auth middleware on every authenticated request,
+		// so it must not pay for a correlated subquery that only the list view
+		// renders. Lax scanning leaves the field nil; this pins that choice so
+		// a later "make it consistent" edit is a deliberate one.
+		var userID string
+		require.NoError(t, conn.QueryRow(ctx, `
+			SELECT userid FROM public.events GROUP BY userid ORDER BY count(*) DESC LIMIT 1
+		`).Scan(&userID))
+
+		one, err := FindUserByID(ctx, userID)
+		require.NoError(t, err)
+		require.NotNil(t, one)
+		assert.Nil(t, one.LastSeen,
+			"findUser must not populate last_seen; it is a list-only field")
+	})
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -808,6 +808,23 @@ components:
           type: string
         identity_provider:
           type: string
+        last_seen:
+          description: |-
+            LastSeen is the most recent action this user recorded in the events audit
+            log. Derived on read, never stored, so it needs no backfill and cannot
+            drift from the log it summarises.
+
+            It is deliberately "last recorded action", NOT "last login": ZTMF records
+            no authentication event, so a user who signs in and never opens a
+            questionnaire or saves anything leaves no trace and reports null. Null
+            therefore means "has taken no action we record" - most often an account
+            provisioned by a bulk load whose owner has not engaged - rather than
+            proof they have never signed in. Read it as a floor on engagement.
+
+            No omitempty: a never-used account is the case this field exists to
+            identify, and omitting the key there would make the answer indistinguishable
+            from the field not being served at all. Null is the answer, so it ships.
+          type: string
         role:
           type: string
         userid:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -810,16 +810,20 @@ components:
           type: string
         last_seen:
           description: |-
-            LastSeen is the most recent action this user recorded in the events audit
-            log. Derived on read, never stored, so it needs no backfill and cannot
-            drift from the log it summarises.
+            LastSeen is the most recent activity this user recorded in the events
+            audit log, including logins (see RecordLogin). Derived on read, never
+            stored, so it needs no backfill and cannot drift from the log it
+            summarises.
 
-            It is deliberately "last recorded action", NOT "last login": ZTMF records
-            no authentication event, so a user who signs in and never opens a
-            questionnaire or saves anything leaves no trace and reports null. Null
-            therefore means "has taken no action we record" - most often an account
-            provisioned by a bulk load whose owner has not engaged - rather than
-            proof they have never signed in. Read it as a floor on engagement.
+            Signing in counts, so a user who logs in and only reads is now
+            distinguishable from one who has never signed in at all - the pair that
+            matters for spotting a stale privileged account, and that used to look
+            identical because every event was a side effect of a write.
+
+            Null means no recorded activity of any kind. For an account created
+            before login events existed, null means "nothing since then", not
+            "never" - the log is not retrospective. That ambiguity ages out as
+            people sign in.
 
             No omitempty: a never-used account is the case this field exists to
             identify, and omitting the key there would make the answer indistinguishable


### PR DESCRIPTION
Backend release train for the code freeze. Approved PRs only, cherry-picked so each contributor's authorship and signature survive. Frontend counterpart is CMS-Enterprise/ztmf-ui#682.

Closes #445
Closes #526

## What is in it

| Source | Author | Change | Closes |
| --- | --- | --- | --- |
| #522 | @danielbowne | Expose `last_seen` on the users list, plus a login event so it means last sign-in | — |
| #524 | @danielbowne | Single home for event-action and score-status values | #445 |
| #528 | @MackOverflow, commits by @voidspooks | Export the full questionnaire per system rather than only answered rows | #526 |

#522 declares no closing issue by design: it is the backend piece, and presentation is deliberately left open on CMS-Enterprise/ztmf-ui#675.

Ordering is by approval. #522 and #524 both touch `events.go` and `users.go`, and they merged without conflict because the edits sit in disjoint regions. #528 is disjoint from both.

One thing dropped on purpose: #522's tip was an empty `chore(ci): retrigger DEV deploy under a fresh image tag` commit, pushed to force a fresh image tag past the immutable ECR repo. It has no meaning in a batch that gets its own SHA, so it was skipped rather than carried.

## Verification on the combined branch

Verified the combination rather than trusting the parts, since three separately green PRs can still interact:

- `go build ./...` and `go vet ./...` clean
- `go test -short ./...` — 13 packages ok
- Full integration suite against a seeded database — 13 packages ok, zero failures, including the three tests that are sometimes date-dependent
- **`make generate-openapi` produces no drift**: the committed spec matches the generated one byte-for-byte. Worth doing here specifically because #522 regenerated the spec and #524 changed models independently, so the combination is the first time those two meet.

## Deploy note, and it is a real one

**Do not stack deploys on this branch.** #528's own SHA has two dev deployments two minutes apart: the first succeeded, the second failed with `waiting for ECS Service update: timeout while waiting for state to become 'tfSTABLE' (last state: 'tfPENDING', timeout: 20m0s)`. The second run raced the first while ECS was still rolling out. #524 lost a deploy the same way earlier in the day.

So this PR was opened ready rather than draft-then-ready, because that transition is what produced the double run. If the deploy here fails on a stabilise timeout, let ECS settle and re-run **one** deploy; do not push again or trigger a second in parallel.

## Merge order

**This merges first.** The frontend batch follows at least five minutes later, which is both a courtesy to the prod pipeline and a correctness requirement: #528's export change has to be live before the frontend's select-all makes never-started systems selectable, or a user can select them and download a header-only file.

## What is not in it

- #525 and #492 are drafts.
- #423 is a dependency bump with no approval.
