### PR TITLE
techdebt(#484): move DB secret resolution from db/conn.go into config

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -26,6 +26,13 @@ type smtp struct {
 	CertIntermediateSecretID *string `env:"SMTP_CA_INT_SECRET_ID"`
 }
 
+// DbCreds holds resolved database credentials, either read directly from env
+// vars or unmarshalled from the Secrets Manager secret named by DB_SECRET_ID.
+type DbCreds struct {
+	Username string
+	Password string
+}
+
 // config is shared by all binaries with values derived from environment variables
 type config struct {
 	Env      string `env:"ENVIRONMENT" envDefault:"production"`
@@ -91,6 +98,12 @@ type config struct {
 	// SMTP config will be loaded from env vars if provided.
 	// If config secret is provided, struct field values will be overwritten by unmarshalling JSON from config secret value hence the pointer to struct
 	SMTP *smtp
+
+	// dbSecret caches the Secrets Manager secret behind Db.SecretId. Unexported
+	// (env.Parse skips it) and per-instance so tests can exercise resolution on a
+	// constructed config without touching the singleton.
+	dbSecret     *secrets.Secret
+	dbSecretOnce sync.Once
 }
 
 // GetInstance returns a singleton of *config
@@ -173,6 +186,54 @@ func GetInstance() *config {
 	}
 
 	return cfg
+}
+
+// DbCreds resolves the current database credentials. If no secret id is
+// specified, user/pass are assumed to be provided in env vars; otherwise they
+// are pulled from the secret. Call dbSecretOnce.Do unconditionally (no bare
+// dbSecret nil-check first): once.Do is what establishes the happens-before for
+// the dbSecret write, so reading the pointer outside it - from concurrent
+// request goroutines at startup - would be an unsynchronized read. err is set
+// only on the goroutine that ran the init, so re-check dbSecret afterward to
+// surface a failed init to every caller.
+func (c *config) DbCreds() (*DbCreds, error) {
+	if c.Db.SecretId == "" {
+		return &DbCreds{c.Db.User, c.Db.Pass}, nil
+	}
+
+	var err error
+	c.dbSecretOnce.Do(func() {
+		c.dbSecret, err = secrets.NewSecret(c.Db.SecretId)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if c.dbSecret == nil {
+		return nil, errors.New("db secret initialization failed")
+	}
+
+	creds := &DbCreds{}
+	if err := c.dbSecret.Unmarshal(creds); err != nil {
+		log.Println("could not unmarshal credentials", err)
+		return nil, err
+	}
+
+	return creds, nil
+}
+
+// RefreshDbCreds forces a re-read of the cached secret from Secrets Manager so
+// the next connection picks up the post-rotation password. Caches the secret on
+// first use if startup somehow skipped it.
+func (c *config) RefreshDbCreds(ctx context.Context) error {
+	if c.dbSecret == nil {
+		if _, err := c.DbCreds(); err != nil {
+			return err
+		}
+		if c.dbSecret == nil {
+			return errors.New("no db secret configured to refresh")
+		}
+	}
+	return c.dbSecret.Refresh(ctx)
 }
 
 // SessionSecret returns the secret used to sign and verify the application

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,11 +1,43 @@
 package config
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // These two helpers gate environment-sensitive behavior: IsLocalOrTest gates
 // test-data seeding (must run in local + E2E test, never a deployed env), and
 // IsLocal gates just-in-time ADMIN user creation (local only, deliberately not
 // the E2E test stack). The deployed default ENVIRONMENT is "production".
+// With no DB_SECRET_ID configured, credentials come straight from the env-var
+// fields and no Secrets Manager call is involved.
+func TestDbCredsEnvFallback(t *testing.T) {
+	cfg := &config{}
+	cfg.Db.User = "ztmfAdmin"
+	cfg.Db.Pass = "hunter2"
+
+	creds, err := cfg.DbCreds()
+	if err != nil {
+		t.Fatalf("DbCreds() with no secret id returned error: %v", err)
+	}
+	if creds.Username != "ztmfAdmin" || creds.Password != "hunter2" {
+		t.Errorf("DbCreds() = %+v, want env-var user/pass", creds)
+	}
+}
+
+// RefreshDbCreds only makes sense for secret-backed credentials; with no
+// DB_SECRET_ID there is nothing to re-fetch and the call must fail rather than
+// pretend it refreshed.
+func TestRefreshDbCredsWithoutSecret(t *testing.T) {
+	cfg := &config{}
+	cfg.Db.User = "ztmfAdmin"
+	cfg.Db.Pass = "hunter2"
+
+	if err := cfg.RefreshDbCreds(context.Background()); err == nil {
+		t.Error("RefreshDbCreds() with no secret configured returned nil, want error")
+	}
+}
+
 func TestEnvironmentGates(t *testing.T) {
 	cases := []struct {
 		env         string

--- a/backend/internal/db/conn.go
+++ b/backend/internal/db/conn.go
@@ -9,16 +9,12 @@ import (
 	"time"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
-	"github.com/CMS-Enterprise/ztmf/backend/internal/secrets"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 var (
-	once     sync.Once
-	dbSecret *secrets.Secret
-
 	pool     *pgxpool.Pool
 	poolOnce sync.Once
 	poolErr  error
@@ -35,11 +31,6 @@ const (
 	maxConnIdleTime = 5 * time.Minute
 	healthCheck     = time.Minute
 )
-
-type dbCreds struct {
-	Username string
-	Password string
-}
 
 // sslMode selects the libpq sslmode for the connection. Deployed environments
 // require TLS to RDS/Aurora with no plaintext fallback. Local and test run
@@ -85,7 +76,7 @@ func Conn(ctx context.Context) (*pgxpool.Conn, error) {
 	}
 
 	log.Println("db authentication failed; refreshing credentials and retrying once")
-	if rerr := refreshDbCreds(ctx); rerr != nil {
+	if rerr := config.GetInstance().RefreshDbCreds(ctx); rerr != nil {
 		log.Println("could not refresh db credentials", rerr)
 		return nil, err
 	}
@@ -131,7 +122,7 @@ func initPool() error {
 	// secret value. Combined with MaxConnLifetime recycling connections, a
 	// rotated credential is picked up without a process restart.
 	poolCfg.BeforeConnect = func(_ context.Context, cc *pgx.ConnConfig) error {
-		creds, err := getDbCreds()
+		creds, err := config.GetInstance().DbCreds()
 		if err != nil {
 			return err
 		}
@@ -171,7 +162,7 @@ func MigrationConn(ctx context.Context) (*pgx.Conn, error) {
 		return nil, err
 	}
 	log.Println("db authentication failed; refreshing credentials and retrying once")
-	if rerr := refreshDbCreds(ctx); rerr != nil {
+	if rerr := config.GetInstance().RefreshDbCreds(ctx); rerr != nil {
 		log.Println("could not refresh db credentials", rerr)
 		return nil, err
 	}
@@ -181,13 +172,13 @@ func MigrationConn(ctx context.Context) (*pgx.Conn, error) {
 // connectOne builds the connection config from the current credentials and
 // opens a single (non-pooled) connection. Used by the migrator.
 func connectOne(ctx context.Context) (*pgx.Conn, error) {
-	creds, err := getDbCreds()
+	cfg := config.GetInstance()
+
+	creds, err := cfg.DbCreds()
 	if err != nil {
 		log.Println("could not get db credentials")
 		return nil, err
 	}
-
-	cfg := config.GetInstance()
 	connConfig, err := pgx.ParseConfig(fmt.Sprintf("host=%s port=%s dbname=%s sslmode=%s", cfg.Db.Host, cfg.Db.Port, cfg.Db.Name, sslMode()))
 	if err != nil {
 		log.Println("could not parse db config", err)
@@ -216,55 +207,4 @@ func connectOne(ctx context.Context) (*pgx.Conn, error) {
 func isAuthError(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == "28P01"
-}
-
-// refreshDbCreds forces a re-read of the cached secret from Secrets Manager so
-// the next connection picks up the post-rotation password. Caches the secret on
-// first use if startup somehow skipped it.
-func refreshDbCreds(ctx context.Context) error {
-	if dbSecret == nil {
-		if _, err := getDbCreds(); err != nil {
-			return err
-		}
-		if dbSecret == nil {
-			return errors.New("no db secret configured to refresh")
-		}
-	}
-	return dbSecret.Refresh(ctx)
-}
-
-func getDbCreds() (*dbCreds, error) {
-	cfg := config.GetInstance()
-
-	// TODO: move this secret handling to config.GetInstance()
-	// if no secret id specified, assume user/pass are provided in env vars
-	if cfg.Db.SecretId == "" {
-		return &dbCreds{cfg.Db.User, cfg.Db.Pass}, nil
-	}
-
-	// otherwise pull user/pass from the secret. Call once.Do unconditionally (no
-	// bare dbSecret nil-check first): once.Do is what establishes the happens-
-	// before for the dbSecret write, so reading the pointer outside it - from
-	// concurrent request goroutines at startup - would be an unsynchronized read.
-	// err is set only on the goroutine that ran the init, so re-check dbSecret
-	// afterward to surface a failed init to every caller.
-	var err error
-	once.Do(func() {
-		dbSecret, err = secrets.NewSecret(cfg.Db.SecretId)
-	})
-	if err != nil {
-		return nil, err
-	}
-	if dbSecret == nil {
-		return nil, errors.New("db secret initialization failed")
-	}
-
-	creds := &dbCreds{}
-	err = dbSecret.Unmarshal(creds)
-	if err != nil {
-		log.Println("could not unmarshal credentials", err)
-		return nil, err
-	}
-
-	return creds, nil
 }


### PR DESCRIPTION
Resolves the standing TODO in `internal/db/conn.go` by centralizing DB secret resolution in `internal/config`, as #484 proposes. Config now owns fetching and caching the Secrets Manager secret through a `DbCreds()` resolver and a `RefreshDbCreds()` refresh path, and `db` consumes resolved credentials instead of running its own `secrets.NewSecret` and `once.Do` initialization. The env-var fallback, the unconditional once.Do happens-before discipline, and the 28P01 refresh-and-retry behavior are verbatim ports; no behavior change intended. The secret cache lives on the config struct rather than at package level so resolution is testable on a constructed config, and two unit tests cover the AWS-free paths (env fallback, refresh with no secret configured). The secret-backed path remains #482's coverage territory.

Closes #484

Local gate: unit, integration, and emberfall e2e (197 passed, 0 failed) all green. Snyk and the deploy checks will show red as usual for a fork PR; maintainers re-run them after pulling the branch.