### PR TITLE
perf(export): index functionoptions(functionid) for the data-call export

### DIFF
--- a/backend/cmd/api/internal/migrations/0055functionoptionsindex.go
+++ b/backend/cmd/api/internal/migrations/0055functionoptionsindex.go
@@ -1,0 +1,27 @@
+package migrations
+
+func init() {
+	appendMigration(
+		"add functionoptions(functionid) index for the data-call export",
+		`
+-- The data-call export (#528 re-anchor of FindAnswers) left-joins scores with
+-- a per-row subquery over functionoptions keyed on functionid. Postgres cannot
+-- fold that IN-subquery into the hash join, so it runs as a per-candidate-row
+-- Join Filter - and functionoptions has no functionid index (only its primary
+-- key), making each evaluation a sequential scan.
+--
+-- Measured on a prod-scale copy (ztmf#531, 1,530 systems / 192k scores): the
+-- whole-call FY26 export performs that scan 1,556,120 times, 47.7s of database
+-- time before the spreadsheet is even rendered - retry/abandon territory, and
+-- near typical gateway idle timeouts. With this index the same export runs in
+-- 2.0s (23x).
+--
+-- functionoptions is a small, static, read-mostly catalogue (1,728 rows; it
+-- changes only when a questionnaire edition is edited), so the write cost is
+-- negligible and no partial or composite form is warranted.
+CREATE INDEX IF NOT EXISTS functionoptions_functionid_idx
+    ON public.functionoptions (functionid);
+`,
+		`DROP INDEX IF EXISTS functionoptions_functionid_idx;`,
+	)
+}

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -251,7 +251,7 @@ func RecordLogin(ctx context.Context, userID string) error {
 	if userID == "" {
 		return nil
 	}
-	return insertEvent(ctx, userID, "created", "session", payload{UserID: &userID})
+	return insertEvent(ctx, userID, eventActionCreated, "session", payload{UserID: &userID})
 }
 
 func FindEvents(ctx context.Context, input *FindEventsInput) ([]*Event, error) {


### PR DESCRIPTION
Closes #531.

## The measurement the ticket asked for

Whole-call FY26 export on a full prod-scale copy (1,530 systems, 192k score rows), `EXPLAIN (ANALYZE, BUFFERS)` on the exact SQL `FindAnswers` generates:

| | DB time |
|---|---|
| Without index | **47.7 s** |
| With `functionoptions(functionid)` | **2.0 s** |

The plan confirms the review's predicted mechanism precisely: the LEFT JOIN's option-ownership subquery runs as a per-candidate-row Join Filter, `Seq Scan on functionoptions ... loops=1,556,120`. The extrapolation was not pessimistic — 47.7 s of database time before the spreadsheet even renders is retry/abandon territory and near typical gateway idle timeouts (nothing app-side sets a ceiling; any limit is infrastructure's). Full numbers on #531.

## The fix

Migration 0055: a plain btree on `functionoptions(functionid)`. Postgres does not index the referencing side of a foreign key, so the column has only ever been reachable by sequential scan. The table is a small, static catalogue (1,728 rows; it changes only when a questionnaire edition is edited), so write cost is negligible. Plain `CREATE INDEX` rather than `CONCURRENTLY` because tern wraps each migration in a transaction, and at this size the lock lasts milliseconds. The btree-vs-partial/composite/INCLUDE question was reviewed against the query shape — the predicate is a bare equality on `functionid`, and the other two `functionoptions` references in the query are served by the primary key.

## Rider

Converts `RecordLogin`'s action literal to `eventActionCreated` — the one-line convergence #524's description deferred to "whichever lands second," which the batch merge left unapplied. No behavior change; the constant carries the identical value.

## Testing

- `make test-integration` — migration applies clean on the ephemeral DB, all green
- Index-only change: no model/controller/router surface, no OpenAPI drift, no emberfall or seed updates required
- Measured improvement recorded on #531 with the probe methodology

## Deploy note

Merging puts `dbversions` at 55. Any dev deploy from a branch cut before this merge would then register only 54 migrations against a DB at 55 — the known crash-loop. Worth merging promptly once approved rather than letting it sit deployed-but-unmerged.
