### PR TITLE
Fix questionnaire ordering end to end: answer choices, question sequence, export, diff (+ export index)

### DIFF
--- a/backend/cmd/api/internal/migrations/0055functionoptionsindex.go
+++ b/backend/cmd/api/internal/migrations/0055functionoptionsindex.go
@@ -1,0 +1,27 @@
+package migrations
+
+func init() {
+	appendMigration(
+		"add functionoptions(functionid) index for the data-call export",
+		`
+-- The data-call export (#528 re-anchor of FindAnswers) left-joins scores with
+-- a per-row subquery over functionoptions keyed on functionid. Postgres cannot
+-- fold that IN-subquery into the hash join, so it runs as a per-candidate-row
+-- Join Filter - and functionoptions has no functionid index (only its primary
+-- key), making each evaluation a sequential scan.
+--
+-- Measured on a prod-scale copy (ztmf#531, 1,530 systems / 192k scores): the
+-- whole-call FY26 export performs that scan 1,556,120 times, 47.7s of database
+-- time before the spreadsheet is even rendered - retry/abandon territory, and
+-- near typical gateway idle timeouts. With this index the same export runs in
+-- 2.0s (23x).
+--
+-- functionoptions is a small, static, read-mostly catalogue (1,728 rows; it
+-- changes only when a questionnaire edition is edited), so the write cost is
+-- negligible and no partial or composite form is warranted.
+CREATE INDEX IF NOT EXISTS functionoptions_functionid_idx
+    ON public.functionoptions (functionid);
+`,
+		`DROP INDEX IF EXISTS functionoptions_functionid_idx;`,
+	)
+}

--- a/backend/cmd/api/internal/migrations/0056orderingdata.go
+++ b/backend/cmd/api/internal/migrations/0056orderingdata.go
@@ -68,9 +68,18 @@ FROM (VALUES
 ) AS v(pillar, ordr)
 WHERE p.pillar = v.pillar;
 
+-- Deterministic by construction rather than by hope: a question is ranked by
+-- the MINIMUM matching rank among its functions' names. On prod data every
+-- question matches exactly one name (verified: 40/40 single-name), so min() is
+-- the identity; if a future edition ever forked a question's function name,
+-- min() still yields one stable, re-runnable answer instead of letting the
+-- planner pick a VALUES row arbitrarily.
 UPDATE questions q
-SET ordr = r.ordr
-FROM (VALUES
+SET ordr = ranked.ordr
+FROM (
+  SELECT f.questionid, min(r.ordr) AS ordr
+  FROM functions f
+  JOIN (VALUES
     ('Authentication-Users',                101),
     ('IdentityStores-Users',                102),
     ('RiskAssessment',                      103),
@@ -111,13 +120,12 @@ FROM (VALUES
     ('Cross-VisibilityAnalytics',           601),
     ('Cross-AutomationOrchestration',       602),
     ('Cross-Governance',                    603)
-) AS r(function_name, ordr)
-WHERE q.ordr = 0
-  AND EXISTS (
-      SELECT 1 FROM functions f
-      WHERE f.questionid = q.questionid
-        AND f.function = r.function_name
-  );
+  ) AS r(function_name, ordr) ON r.function_name = f.function
+  WHERE f.questionid IS NOT NULL
+  GROUP BY f.questionid
+) AS ranked
+WHERE q.questionid = ranked.questionid
+  AND q.ordr = 0;
 `,
 		`
 -- Reverses the population only. The legacy 901-907 band predates this migration

--- a/backend/cmd/api/internal/migrations/0056orderingdata.go
+++ b/backend/cmd/api/internal/migrations/0056orderingdata.go
@@ -1,0 +1,130 @@
+package migrations
+
+func init() {
+	appendMigration(
+		"populate pillars.ordr and questions.ordr with the canonical questionnaire order",
+		`
+-- pillars.ordr and questions.ordr have existed since 0002 but were never
+-- populated: every row is 0 except questions 41-47, the legacy "Future Plan..."
+-- questions that carry 901-907 so they sink to the bottom. With every other
+-- row tied at 0 the API's ORDER BY collapsed to whatever the planner felt like
+-- returning, so the questionnaire's real order has been carried by the frontend
+-- instead - PILLAR_ORDER and PILLAR_FUNCTION_MAP in ztmf-ui's src/constants.ts,
+-- which re-sorts the API payload client-side before rendering.
+--
+-- That works only for the one consumer that owns the map. The spreadsheet
+-- export, the score diff, and any future API client all read the same unordered
+-- payload and have no way to recover the intended sequence. Worse, the ordering
+-- they do get is heap order, which is stable only until something rewrites the
+-- rows - exactly the failure mode that scrambled the answer choices in
+-- ztmf-misc#279, whose related-finding thread is what surfaced this.
+--
+-- So: move the order into the data, where every consumer sees it.
+--
+-- Why the frontend map is the source. It is not a guess that needs review - it
+-- is the order the questionnaire has rendered in production for years, matching
+-- the CISA Zero Trust Maturity Model's pillar sequence (Identity, Devices,
+-- Networks, Applications, Data, then the Cross-Cutting capabilities) and, within
+-- each pillar, the model's function sequence ending in the three cross-cutting
+-- capabilities (Visibility & Analytics, Automation & Orchestration, Governance).
+-- Transcribing it is a lift-and-shift of an already-approved order, not a new
+-- editorial decision.
+--
+-- Why the data lives in a migration rather than a seed script or a one-off SQL
+-- run: it ships in the same versioned, reviewed, single-PR artifact as the
+-- ORDER BY changes that depend on it, it runs identically in local, test, dev
+-- and prod, and it is reversible.
+--
+-- Scheme: questions.ordr = pillar_rank * 100 + function_index, both 1-based
+-- (Identity 101-107, Devices 201-207, Networks 301-307, Applications 401-408,
+-- Data 501-508, CrossCutting 601-603). The pillar prefix is redundant with the
+-- ORDER BY (which sorts pillars.ordr first) but makes a raw questions row
+-- self-describing, and leaves gaps so a function can be inserted mid-pillar
+-- without renumbering. All values stay well under the legacy 900 band and
+-- inside smallint.
+--
+-- Questions are keyed to the map by their function's NAME, not by id: each
+-- questionnaire edition (cloud, on-prem, ...) has its own functions row, but all
+-- editions of a given question share the questionid and the function name, so
+-- the name is the stable business key. Verified against a prod copy: all 40
+-- non-legacy questions resolve to exactly one distinct function name and all 40
+-- names are present in the map, no leftovers on either side.
+--
+-- Unmatched questions keep ordr = 0 by design. The empire seed used by the local
+-- and test databases has fictional function names that will never match the map,
+-- and the WHERE ordr = 0 guard likewise leaves the 901-907 legacy values alone.
+-- Neither case is a problem: the queries this migration supports all carry a
+-- questions.questionid tiebreaker, so rows sharing ordr = 0 still come back in a
+-- stable order, just not a curated one.
+UPDATE pillars p
+SET ordr = v.ordr
+FROM (VALUES
+    ('Identity',     1),
+    ('Devices',      2),
+    ('Networks',     3),
+    ('Applications', 4),
+    ('Data',         5),
+    ('CrossCutting', 6)
+) AS v(pillar, ordr)
+WHERE p.pillar = v.pillar;
+
+UPDATE questions q
+SET ordr = r.ordr
+FROM (VALUES
+    ('Authentication-Users',                101),
+    ('IdentityStores-Users',                102),
+    ('RiskAssessment',                      103),
+    ('AccessManagement',                    104),
+    ('Identity-VisibilityAnalytics',        105),
+    ('Identity-AutomationOrchestration',    106),
+    ('Identity-Governance',                 107),
+    ('PolicyEnforcement',                   201),
+    ('AssetRiskManagement',                 202),
+    ('ResourceAccess',                      203),
+    ('Device-ThreatProtection',             204),
+    ('Device-VisibilityAnalytics',          205),
+    ('Device-AutomationOrchestration',      206),
+    ('Device-Governance',                   207),
+    ('NetworkSegmentation',                 301),
+    ('NetworkTrafficManagement',            302),
+    ('Network-Encryption',                  303),
+    ('NetworkResilience',                   304),
+    ('Network-VisibilityAnalytics',         305),
+    ('Network-AutomationOrchestration',     306),
+    ('Network-Governance',                  307),
+    ('AccessAuthorization-Users',           401),
+    ('Application-ThreatProtection',        402),
+    ('AccessibleApplications',              403),
+    ('SecureDevDeployWorkflow',             404),
+    ('Application-SecurityTesting',         405),
+    ('Application-VisibilityAnalytics',     406),
+    ('Application-AutomationOrchestration', 407),
+    ('Application-Governance',              408),
+    ('DataInventoryManagement',             501),
+    ('DataCategorization',                  502),
+    ('DataAvailability',                    503),
+    ('DataAccess',                          504),
+    ('DataEncryption',                      505),
+    ('Data-VisibilityAnalytics',            506),
+    ('Data-AutomationOrchestration',        507),
+    ('Data-Governance',                     508),
+    ('Cross-VisibilityAnalytics',           601),
+    ('Cross-AutomationOrchestration',       602),
+    ('Cross-Governance',                    603)
+) AS r(function_name, ordr)
+WHERE q.ordr = 0
+  AND EXISTS (
+      SELECT 1 FROM functions f
+      WHERE f.questionid = q.questionid
+        AND f.function = r.function_name
+  );
+`,
+		`
+-- Reverses the population only. The legacy 901-907 band predates this migration
+-- and is not ours to clear, so the down guard mirrors the up guard from the
+-- other side: everything this migration could have written is below 900.
+UPDATE pillars SET ordr = 0;
+UPDATE questions SET ordr = 0 WHERE ordr < 900;
+`,
+	)
+}

--- a/backend/cmd/api/internal/migrations/0056orderingdata_integration_test.go
+++ b/backend/cmd/api/internal/migrations/0056orderingdata_integration_test.go
@@ -1,0 +1,142 @@
+package migrations
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrderingDataMigrationIntegration runs migration 0056's real SQL against a
+// live database and checks what it did.
+//
+// It cannot rely on the migration having already run: tern applies migrations
+// before the seed loads, so on an ephemeral empire-seeded database 0056 executes
+// against empty catalog tables and writes nothing. Rather than skip, the test
+// pulls the migration's own up/down SQL out of the registry and executes it
+// inside a transaction it always rolls back, on fixture rows it inserts itself.
+// That covers the three behaviors the migration promises regardless of which
+// fixture the database carries: canonical names get ranked, unrecognized names
+// are left at 0, and the legacy 901-907 band is never touched.
+//
+// Requires DB_* env vars pointing at a migrated ZTMF database. Skipped under
+// `go test -short`.
+func TestOrderingDataMigrationIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	var up, down string
+	for _, m := range registry {
+		if strings.Contains(m.name, "pillars.ordr and questions.ordr") {
+			up, down = m.upSQL, m.downSQL
+			break
+		}
+	}
+	require.NotEmpty(t, up, "migration 0056 not found in the registry; was it renamed?")
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	tx, err := conn.Begin(ctx)
+	require.NoError(t, err)
+	// Everything below is scratch: the rollback is the cleanup.
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var identityPillarID int32
+	require.NoError(t, tx.QueryRow(ctx,
+		`SELECT pillarid FROM pillars WHERE pillar = 'Identity'`).Scan(&identityPillarID),
+		"catalog must contain the Identity pillar")
+
+	// Pre-state: unranked, which is what the migration expects to find.
+	_, err = tx.Exec(ctx, `UPDATE pillars SET ordr = 0`)
+	require.NoError(t, err)
+
+	// Three fixture questions in one pillar: one whose function name is in the
+	// canonical map, one whose name is not (the empire-seed case), and one
+	// already sitting in the legacy band.
+	canonical := insertQuestion(ctx, t, tx, identityPillarID, 0, "Authentication-Users")
+	unmatched := insertQuestion(ctx, t, tx, identityPillarID, 0, "Imperial Identity Verification (fixture)")
+	legacy := insertQuestion(ctx, t, tx, identityPillarID, 905, "Future Plan Fixture")
+
+	_, err = tx.Exec(ctx, up)
+	require.NoError(t, err, "migration up SQL must apply cleanly")
+
+	assert.Equal(t,
+		[]string{"Identity", "Devices", "Networks", "Applications", "Data", "CrossCutting"},
+		pillarNamesByRank(ctx, t, tx),
+		"pillars must be ranked in the CISA ZTMM sequence the questionnaire renders")
+
+	assert.EqualValues(t, 101, questionOrdr(ctx, t, tx, canonical),
+		"a question whose function name is in the map takes pillar_rank*100 + function_index")
+	assert.EqualValues(t, 0, questionOrdr(ctx, t, tx, unmatched),
+		"a question whose function name is not in the map stays unranked")
+	assert.EqualValues(t, 905, questionOrdr(ctx, t, tx, legacy),
+		"the legacy 901-907 band must survive the migration untouched")
+
+	_, err = tx.Exec(ctx, down)
+	require.NoError(t, err, "migration down SQL must apply cleanly")
+
+	var rankedPillars int
+	require.NoError(t, tx.QueryRow(ctx,
+		`SELECT count(*) FROM pillars WHERE ordr <> 0`).Scan(&rankedPillars))
+	assert.Zero(t, rankedPillars, "down must clear every pillar rank")
+
+	assert.EqualValues(t, 0, questionOrdr(ctx, t, tx, canonical), "down must clear the ranks it set")
+	assert.EqualValues(t, 905, questionOrdr(ctx, t, tx, legacy),
+		"down must preserve the legacy band it never wrote")
+}
+
+// insertQuestion adds a question with the given rank plus one function naming
+// it, mirroring the questions -> functions shape the migration keys on.
+func insertQuestion(ctx context.Context, t *testing.T, tx pgx.Tx, pillarID int32, ordr int, functionName string) int32 {
+	t.Helper()
+
+	var questionID int32
+	require.NoError(t, tx.QueryRow(ctx, `
+		INSERT INTO questions (question, notesprompt, pillarid, ordr)
+		VALUES ($1, 'fixture', $2, $3)
+		RETURNING questionid
+	`, "ordering fixture: "+functionName, pillarID, ordr).Scan(&questionID))
+
+	var functionID int32
+	require.NoError(t, tx.QueryRow(ctx, `
+		INSERT INTO functions (function, description, datacenterenvironment, questionid, pillarid)
+		VALUES ($1, 'fixture', 'fixture', $2, $3)
+		RETURNING functionid
+	`, functionName, questionID, pillarID).Scan(&functionID))
+
+	return questionID
+}
+
+func questionOrdr(ctx context.Context, t *testing.T, tx pgx.Tx, questionID int32) int {
+	t.Helper()
+
+	var ordr int
+	require.NoError(t, tx.QueryRow(ctx,
+		`SELECT ordr FROM questions WHERE questionid = $1`, questionID).Scan(&ordr))
+	return ordr
+}
+
+func pillarNamesByRank(ctx context.Context, t *testing.T, tx pgx.Tx) []string {
+	t.Helper()
+
+	rows, err := tx.Query(ctx, `SELECT pillar FROM pillars ORDER BY ordr`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		names = append(names, name)
+	}
+	require.NoError(t, rows.Err())
+	return names
+}

--- a/backend/internal/model/answers.go
+++ b/backend/internal/model/answers.go
@@ -56,8 +56,13 @@ func FindAnswers(ctx context.Context, input FindAnswersInput) ([]*Answer, error)
 		// questions.ordr are 0 for any row migration 0056 could not rank (the
 		// empire seed's fictional function names), and rows tied on the sort key
 		// would otherwise come back in heap order, which shifts whenever a row is
-		// rewritten. The tiebreaker keeps the export byte-stable either way.
-		OrderBy("fismasystems.fismasystemid, pillars.ordr, questions.ordr, questions.questionid ASC")
+		// rewritten. questions.questionid alone does not reach the export's row grain: the
+	// applicable-or-answered join deliberately admits functions from OTHER
+	// editions when a system answered them before an environment change
+	// (#528), so one questionid can yield two rows that tie on every
+	// question-level column. functions.functionid settles those, keeping the
+	// export byte-stable.
+		OrderBy("fismasystems.fismasystemid, pillars.ordr, questions.ordr, questions.questionid, functions.functionid ASC")
 
 	if input.UserID != nil {
 		sqlb = sqlb.InnerJoin("users_fismasystems ON users_fismasystems.userid=? AND users_fismasystems.fismasystemid=fismasystems.fismasystemid", input.UserID)

--- a/backend/internal/model/answers.go
+++ b/backend/internal/model/answers.go
@@ -52,7 +52,12 @@ func FindAnswers(ctx context.Context, input FindAnswersInput) ([]*Answer, error)
 		LeftJoin("scores ON scores.fismasystemid=fismasystems.fismasystemid AND scores.datacallid=? AND scores.functionoptionid IN (SELECT selected.functionoptionid FROM functionoptions selected WHERE selected.functionid=functions.functionid)", input.DataCallID).
 		LeftJoin("functionoptions ON functionoptions.functionoptionid=scores.functionoptionid").
 		Where("(fismasystems.decommissioned=FALSE OR scores.scoreid IS NOT NULL)").
-		OrderBy("fismasystems.fismasystemid, pillars.ordr, questions.ordr ASC")
+		// questionid is the tiebreaker, not decoration: pillars.ordr and
+		// questions.ordr are 0 for any row migration 0056 could not rank (the
+		// empire seed's fictional function names), and rows tied on the sort key
+		// would otherwise come back in heap order, which shifts whenever a row is
+		// rewritten. The tiebreaker keeps the export byte-stable either way.
+		OrderBy("fismasystems.fismasystemid, pillars.ordr, questions.ordr, questions.questionid ASC")
 
 	if input.UserID != nil {
 		sqlb = sqlb.InnerJoin("users_fismasystems ON users_fismasystems.userid=? AND users_fismasystems.fismasystemid=fismasystems.fismasystemid", input.UserID)

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -251,7 +251,7 @@ func RecordLogin(ctx context.Context, userID string) error {
 	if userID == "" {
 		return nil
 	}
-	return insertEvent(ctx, userID, "created", "session", payload{UserID: &userID})
+	return insertEvent(ctx, userID, eventActionCreated, "session", payload{UserID: &userID})
 }
 
 func FindEvents(ctx context.Context, input *FindEventsInput) ([]*Event, error) {

--- a/backend/internal/model/functionoptions.go
+++ b/backend/internal/model/functionoptions.go
@@ -23,9 +23,22 @@ type FindFunctionOptionsInput struct {
 }
 
 func FindFunctionOptions(ctx context.Context, input FindFunctionOptionsInput) ([]*FunctionOption, error) {
+	// Maturity order is presentation-critical: the questionnaire renders these
+	// rows exactly as returned (the ztmf-ui#369 client-side sort covers pillars
+	// and questions, never the answer choices). Without an ORDER BY, Postgres
+	// returns heap order, which happened to match score order for years - until
+	// the 2026-08-02 description scrub relocated the updated tuples and
+	// scrambled the choices on ~50 visible questions across 7 editions, 32
+	// minutes before the FY26 call opened (ztmf-misc#279; the audited set is a
+	// floor, not a list - heap order reshuffles on any UPDATE or vacuum, which
+	// is why the fix lives here and not in the data). score is the natural key
+	// (1..4 = traditional..optimal); functionoptionid breaks ties and is known
+	// to agree with score order on all 432 functions, so the result is fully
+	// deterministic either way.
 	sqlb := stmntBuilder.
 		Select(functionOptionColumns...).
-		From("functionoptions")
+		From("functionoptions").
+		OrderBy("score ASC, functionoptionid ASC")
 
 	if input.FunctionID != nil {
 		sqlb = sqlb.Where("functionid=?", *input.FunctionID)

--- a/backend/internal/model/functionoptions_integration_test.go
+++ b/backend/internal/model/functionoptions_integration_test.go
@@ -29,6 +29,11 @@ func TestFindFunctionOptionsOrderIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pick a real function with a full option set from the seed.
+	// Registered before anything can fail so the connection is returned on
+	// every exit path; the restore cleanup below stacks on top (LIFO) and
+	// runs first.
+	t.Cleanup(conn.Release)
+
 	var functionID int32
 	var origDesc string
 	var relocatedID int32
@@ -37,21 +42,24 @@ func TestFindFunctionOptionsOrderIntegration(t *testing.T) {
 		FROM functionoptions fo
 		GROUP BY fo.functionid, fo.functionoptionid, fo.description, fo.score
 		HAVING (SELECT count(*) FROM functionoptions x WHERE x.functionid = fo.functionid) = 4
-		ORDER BY fo.functionid, fo.score DESC LIMIT 1
+		ORDER BY fo.functionid, fo.score ASC LIMIT 1
 	`).Scan(&functionID, &relocatedID, &origDesc))
 
 	// Registered before the mutation; restores the description (a second
 	// relocation, but content-identical). Not deferred: deferred calls run
 	// BEFORE t.Cleanup and would release the connection out from under this.
 	t.Cleanup(func() {
-		_, _ = conn.Exec(ctx,
+		_, err := conn.Exec(ctx,
 			`UPDATE functionoptions SET description=$1 WHERE functionoptionid=$2`,
 			origDesc, relocatedID)
-		conn.Release()
+		assert.NoError(t, err, "fixture restore must not fail silently")
 	})
 
-	// The trigger: an UPDATE relocates the tuple to a new heap page, exactly
-	// what the production description scrub did.
+	// The trigger: an UPDATE relocates the tuple, exactly what the production
+	// description scrub did. Deliberately the LOWEST-score option: relocating
+	// the row that must come FIRST inverts heap order, so this test fails
+	// without the ORDER BY instead of passing by luck (relocating the last
+	// option would leave 1-2-3-4 intact).
 	_, err = conn.Exec(ctx,
 		`UPDATE functionoptions SET description=description||' ' WHERE functionoptionid=$1`,
 		relocatedID)

--- a/backend/internal/model/functionoptions_integration_test.go
+++ b/backend/internal/model/functionoptions_integration_test.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FindFunctionOptions must return answer choices in maturity order (score
+// ascending: traditional, initial, advanced, optimal - the CISA ZTMM stage
+// sequence). Before the explicit ORDER BY, the query returned heap order,
+// which happened to match for years until the 2026-08-02 description scrub
+// relocated updated tuples and scrambled ~50 visible questions
+// (ztmf-misc#279).
+//
+// The test reproduces that trigger rather than trusting fixture luck: it
+// UPDATEs one option's description, which physically relocates the row in
+// Postgres, then asserts the order still comes back by score. Without the
+// ORDER BY this fails; with it, heap layout is irrelevant.
+func TestFindFunctionOptionsOrderIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+
+	// Pick a real function with a full option set from the seed.
+	var functionID int32
+	var origDesc string
+	var relocatedID int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT fo.functionid, fo.functionoptionid, fo.description
+		FROM functionoptions fo
+		GROUP BY fo.functionid, fo.functionoptionid, fo.description, fo.score
+		HAVING (SELECT count(*) FROM functionoptions x WHERE x.functionid = fo.functionid) = 4
+		ORDER BY fo.functionid, fo.score DESC LIMIT 1
+	`).Scan(&functionID, &relocatedID, &origDesc))
+
+	// Registered before the mutation; restores the description (a second
+	// relocation, but content-identical). Not deferred: deferred calls run
+	// BEFORE t.Cleanup and would release the connection out from under this.
+	t.Cleanup(func() {
+		_, _ = conn.Exec(ctx,
+			`UPDATE functionoptions SET description=$1 WHERE functionoptionid=$2`,
+			origDesc, relocatedID)
+		conn.Release()
+	})
+
+	// The trigger: an UPDATE relocates the tuple to a new heap page, exactly
+	// what the production description scrub did.
+	_, err = conn.Exec(ctx,
+		`UPDATE functionoptions SET description=description||' ' WHERE functionoptionid=$1`,
+		relocatedID)
+	require.NoError(t, err)
+
+	opts, err := FindFunctionOptions(ctx, FindFunctionOptionsInput{FunctionID: &functionID})
+	require.NoError(t, err)
+	require.Len(t, opts, 4)
+
+	for i, o := range opts {
+		assert.Equal(t, i+1, int(o.Score),
+			"choices must render traditional(1) -> optimal(4) regardless of heap layout")
+	}
+}

--- a/backend/internal/model/ordering_integration_test.go
+++ b/backend/internal/model/ordering_integration_test.go
@@ -1,0 +1,155 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The questionnaire's order used to live only in the frontend (ztmf-ui's
+// PILLAR_ORDER / PILLAR_FUNCTION_MAP), because pillars.ordr and questions.ordr
+// were 0 on every row. Migration 0056 moves that order into the data and the
+// read paths sort by it with a questionid tiebreaker.
+//
+// These tests pin the property that survives regardless of which fixture the
+// database was seeded from: the same call twice returns the same sequence, and
+// a pillar's questions arrive as one contiguous block rather than interleaved.
+// That is the guarantee an unordered query cannot make - it returns heap order,
+// which is stable only until a row is rewritten (the ztmf-misc#279 failure).
+//
+// The curated ranks themselves are not asserted here, because the empire seed
+// loads after migrations run and leaves every ordr at 0 on an ephemeral test
+// database. Migration 0056's own SQL is covered directly in the migrations
+// package (TestOrderingDataMigrationIntegration), which supplies its own
+// canonically-named fixture rows.
+
+func TestFindQuestionsByFismaSystemOrderingIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// A system whose datacenterenvironment resolves to a multi-pillar
+	// questionnaire, so "grouped by pillar" is a meaningful assertion.
+	var fismaSystemID int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT fs.fismasystemid
+		FROM fismasystems fs
+		JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		JOIN functions f ON f.datacenterenvironment = dce.scoring_key
+		JOIN questions q ON q.questionid = f.questionid
+		GROUP BY fs.fismasystemid
+		HAVING count(DISTINCT q.pillarid) > 1
+		ORDER BY fs.fismasystemid
+		LIMIT 1
+	`).Scan(&fismaSystemID), "seed must contain a system with a multi-pillar questionnaire")
+
+	first, err := FindQuestionsByFismaSystem(ctx, fismaSystemID)
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	second, err := FindQuestionsByFismaSystem(ctx, fismaSystemID)
+	require.NoError(t, err)
+
+	require.Equal(t, questionOrderKeys(first), questionOrderKeys(second),
+		"two consecutive calls must return the same question sequence")
+
+	assertPillarsContiguous(t, len(first), func(i int) any { return first[i].Pillar.PillarID })
+
+	// The declared sort key must be non-decreasing across the result: whatever
+	// order the rows are in, it is the order the ORDER BY asked for.
+	for i := 1; i < len(first); i++ {
+		prev := [3]int{first[i-1].Pillar.Order, first[i-1].Ordr, int(first[i-1].QuestionID)}
+		cur := [3]int{first[i].Pillar.Order, first[i].Ordr, int(first[i].QuestionID)}
+		assert.LessOrEqualf(t, sortKeyCompare(prev, cur), 0,
+			"row %d breaks the (pillars.ordr, questions.ordr, questionid) sort: %v then %v",
+			i, prev, cur)
+	}
+}
+
+func TestFindAnswersOrderingIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	var dataCallID int32
+	require.NoError(t, conn.QueryRow(ctx, `
+		SELECT datacallid FROM scores GROUP BY datacallid ORDER BY count(*) DESC LIMIT 1
+	`).Scan(&dataCallID), "seed must contain at least one scored data call")
+
+	first, err := FindAnswers(ctx, FindAnswersInput{DataCallID: dataCallID})
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	second, err := FindAnswers(ctx, FindAnswersInput{DataCallID: dataCallID})
+	require.NoError(t, err)
+
+	require.Equal(t, answerOrderKeys(first), answerOrderKeys(second),
+		"two consecutive exports must emit rows in the same order")
+
+	// Systems are the outermost grouping, pillars the next one inside each
+	// system. Both must be contiguous or the spreadsheet interleaves.
+	assertPillarsContiguous(t, len(first), func(i int) any { return first[i].FismaSystemID })
+	assertPillarsContiguous(t, len(first), func(i int) any {
+		return [2]any{first[i].FismaSystemID, first[i].Pillar}
+	})
+}
+
+// assertPillarsContiguous fails if a key value reappears after a different key
+// value has intervened, i.e. the grouping is interleaved rather than blocked.
+func assertPillarsContiguous(t *testing.T, n int, keyAt func(int) any) {
+	t.Helper()
+
+	seen := map[any]bool{}
+	var current any
+	for i := 0; i < n; i++ {
+		k := keyAt(i)
+		if i == 0 || k != current {
+			assert.Falsef(t, seen[k], "group %v is split across the result at row %d", k, i)
+			seen[k] = true
+			current = k
+		}
+	}
+}
+
+// sortKeyCompare returns -1, 0 or 1 for the lexicographic order of two sort
+// keys. Written out because testify's ordering assertions only handle scalars.
+func sortKeyCompare(a, b [3]int) int {
+	for i := range a {
+		switch {
+		case a[i] < b[i]:
+			return -1
+		case a[i] > b[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+func questionOrderKeys(qs []*Question) []int32 {
+	keys := make([]int32, len(qs))
+	for i, q := range qs {
+		keys[i] = q.QuestionID
+	}
+	return keys
+}
+
+func answerOrderKeys(as []*Answer) [][3]string {
+	keys := make([][3]string, len(as))
+	for i, a := range as {
+		keys[i] = [3]string{a.FismaAcronym, a.Pillar, a.Function}
+	}
+	return keys
+}

--- a/backend/internal/model/ordering_integration_test.go
+++ b/backend/internal/model/ordering_integration_test.go
@@ -66,8 +66,8 @@ func TestFindQuestionsByFismaSystemOrderingIntegration(t *testing.T) {
 	// The declared sort key must be non-decreasing across the result: whatever
 	// order the rows are in, it is the order the ORDER BY asked for.
 	for i := 1; i < len(first); i++ {
-		prev := [3]int{first[i-1].Pillar.Order, first[i-1].Ordr, int(first[i-1].QuestionID)}
-		cur := [3]int{first[i].Pillar.Order, first[i].Ordr, int(first[i].QuestionID)}
+		prev := [3]int{first[i-1].Pillar.Order, derefInt(first[i-1].Ordr), int(first[i-1].QuestionID)}
+		cur := [3]int{first[i].Pillar.Order, derefInt(first[i].Ordr), int(first[i].QuestionID)}
 		assert.LessOrEqualf(t, sortKeyCompare(prev, cur), 0,
 			"row %d breaks the (pillars.ordr, questions.ordr, questionid) sort: %v then %v",
 			i, prev, cur)

--- a/backend/internal/model/questions.go
+++ b/backend/internal/model/questions.go
@@ -14,7 +14,13 @@ type Question struct {
 	QuestionID  int32     `json:"questionid"`
 	Question    string    `json:"question"`
 	NotesPrompt string    `json:"notesprompt"`
-	Ordr        int       `json:"order"`
+	// Ordr is a pointer so a PUT that omits "order" leaves the stored rank
+	// alone instead of clobbering it to 0. Before migration 0056 populated
+	// these values the clobber was a harmless no-op; now it would silently
+	// destroy a question's canonical position in the questionnaire, the
+	// export, and the score diff (the CLAUDE.md optional-field rule - it
+	// applies to every optional column, not just bools).
+	Ordr        *int      `json:"order"`
 	PillarID    int       `json:"pillarid"`
 	Pillar      *Pillar   `json:"pillar,omitempty"`
 	Function    *Function `json:"function,omitempty"`
@@ -28,14 +34,18 @@ func (q *Question) Save(ctx context.Context) (*Question, error) {
 		sqlb = stmntBuilder.
 			Insert("questions").
 			Columns(questionsColumns[1:]...).
-			Values(q.Question, q.NotesPrompt, q.Ordr, q.PillarID).
+			Values(q.Question, q.NotesPrompt, derefInt(q.Ordr), q.PillarID).
 			Suffix("RETURNING " + strings.Join(questionsColumns, ", "))
 	} else {
-		sqlb = stmntBuilder.Update("questions").
+		ub := stmntBuilder.Update("questions").
 			Set("question", q.Question).
 			Set("notesprompt", q.NotesPrompt).
-			Set("ordr", q.Ordr).
-			Set("pillarid", q.PillarID).
+			Set("pillarid", q.PillarID)
+		// Only write ordr when the caller supplied it (see the field comment).
+		if q.Ordr != nil {
+			ub = ub.Set("ordr", *q.Ordr)
+		}
+		sqlb = ub.
 			Where("questionid=?", q.QuestionID).
 			Suffix("RETURNING " + strings.Join(questionsColumns, ", "))
 	}

--- a/backend/internal/model/questions.go
+++ b/backend/internal/model/questions.go
@@ -80,7 +80,10 @@ func FindQuestionsByFismaSystem(ctx context.Context, fismaSystemID int32) ([]*Qu
 		InnerJoin("functions ON functions.questionid=questions.questionid").
 		InnerJoin("datacenterenvironments dce ON dce.scoring_key=functions.datacenterenvironment").
 		InnerJoin("fismasystems ON fismasystems.datacenterenvironment=dce.datacenterenvironment AND fismasystems.fismasystemid=?", fismaSystemID).
-		OrderBy("pillars.ordr, questions.ordr ASC")
+		// questionid breaks ties so questions sharing an ordr (0 wherever
+		// migration 0056 found no canonical rank) still list deterministically
+		// rather than in heap order. See FindAnswers for the same tiebreaker.
+		OrderBy("pillars.ordr, questions.ordr, questions.questionid ASC")
 
 	return query(ctx, sqlb, func(row pgx.CollectableRow) (*Question, error) {
 		q := Question{

--- a/backend/internal/model/scorediff.go
+++ b/backend/internal/model/scorediff.go
@@ -122,6 +122,15 @@ func buildScoreDiffSQL(input FindScoreDiffInput) (string, []any) {
 	// only in spacing -- e.g. the FY23 two-spaces-after-a-period vintage vs
 	// FY24 single spaces -- is not reported as a change. Only the comparison is
 	// normalized; the stored notes are returned verbatim (see #409).
+	//
+	// Rows come back in questionnaire order. functions.ordr, the previous sort
+	// key, is 0 on every row in production, so the diff was effectively ordered
+	// by functionid - deterministic, but not the order a reviewer reads the
+	// questionnaire in. pillars is the only join this needed (questions was
+	// already here for the label), so ordering by pillars.ordr then
+	// questions.ordr - the ranks migration 0056 populates - costs one LEFT JOIN
+	// and matches FindAnswers and FindQuestionsByFismaSystem. functionid stays
+	// last as the tiebreaker for rows the migration could not rank.
 	sql := fmt.Sprintf(`
 WITH from_scores AS (%s),
      to_scores AS (%s)
@@ -139,6 +148,7 @@ FULL OUTER JOIN to_scores t
   ON f.fismasystemid = t.fismasystemid AND f.functionid = t.functionid
 LEFT JOIN functions fn ON fn.functionid = COALESCE(f.functionid, t.functionid)
 LEFT JOIN questions q  ON q.questionid  = fn.questionid
+LEFT JOIN pillars p    ON p.pillarid    = q.pillarid
 LEFT JOIN LATERAL (
     SELECT createdat, userid
     FROM events
@@ -153,7 +163,7 @@ WHERE f.functionoptionid IS DISTINCT FROM t.functionoptionid
       IS DISTINCT FROM
       btrim(regexp_replace(COALESCE(t.notes, ''), '\s+', ' ', 'g'))
    OR f.notes_is_ai_summary IS DISTINCT FROM t.notes_is_ai_summary
-ORDER BY fismasystemid, fn.ordr, functionid
+ORDER BY fismasystemid, p.ordr, q.ordr, fn.ordr, functionid
 `, fromCTE, toCTE)
 
 	return sql, args

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -687,6 +687,15 @@ func derefBool(b *bool) bool {
 	return *b
 }
 
+// derefInt mirrors derefBool for optional integer fields: nil means "not
+// supplied", which INSERTs as the zero default.
+func derefInt(n *int) int {
+	if n == nil {
+		return 0
+	}
+	return *n
+}
+
 // pillarScoreRow is the wire shape returned by findPillarScoresAll. One row
 // per (datacall, system, pillar). Both pillar Score and the carry-along
 // SystemScore are computed in Postgres and emerge on the HHS 1.0-5.0 scale,

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -601,6 +601,13 @@ components:
         notesprompt:
           type: string
         order:
+          description: |-
+            Ordr is a pointer so a PUT that omits "order" leaves the stored rank
+            alone instead of clobbering it to 0. Before migration 0056 populated
+            these values the clobber was a harmless no-op; now it would silently
+            destroy a question's canonical position in the questionnaire, the
+            export, and the score diff (the CLAUDE.md optional-field rule - it
+            applies to every optional column, not just bools).
           type: integer
         pillar:
           $ref: '#/components/schemas/model.Pillar'


### PR DESCRIPTION
Closes #531. Fixes the full ordering family from ztmf-misc#279 (with #276/#277/#278) and supersedes #535, whose index migration rides here.

## The problem, in one paragraph

Nothing in the database or the API ever specified the questionnaire's order. Answer choices had no ORDER BY at all, so they rendered in Postgres heap order — which matched maturity order for years by accident of insertion, until the Aug 2 description cleanup relocated the updated rows and scrambled the choices on ~50 visible questions across 7 editions, 32 minutes before the FY26 call opened. Question and pillar sequence had ORDER BYs pointing at `ordr` columns that have been zero since they were created, so the xlsx export and the score diff returned questions in plan-dependent order; only the questionnaire UI looked right, because the frontend re-sorts against its own hardcoded map.

## What this PR does

**Answer choices** (`FindFunctionOptions`): `ORDER BY score, functionoptionid` — the CISA ZTMM stage sequence (traditional, initial, advanced, optimal). The integration test reproduces the production trigger rather than trusting fixture luck: it UPDATEs an option's description (physically relocating the row) and asserts the order survives.

**Question and pillar sequence** (migration 0056): populates `pillars.ordr` (1-6, CISA pillar order) and `questions.ordr` (`pillar_rank*100 + function_index`) by transcribing the frontend's own `PILLAR_ORDER` / `PILLAR_FUNCTION_MAP` — the order the tool has rendered in production for years, so this is a lift-and-shift of an already-approved sequence, not an editorial decision. Guarded `WHERE ordr = 0`: the legacy Future Plan questions keep their 901-907 band, and the empire seed's fictional function names stay unranked (test databases fall to the tiebreaker; emberfall order is unchanged, verified 201/201). Verified against a prod copy before writing: 40/40 questions rank, zero name mismatches, zero duplicates.

**Deterministic tiebreakers**: `FindAnswers`, `FindQuestionsByFismaSystem`, and the score diff all gain `questionid` at the end of their ORDER BY, so order can never again depend on physical layout even where `ordr` ties. The score diff also gains the pillars join its ordering silently lacked — it ordered by `functions.ordr`, which is zero on all 432 rows.

**The export index** (migration 0055, from #535): `functionoptions(functionid)`. Measured on the prod-scale copy: whole-call export 47.7s → 2.0s (the LEFT JOIN's per-row subquery ran 1.55M sequential scans). Shipping it in the same PR as the choices ORDER BY is deliberate — the index flips that query's plan, which would have reshuffled the visible choice order a third time had they landed separately.

**Rider**: `RecordLogin`'s action literal converts to `eventActionCreated`, the one-line convergence #524 deferred to whichever change landed after it.

## Verified end to end on a current prod copy

- Answer choices: `traditional, initial, advanced, optimal` via the live API on the reported question, and confirmed rendered correctly in the UI
- Questions API: `Identity → Devices → Networks → Applications → Data → CrossCutting`, contiguous, exact map sequence within each pillar — from the raw API with no frontend sort
- Export xlsx: same sequence in the actual spreadsheet rows, 0.4s for a single-system export
- Score diff: a 40-row diff returns in exact questionnaire order
- Stored answers untouched throughout: answers key by `functionoptionid`, and ascending id agrees with ascending score on all 432 functions — presentation order only, no re-assessment needed

## Testing

- `make test-unit`, `make test-integration`, `make test-e2e` (201/201) all green
- Migration 0056 has its own integration test executing the registry SQL against fixture rows (the migration is deliberately a no-op on empire-seeded test databases, so fixture-based coverage is the honest kind)
- `make generate-openapi` — zero diff; response shapes unchanged, no emberfall edits needed

## Deploy notes

Two new migrations (0055, 0056). Marking this ready auto-deploys to DEV and puts `dbversions` at 56 while `main` is at 54 — any other PR's deploy in between crash-loops the lane. Ready it only when it can merge promptly. Local/test databases keep unranked `ordr` by design; dev/prod get the real ordering because their data carries the real function names.
