### PR TITLE
chore(functions): derive a function's pillar from its question (#534)

### DIFF
--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -1268,6 +1268,37 @@ tests:
     expect:
       status: 400
 
+  # Same on update. The UPDATE sets every column, so before questionid was
+  # required this partial-update shape wrote NULL and orphaned the function from
+  # every questionnaire instead of failing.
+  - url: "http://localhost:8080/api/v1/functions/{{.createFunction.Response.data.functionid}}"
+    method: PUT
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        function: "Updated Identity Management"
+        description: "no questionid on update, must be rejected"
+        datacenterenvironment: "AWS"
+        order: 2
+        pillarid: 1
+    expect:
+      status: 400
+
+  # Nothing from the rejected update applied: the question is intact and the
+  # fields it did carry (a changed description) were not written either.
+  - url: "http://localhost:8080/api/v1/functions/{{.createFunction.Response.data.functionid}}"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            <<: *updatedFunctionData
+
   # Function Options Endpoints
   - url: "http://localhost:8080/api/v1/functions/{{.createFunction.Response.data.functionid}}/options"
     method: GET

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -107,11 +107,14 @@ reactivatedFismaSystemData: &reactivatedFismaSystemData
   decommissioned_notes: "System migrated to cloud infrastructure"
   reactivation_notes: "Brought back online for follow-on work"
 
+# questionid is required, and pillarid is derived from that question rather than
+# taken from the request. Seed question 8001 is in pillar 1.
 functionData: &functionData
   function: "Identity Management"
   description: "Manage user identities and access"
   datacenterenvironment: "AWS"
   order: 1
+  questionid: 8001
   pillarid: 1
 
 updatedFunctionData: &updatedFunctionData
@@ -119,6 +122,7 @@ updatedFunctionData: &updatedFunctionData
   description: "Updated identity and access management"
   datacenterenvironment: "AWS"
   order: 2
+  questionid: 8001
   pillarid: 1
 
 userData: &userData
@@ -1222,7 +1226,48 @@ tests:
       status: 200
       headers:
         content-type: "application/json"
-  
+
+  # A caller-supplied pillarid that disagrees with the question is corrected, not
+  # persisted. Question 8001 is in pillar 1; the request claims pillar 6.
+  - id: createFunctionPillarDrift
+    url: http://localhost:8080/api/v1/functions
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        function: "Pillar Derivation Check"
+        description: "pillarid must follow the question, not the request body"
+        datacenterenvironment: "AWS"
+        order: 99
+        questionid: 8001
+        pillarid: 6
+    expect:
+      status: 201
+      body:
+        json:
+          data:
+            questionid: 8001
+            pillarid: 1
+
+  # A function with no question has no pillar to derive from and reaches no
+  # questionnaire, so it is rejected.
+  - url: http://localhost:8080/api/v1/functions
+    method: POST
+    headers:
+      <<: *commonHeaders
+      content-type: "application/json"
+    body:
+      json:
+        function: "Questionless Function"
+        description: "no questionid, must be rejected"
+        datacenterenvironment: "AWS"
+        order: 99
+        pillarid: 1
+    expect:
+      status: 400
+
   # Function Options Endpoints
   - url: "http://localhost:8080/api/v1/functions/{{.createFunction.Response.data.functionid}}/options"
     method: GET

--- a/backend/internal/model/functions.go
+++ b/backend/internal/model/functions.go
@@ -17,7 +17,8 @@ type Function struct {
 	DataCenterEnvironment string `json:"datacenterenvironment"`
 	Ordr                  int    `json:"order"`
 	QuestionID            *int32 `json:"questionid,omitempty"`
-	PillarID              int32  `json:"pillarid"`
+	// Derived from the function's question on write; a value sent by a client is ignored.
+	PillarID int32 `json:"pillarid" readonly:"true"`
 }
 
 type FindFunctionsInput struct {

--- a/backend/internal/model/functions.go
+++ b/backend/internal/model/functions.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -80,6 +81,16 @@ func (f *Function) Save(ctx context.Context) (*Function, error) {
 		return nil, &InvalidInputError{data: map[string]any{"datacenterenvironment": f.DataCenterEnvironment}}
 	}
 
+	// A function's pillar is a fact about its question, so derive it and ignore the
+	// caller's value; functions.pillarid can then never drift from questions.pillarid.
+	q, err := FindQuestionByID(ctx, *f.QuestionID)
+	if errors.Is(err, ErrNoData) {
+		return nil, ErrNoReference
+	} else if err != nil {
+		return nil, err
+	}
+	f.PillarID = int32(q.PillarID)
+
 	if f.FunctionID == 0 {
 		sqlb = stmntBuilder.
 			Insert("functions").
@@ -115,12 +126,11 @@ func (f *Function) validate() error {
 	// datacenterenvironment is validated against the datacenterenvironments
 	// reference table in Save(), which has the context needed for the lookup.
 
-	if f.QuestionID != nil && !isValidIntID(f.QuestionID) {
+	// Required: a function with no question reaches no questionnaire and has no
+	// pillar to derive from. pillarid is not validated because Save() overwrites
+	// it with the question's pillar.
+	if !isValidIntID(f.QuestionID) {
 		err.data["questionid"] = f.QuestionID
-	}
-
-	if !isValidIntID(f.PillarID) {
-		err.data["pillarid"] = f.PillarID
 	}
 
 	if len(err.data) > 0 {

--- a/backend/internal/model/functions.go
+++ b/backend/internal/model/functions.go
@@ -82,7 +82,13 @@ func (f *Function) Save(ctx context.Context) (*Function, error) {
 	}
 
 	// A function's pillar is a fact about its question, so derive it and ignore the
-	// caller's value; functions.pillarid can then never drift from questions.pillarid.
+	// caller's value; the caller cannot put functions.pillarid out of agreement with
+	// questions.pillarid. validate() has already rejected a nil questionid; the guard
+	// repeats it so the deref below does not depend on a check in another method.
+	if f.QuestionID == nil {
+		return nil, &InvalidInputError{data: map[string]any{"questionid": nil}}
+	}
+
 	q, err := FindQuestionByID(ctx, *f.QuestionID)
 	if errors.Is(err, ErrNoData) {
 		return nil, ErrNoReference

--- a/backend/internal/model/functions_pillarderive_integration_test.go
+++ b/backend/internal/model/functions_pillarderive_integration_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 // TestFunctionPillarDeriveIntegration proves a function's pillar is derived from
-// its question on every write, so functions.pillarid can no longer disagree with
-// questions.pillarid no matter what the caller sends.
+// its question on every write, so a caller-supplied pillarid cannot put the two
+// out of agreement. Editing the question's own pillar still leaves dependent
+// functions stale until they are next saved; that path is not covered here.
 //
 // Fixtures come from the empire seed: question 8004 is in pillar 2 (Applications).
 // The fixtures use the "AWS" environment, which no seeded system maps to, so a
@@ -101,20 +102,6 @@ func TestFunctionPillarDeriveIntegration(t *testing.T) {
 		assert.Nil(t, saved)
 	})
 
-	t.Run("SeededDataAgrees", func(t *testing.T) {
-		c, err := db.Conn(ctx)
-		require.NoError(t, err)
-		defer c.Release()
-
-		var drifted int
-		err = c.QueryRow(ctx, `
-			SELECT count(*)
-			  FROM functions f
-			  JOIN questions q ON q.questionid = f.questionid
-			 WHERE f.pillarid <> q.pillarid`).Scan(&drifted)
-		require.NoError(t, err)
-		assert.Zero(t, drifted, "no function may disagree with its question's pillar")
-	})
 }
 
 func hardDeleteFunctionByID(id int32) {

--- a/backend/internal/model/functions_pillarderive_integration_test.go
+++ b/backend/internal/model/functions_pillarderive_integration_test.go
@@ -1,0 +1,127 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFunctionPillarDeriveIntegration proves a function's pillar is derived from
+// its question on every write, so functions.pillarid can no longer disagree with
+// questions.pillarid no matter what the caller sends.
+//
+// Fixtures come from the empire seed: question 8004 is in pillar 2 (Applications).
+// The fixtures use the "AWS" environment, which no seeded system maps to, so a
+// fixture is never visible to a questionnaire while the test runs. Requires DB_*
+// env vars pointing at a seeded ZTMF database. Skipped under `go test -short`.
+func TestFunctionPillarDeriveIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+
+	questionID := int32(8004) // pillar 2
+
+	t.Run("InsertIgnoresCallerPillar", func(t *testing.T) {
+		f := &Function{
+			Function:              "pillar derive insert fixture",
+			Description:           "pillar must come from the question, not the caller",
+			DataCenterEnvironment: "AWS",
+			Ordr:                  99,
+			QuestionID:            &questionID,
+			PillarID:              1, // deliberately wrong
+		}
+		saved, err := f.Save(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+		t.Cleanup(func() { hardDeleteFunctionByID(saved.FunctionID) })
+
+		assert.Equal(t, int32(2), saved.PillarID, "returned struct carries the question's pillar")
+
+		got, err := FindFunctionByID(ctx, saved.FunctionID)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), got.PillarID, "and so does the persisted row")
+	})
+
+	t.Run("UpdateIgnoresCallerPillar", func(t *testing.T) {
+		f := &Function{
+			Function:              "pillar derive update fixture",
+			Description:           "an admin edit must not be able to introduce drift",
+			DataCenterEnvironment: "AWS",
+			Ordr:                  99,
+			QuestionID:            &questionID,
+			PillarID:              2,
+		}
+		saved, err := f.Save(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { hardDeleteFunctionByID(saved.FunctionID) })
+
+		saved.PillarID = 6 // deliberately wrong
+		updated, err := saved.Save(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), updated.PillarID)
+
+		got, err := FindFunctionByID(ctx, saved.FunctionID)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), got.PillarID)
+	})
+
+	t.Run("MissingQuestionIsRejected", func(t *testing.T) {
+		f := &Function{
+			Function:              "pillar derive questionless fixture",
+			Description:           "must not be written",
+			DataCenterEnvironment: "AWS",
+			Ordr:                  99,
+			PillarID:              3,
+		}
+		saved, err := f.Save(ctx)
+		assert.Nil(t, saved)
+
+		var invalid *InvalidInputError
+		if assert.ErrorAs(t, err, &invalid) {
+			assert.Contains(t, invalid.Data(), "questionid")
+		}
+	})
+
+	t.Run("UnknownQuestionIsRejected", func(t *testing.T) {
+		missing := int32(999999)
+		f := &Function{
+			Function:              "pillar derive bad question fixture",
+			Description:           "must not be written",
+			DataCenterEnvironment: "AWS",
+			Ordr:                  99,
+			QuestionID:            &missing,
+			PillarID:              1,
+		}
+		saved, err := f.Save(ctx)
+		assert.ErrorIs(t, err, ErrNoReference, "same 400 the FK violation produced, caught before the insert")
+		assert.Nil(t, saved)
+	})
+
+	t.Run("SeededDataAgrees", func(t *testing.T) {
+		c, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer c.Release()
+
+		var drifted int
+		err = c.QueryRow(ctx, `
+			SELECT count(*)
+			  FROM functions f
+			  JOIN questions q ON q.questionid = f.questionid
+			 WHERE f.pillarid <> q.pillarid`).Scan(&drifted)
+		require.NoError(t, err)
+		assert.Zero(t, drifted, "no function may disagree with its question's pillar")
+	})
+}
+
+func hardDeleteFunctionByID(id int32) {
+	c, err := db.Conn(context.Background())
+	if err != nil {
+		return
+	}
+	defer c.Release()
+	_, _ = c.Exec(context.Background(), `DELETE FROM functions WHERE functionid = $1`, id)
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -507,6 +507,9 @@ components:
         order:
           type: integer
         pillarid:
+          description: Derived from the function's question on write; a value sent
+            by a client is ignored.
+          readOnly: true
           type: integer
         questionid:
           type: integer


### PR DESCRIPTION
Closes #534.

## Problem

`functions.pillarid` and `questions.pillarid` store the same fact independently — two separate FKs to `pillars`, with nothing forcing them to agree. `Function.Save()` wrote the function's copy straight from caller input rather than deriving it from the function's question, so an admin edit or a direct API call could create a disagreement at any time.

Nothing user-facing reads the function's copy today: #528 re-anchored the export's Pillar column through the question, matching the questionnaire and `/scores/progress`, and #530 verified zero drift in production (360/360 agree). So this was latent rather than live — but the stale copy sat there waiting to mislead the next query that read it directly.

## Approach

Option 1 from the issue: close the write path rather than drop the column.

`Save()` now resolves the function's question and writes that question's `pillarid`, discarding whatever the caller sent. `questionid` becomes required — a function with no question reaches no questionnaire (`FindQuestionsByFismaSystem` inner-joins `functions` on `questionid`) and has no pillar to derive from, so it is invalid input. With `pillarid` always derived, the `pillarid` check in `validate()` is dead for every valid input and comes out.

An unknown `questionid` returns `ErrNoReference`, which is the same 400 the caller already got — today that input reaches Postgres and comes back as a 23503 that `trapError` maps to `ErrNoReference` anyway — just detected before the insert.

### Requiring questionid also closes an accidental-NULL path

Worth calling out separately, because it is a second bug rather than a consequence of the first. The UPDATE in `Save()` sets every column unconditionally, so pre-PR a `PUT /functions/{id}` that omitted `questionid` — an ordinary partial-update shape — wrote NULL to the column and silently orphaned the function from every questionnaire, since `FindQuestionsByFismaSystem` inner-joins `functions` on `questionid`. The function would simply stop appearing for every system in its data center environment, with no error to the caller. Requiring `questionid` makes that request a 400 instead.

**No migration.** #530 showed production already agrees across all 360 functions, and writes are now self-correcting.

### Scope of the guarantee

This closes the `/functions` write path only: a caller-supplied `pillarid` can no longer put a function out of agreement with its question. It does **not** make the invariant total. `PUT /api/v1/questions/{id}` writes `questions.pillarid` with no cascade to dependent functions, so moving a question to a different pillar leaves its functions stale until each is next saved (at which point this change re-derives and self-heals it). That path is pre-existing and untouched here — see the follow-up below.

## Acceptance criteria

- [x] `POST`/`PUT /api/v1/functions` writes the question's `pillarid` regardless of the `pillarid` in the request body, on both insert and update.
- [x] A request whose `pillarid` disagrees with its question returns 201/200 with the corrected value, rather than persisting the disagreement.
- [x] `questionid` is required; a request without one returns 400 with `questionid` in the error payload, and nothing is written.
- [x] An unknown `questionid` returns 400 (`ErrNoReference`) and nothing is written.
- [x] A `PUT` omitting `questionid` returns 400 rather than NULLing the column and orphaning the function from every questionnaire.
- [x] No schema change and no data migration.
- [x] Existing readers are unaffected: the questionnaire, `/scores/progress`, the scoring aggregate and the export all already join `questions.pillarid`.

## Testing

- `internal/model/functions_pillarderive_integration_test.go` (new) — insert and update each correct a deliberately wrong `pillarid`; missing `questionid` → `InvalidInputError` carrying `questionid`; unknown `questionid` → `ErrNoReference`. Fixtures use the `AWS` environment, which no seeded system maps to, so they are never visible to a questionnaire while the test runs.
- `emberfall_tests.yml` — `functionData` / `updatedFunctionData` gained `questionid: 8001`; added a drift case (claims pillar 6 against a pillar-1 question → 201 with `pillarid: 1`), a questionless `POST` → 400, and a questionless `PUT` → 400 followed by a `GET` asserting the whole prior state, so a partial write of any field fails the case.
- `make test-unit` — pass
- `make test-integration` — pass, including all 4 new subtests
- `make test-e2e` — 201 ran, 0 failed
- `openapi.yaml` regenerated: `pillarid` is now `readOnly: true` with a description. Redocly lint is unchanged at 8 warnings / 2 ignored, verified against the baseline.

## Reviewer notes

- **Behavior change:** `POST`/`PUT /api/v1/functions` without a `questionid` now returns 400 where it previously succeeded. The frontend never writes to this endpoint — its only `functions` calls are `GET functions/{id}/options` in `QuestionnairePage` and `QuestionnareModal`, and there is no admin "manage functions" view — so the only affected callers would be hand-rolled scripts against the admin API.
- `Save()` repeats the nil check on `QuestionID` immediately before dereferencing it. `validate()` already rejects nil, so the branch is unreachable today; it is there so the deref does not silently depend on a guard sixteen lines up in another method.
- Worth confirming before merge that production has no `functions` rows with a NULL `questionid` (`SELECT count(*) FROM functions WHERE questionid IS NULL;`). Such rows are already orphaned from every questionnaire, but they would no longer be editable through the API without supplying a question. #530's 360/360 count only covered rows that join to a question, so it would not have surfaced them.

## Follow-up (post data call)

Deferring the remaining work to a single change after the current data call, rather than splitting it across cycles:

- Cascade or eliminate the question-edit path described above, so a question moving pillars cannot leave its functions stale.
- Option 2 from #534: drop `functions.pillarid` entirely and read through the question everywhere. This subsumes the cascade — with no second copy there is nothing to keep in sync. It needs `functions.questionid` made NOT NULL, plus updates to the `PillarID` filter in `FindFunctions`, the Empire seed's score generator, and the OpenAPI schema.

Doing both at once avoids writing a cascade that the column drop would immediately delete. Not scheduled during the data call because it touches the questionnaire's schema while systems are actively being scored.

Refs #528, #530.
