### PR TITLE
fix(#289): scope SaaS progress counts and exports to 25 questions

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -1086,7 +1086,7 @@ END $$;
 BEGIN;
 
 -- Clean re-run: remove only what this file owns (scores cascade via datacall)
-DELETE FROM public.datacalls WHERE datacallid IN (101, 102, 103);
+DELETE FROM public.datacalls WHERE datacallid IN (101, 102, 103, 104);
 DELETE FROM public.fismasystems WHERE fismaacronym LIKE 'MOCK-%';
 
 -- The 3 historical HHS data calls
@@ -1120,11 +1120,90 @@ INSERT INTO public.fismasystems (fismasystemid, fismauid, fismaacronym, fismanam
  (2014,'00AD27C9-28C2-449D-E190-83A5AD62DB06','MOCK-PRESSREL','Imperial Press Release Portal',NULL,NULL,NULL,NULL,'REBELLION','Imperial-Fleet',NULL,'mock.isso2014@example.empire',TRUE,(SELECT opdiv_id FROM public.opdivs WHERE LOWER(code)=LOWER('REBELLION')),'No','Moderate','Minor Standalone','YES',NULL,NULL,'Contractor','GOCO','Mock Officer 2014','mock.owner2014@example.empire',NULL,'Mock ISSO 2014'),
  (2015,'60246879-EA24-820C-6910-E501E6271733','MOCK-WASTE','Trash Compactor Maintenance Scheduler',NULL,NULL,NULL,NULL,'IMPNAVY','Imperial-Fleet',NULL,'mock.isso2015@example.empire',TRUE,(SELECT opdiv_id FROM public.opdivs WHERE LOWER(code)=LOWER('IMPNAVY')),'No','Moderate','Minor Standalone','No',NULL,NULL,'Agency','GOCO','Mock Officer 2015','mock.owner2015@example.empire',NULL,'Mock ISSO 2015');
 
+
+-- ---------------------------------------------------------------------------
+-- SaaS reduced-scope fixture (ztmf-misc#289)
+--
+-- The reduced scope keys on scoring_key = 'SaaS' AND an FY26-named cycle. The
+-- Imperial fixtures provide neither, so every behavioural test for it skipped in
+-- CI and only the SQL-shape assertions ran. This gives them something to execute
+-- against. The 'SaaS' mapping row itself comes from migration 0045, not here.
+--
+-- Deadline sits below the 2099 Audit cycle, so "latest by deadline" is unchanged
+-- for every other test. Only MOCK-SAAS maps to scoring_key 'SaaS', so no existing
+-- fixture changes behaviour.
+-- ---------------------------------------------------------------------------
+INSERT INTO public.datacalls (datacallid, datacall, datecreated, deadline) VALUES
+ (104,'FY26 ZTM','2025-10-01 00:00:00+00','2026-09-11 00:00:00+00')
+ON CONFLICT DO NOTHING;
+
+-- One SaaS function per pillar, derived rather than hardcoded: ids 7101-7106 sit
+-- above every explicit id in this file, and each function borrows an existing
+-- question in its pillar so the applicability join (which reads
+-- questions.pillarid, not functions.pillarid) resolves. Hardcoding catalogue ids
+-- here collided silently with the Ground-Assault set under ON CONFLICT DO NOTHING.
+INSERT INTO public.functions (functionid, function, description, datacenterenvironment, questionid, pillarid, ordr)
+SELECT 7100 + p.pillarid, 'SaaS ' || p.pillar, 'SaaS reduced-scope fixture', 'SaaS', q.questionid, p.pillarid, 0
+  FROM public.pillars p
+  CROSS JOIN LATERAL (
+      SELECT questionid FROM public.questions WHERE pillarid = p.pillarid ORDER BY questionid LIMIT 1
+  ) q
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.functionoptions (functionoptionid, functionid, score, optionname, description)
+SELECT 900 + (f.functionid - 7100) * 4 + s.score, f.functionid, s.score,
+       CASE s.score WHEN 1 THEN 'Traditional' ELSE 'Advanced' END,
+       'SaaS reduced-scope fixture option'
+  FROM public.functions f, (VALUES (1), (3)) AS s(score)
+ WHERE f.functionid BETWEEN 7101 AND 7106
+ON CONFLICT DO NOTHING;
+
+-- Active SaaS system. MOCK- prefix puts it under this file's existing cleanup.
+INSERT INTO public.fismasystems
+ (fismasystemid, fismauid, fismaacronym, fismaname, datacenterenvironment, issoemail,
+  sdl_sync_enabled, opdiv_id, isso_name)
+VALUES
+ (2016,'5A1A5000-0000-4000-8000-000000002016','MOCK-SAAS','Mock SaaS Reduced Scope System','SaaS',
+  'mock.isso2016@example.empire', TRUE,
+  (SELECT opdiv_id FROM public.opdivs WHERE UPPER(code) <> 'CMS' ORDER BY opdiv_id LIMIT 1),'Mock ISSO 2016'),
+ -- CMS counterpart: the reduced scope is understood to be an HHS-OpDiv rule with
+ -- CMS keeping all 40, but that is undecided, so both currently read 25. Without a
+ -- CMS SaaS system the subtest pinning that interim behaviour skips.
+ (2017,'5A1A5000-0000-4000-8000-000000002017','MOCK-SAAS-CMS','Mock CMS SaaS Reduced Scope System','SaaS',
+  'mock.isso2017@example.empire', TRUE,
+  (SELECT opdiv_id FROM public.opdivs WHERE UPPER(code) = 'CMS' LIMIT 1),'Mock ISSO 2017')
+ON CONFLICT DO NOTHING;
+
+-- Answers on EVERY pillar in both cycles, including the two the scope excludes.
+-- That is the load-bearing part: the FY26 rows make the carried-forward case real,
+-- so a scope applied to only one progress CTE, or to only one branch of the
+-- export's applicable-OR-answered join, produces wrong counts rather than
+-- identical ones. FY26 leaves the excluded pillars 'not_started', as a rollover
+-- would.
+INSERT INTO public.scores (fismasystemid, datacallid, functionoptionid, notes, status)
+SELECT sys.fismasystemid, 103, fo.functionoptionid, 'FY25 SaaS fixture answer', 'done'
+  FROM public.functionoptions fo, (VALUES (2016), (2017)) AS sys(fismasystemid)
+ WHERE fo.functionid BETWEEN 7101 AND 7106 AND fo.score = 1;
+
+INSERT INTO public.scores (fismasystemid, datacallid, functionoptionid, notes, status)
+SELECT sys.fismasystemid, 104, fo.functionoptionid, 'FY26 SaaS fixture answer',
+       CASE WHEN p.pillar IN ('Devices', 'Applications') THEN 'not_started' ELSE 'done' END
+  FROM public.functionoptions fo
+  CROSS JOIN (VALUES (2016), (2017)) AS sys(fismasystemid)
+  JOIN public.functions f ON f.functionid = fo.functionid
+  JOIN public.questions q ON q.questionid = f.questionid
+  JOIN public.pillars   p ON p.pillarid   = q.pillarid
+ WHERE f.functionid BETWEEN 7101 AND 7106 AND fo.score = 3;
+
 -- Keep the sequence ahead of our explicit ids
 SELECT setval(pg_get_serial_sequence('public.fismasystems','fismasystemid'),
               (SELECT MAX(fismasystemid) FROM public.fismasystems));
 SELECT setval(pg_get_serial_sequence('public.datacalls','datacallid'),
               (SELECT MAX(datacallid) FROM public.datacalls));
+SELECT setval(pg_get_serial_sequence('public.functions','functionid'),
+              (SELECT MAX(functionid) FROM public.functions));
+SELECT setval(pg_get_serial_sequence('public.functionoptions','functionoptionid'),
+              (SELECT MAX(functionoptionid) FROM public.functionoptions));
 
 -- FY23/24/25 ZTM scores: for the NEW systems AND the existing Empire systems.
 -- An existing system (e.g. the Death Star) now carries two series: its

--- a/backend/internal/model/answers.go
+++ b/backend/internal/model/answers.go
@@ -52,6 +52,19 @@ func FindAnswers(ctx context.Context, input FindAnswersInput) ([]*Answer, error)
 		LeftJoin("scores ON scores.fismasystemid=fismasystems.fismasystemid AND scores.datacallid=? AND scores.functionoptionid IN (SELECT selected.functionoptionid FROM functionoptions selected WHERE selected.functionid=functions.functionid)", input.DataCallID).
 		LeftJoin("functionoptions ON functionoptions.functionoptionid=scores.functionoptionid").
 		Where("(fismasystems.decommissioned=FALSE OR scores.scoreid IS NOT NULL)").
+		// Top-level WHERE, not a condition on the functions join: that join is
+		// applicable-OR-answered (#528), so filtering one branch would export 40
+		// rows for a system with carried-forward excluded answers and 25 for a
+		// fresh one. The scoring key needs a subquery because no dce alias is in
+		// scope here.
+		Where(
+			saasPillarScopeSQL(
+				"(SELECT dcescope.scoring_key FROM datacenterenvironments dcescope WHERE dcescope.datacenterenvironment=fismasystems.datacenterenvironment)",
+				"pillars.pillar",
+				"?",
+			),
+			input.DataCallID,
+		).
 		// questionid is the tiebreaker, not decoration: pillars.ordr and
 		// questions.ordr are 0 for any row migration 0056 could not rank (the
 		// empire seed's fictional function names), and rows tied on the sort key

--- a/backend/internal/model/answers_integration_test.go
+++ b/backend/internal/model/answers_integration_test.go
@@ -182,3 +182,114 @@ func TestFindAnswersIntegration(t *testing.T) {
 		t.Log("no decommissioned system with scores in seed; skipping the decommissioned-guard assertion")
 	}
 }
+
+// TestFindAnswersSaaSPillarScopeIntegration pins the export half of
+// ztmf-misc#289: 25 questions for SaaS from FY26 on, 40 on earlier cycles.
+//
+// Asserting that NO exported row carries an excluded pillar covers both branches
+// of the applicable-OR-answered join (#528) at once - filtering only one leaves
+// carried-forward systems exporting 40 while fresh ones export 25.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindAnswersSaaSPillarScopeIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+
+	fy26, prior, ok := fy26AndPriorDataCalls(ctx, t)
+	if !ok {
+		t.Skip("database has no FY26 call with an earlier cycle to compare against")
+	}
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// Every SaaS system, plus one carrying answers on an excluded pillar in FY26 -
+	// the case the OR branch would readmit.
+	saas := map[int32]bool{}
+	rows, err := conn.Query(ctx, `
+		SELECT fs.fismasystemid
+		FROM fismasystems fs
+		JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		WHERE dce.scoring_key = 'SaaS'`)
+	require.NoError(t, err)
+	for rows.Next() {
+		var id int32
+		require.NoError(t, rows.Scan(&id))
+		saas[id] = true
+	}
+	rows.Close()
+	if len(saas) == 0 {
+		t.Skip("database carries no SaaS systems")
+	}
+
+	var carriedForward int32
+	err = conn.QueryRow(ctx, `
+		SELECT s.fismasystemid
+		FROM scores s
+		JOIN functionoptions fo ON fo.functionoptionid = s.functionoptionid
+		JOIN functions f ON f.functionid = fo.functionid
+		JOIN questions q ON q.questionid = f.questionid
+		JOIN pillars p ON p.pillarid = q.pillarid
+		JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+		JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		WHERE s.datacallid = $1 AND dce.scoring_key = 'SaaS'
+		  AND p.pillar IN ('Devices', 'Applications')
+		LIMIT 1
+	`, fy26).Scan(&carriedForward)
+	haveCarried := err == nil
+
+	t.Run("FY26ExcludesTheReducedPillars", func(t *testing.T) {
+		answers, err := FindAnswers(ctx, FindAnswersInput{DataCallID: fy26})
+		require.NoError(t, err)
+		require.NotEmpty(t, answers)
+
+		seenSaaS := map[int32]bool{}
+		for _, a := range answers {
+			if !saas[a.FismaSystemID] {
+				continue
+			}
+			seenSaaS[a.FismaSystemID] = true
+			assert.NotContains(t, []string{"Devices", "Applications"}, a.Pillar,
+				"system %d exported an excluded pillar (%s) on the FY26 call", a.FismaSystemID, a.Pillar)
+		}
+		assert.NotEmpty(t, seenSaaS, "SaaS systems must still appear in the export, just with fewer questions")
+
+		if haveCarried {
+			assert.True(t, seenSaaS[carriedForward],
+				"the system with carried-forward excluded answers must still export its in-scope questions")
+		}
+	})
+
+	t.Run("PriorCycleStillExportsEveryPillar", func(t *testing.T) {
+		answers, err := FindAnswers(ctx, FindAnswersInput{DataCallID: prior})
+		require.NoError(t, err)
+
+		excluded := 0
+		for _, a := range answers {
+			if saas[a.FismaSystemID] && (a.Pillar == "Devices" || a.Pillar == "Applications") {
+				excluded++
+			}
+		}
+		assert.Greater(t, excluded, 0,
+			"cycles earlier than FY26 collected the full set and must keep exporting it")
+	})
+
+	t.Run("NonSaaSSystemsAreUntouchedOnFY26", func(t *testing.T) {
+		answers, err := FindAnswers(ctx, FindAnswersInput{DataCallID: fy26})
+		require.NoError(t, err)
+
+		excluded := 0
+		for _, a := range answers {
+			if !saas[a.FismaSystemID] && (a.Pillar == "Devices" || a.Pillar == "Applications") {
+				excluded++
+			}
+		}
+		assert.Greater(t, excluded, 0,
+			"the scope is SaaS-only; other environments still export both pillars")
+	})
+}

--- a/backend/internal/model/answers_integration_test.go
+++ b/backend/internal/model/answers_integration_test.go
@@ -259,6 +259,32 @@ func TestFindAnswersSaaSPillarScopeIntegration(t *testing.T) {
 		}
 		assert.NotEmpty(t, seenSaaS, "SaaS systems must still appear in the export, just with fewer questions")
 
+		// Row counts per system are not a useful assertion: the #528
+		// applicable-or-answered join legitimately doubles them for a system
+		// carrying answers from another edition. The surviving pillar SET is, and
+		// it also catches over-pruning inside the in-scope pillars.
+		var inScope, expectedInScope int
+		err = conn.QueryRow(ctx, `
+			SELECT COUNT(DISTINCT p.pillar)
+			FROM pillars p
+			WHERE p.pillar NOT IN ('Devices', 'Applications')
+			  AND EXISTS (
+			      SELECT 1 FROM questions q
+			      JOIN functions f ON f.questionid = q.questionid
+			      WHERE q.pillarid = p.pillarid AND f.datacenterenvironment = 'SaaS')
+		`).Scan(&expectedInScope)
+		require.NoError(t, err)
+
+		pillars := map[string]bool{}
+		for _, a := range answers {
+			if saas[a.FismaSystemID] {
+				pillars[a.Pillar] = true
+			}
+		}
+		inScope = len(pillars)
+		assert.Equal(t, expectedInScope, inScope,
+			"every in-scope pillar must still be exported, not just the excluded ones dropped")
+
 		if haveCarried {
 			assert.True(t, seenSaaS[carriedForward],
 				"the system with carried-forward excluded answers must still export its in-scope questions")

--- a/backend/internal/model/pillarscope.go
+++ b/backend/internal/model/pillarscope.go
@@ -5,6 +5,16 @@ import (
 	"strings"
 )
 
+// reducedPillarScopeCyclePrefixes identifies the cycle the reduced scope starts
+// at. Owned here rather than borrowed from rolloverHardcodeTargetPrefixes: that
+// slice sits inside the TEMPORARY HARD-CODE block ztmf#502 is queued to delete,
+// and depending on it from outside would have blocked that removal.
+//
+// INTERIM, and not a pattern to copy: matching a cycle by name is a stand-in for
+// data. ztmf#545 replaces this with a seeded rule carrying the effective data
+// call, at which point this variable and the name matching below both come out.
+var reducedPillarScopeCyclePrefixes = []string{"FY2026", "FY26"}
+
 // saasPillarScopeSQL excludes the Devices and Applications pillars for SaaS
 // systems from the FY26 cycle onward (ztmf-misc#289). Shared by the progress
 // counts and the export so they cannot disagree.
@@ -18,22 +28,21 @@ import (
 // A cycle is in scope when it is named FY26 or its deadline falls after every FY26
 // cycle. Deliberately not "deadline >= the earliest FY26 deadline": an FY26 call
 // mis-dated before a closed cycle would drag that closed cycle into scope and
-// restate it. Names are matched the way matchesRolloverHardcodeTarget does
-// (trimmed, upper) so the two agree on which cycle is FY26.
+// restate it. Names are trimmed and uppercased before matching.
 //
 // Not scoped by OpDiv yet: CMS is expected to keep all 40, but the frontend filter
 // is OpDiv-blind, so exempting CMS here alone would leave those systems unable to
 // answer the 15 questions a 40 denominator demands. When confirmed, add alongside
 // the frontend change:
 //
-//	AND EXISTS (SELECT 1 FROM opdivs o WHERE o.opdiv_id = <system>.opdiv_id AND UPPER(o.code) <> rolloverHardcodeCMSOpDiv)
+//	AND EXISTS (SELECT 1 FROM opdivs o WHERE o.opdiv_id = <system>.opdiv_id AND UPPER(o.code) <> 'CMS')
 //
 // Arguments are SQL expressions valid in the caller's scope. dataCallExpr is the
 // placeholder for the call being read ("$3" hand-built, "?" via squirrel).
 func saasPillarScopeSQL(scoringKeyExpr, pillarExpr, dataCallExpr string) string {
 	prefixCond := func(alias string) string {
-		conds := make([]string, len(rolloverHardcodeTargetPrefixes))
-		for i, prefix := range rolloverHardcodeTargetPrefixes {
+		conds := make([]string, len(reducedPillarScopeCyclePrefixes))
+		for i, prefix := range reducedPillarScopeCyclePrefixes {
 			conds[i] = fmt.Sprintf("UPPER(TRIM(%s.datacall)) LIKE '%s%%'", alias, prefix)
 		}
 		return strings.Join(conds, " OR ")

--- a/backend/internal/model/pillarscope.go
+++ b/backend/internal/model/pillarscope.go
@@ -9,35 +9,54 @@ import (
 // systems from the FY26 cycle onward (ztmf-misc#289). Shared by the progress
 // counts and the export so they cannot disagree.
 //
-// Anchored on deadline, not datacallid: ids are not chronological, so a backfill
-// loaded later must still read as history. EXISTS rather than a bare comparison
-// because callers place this in a JOIN ... ON, where NULL drops the row - a
-// database with no FY26 call has to fall back to the full 40.
+// COALESCE on the scoring key is load-bearing: it is nullable (DECOMMISSIONED
+// maps to NULL), and NOT(NULL AND ...) is NULL, which a top-level WHERE treats as
+// false - silently dropping an excluded-pillar row for a non-SaaS system. Every
+// condition must resolve to true or false, never NULL, because callers put this in
+// both a WHERE and a JOIN ... ON.
 //
-// Not scoped by OpDiv yet: CMS is expected to keep all 40, but the frontend
-// filter is OpDiv-blind, so exempting CMS here alone would leave those systems
-// unable to answer the 15 questions a 40 denominator demands. When confirmed, add
-// alongside the frontend change:
+// A cycle is in scope when it is named FY26 or its deadline falls after every FY26
+// cycle. Deliberately not "deadline >= the earliest FY26 deadline": an FY26 call
+// mis-dated before a closed cycle would drag that closed cycle into scope and
+// restate it. Names are matched the way matchesRolloverHardcodeTarget does
+// (trimmed, upper) so the two agree on which cycle is FY26.
+//
+// Not scoped by OpDiv yet: CMS is expected to keep all 40, but the frontend filter
+// is OpDiv-blind, so exempting CMS here alone would leave those systems unable to
+// answer the 15 questions a 40 denominator demands. When confirmed, add alongside
+// the frontend change:
 //
 //	AND EXISTS (SELECT 1 FROM opdivs o WHERE o.opdiv_id = <system>.opdiv_id AND UPPER(o.code) <> rolloverHardcodeCMSOpDiv)
 //
 // Arguments are SQL expressions valid in the caller's scope. dataCallExpr is the
 // placeholder for the call being read ("$3" hand-built, "?" via squirrel).
 func saasPillarScopeSQL(scoringKeyExpr, pillarExpr, dataCallExpr string) string {
-	prefixConds := make([]string, len(rolloverHardcodeTargetPrefixes))
-	for i, prefix := range rolloverHardcodeTargetPrefixes {
-		prefixConds[i] = fmt.Sprintf("UPPER(fdc.datacall) LIKE '%s%%'", prefix)
+	prefixCond := func(alias string) string {
+		conds := make([]string, len(rolloverHardcodeTargetPrefixes))
+		for i, prefix := range rolloverHardcodeTargetPrefixes {
+			conds[i] = fmt.Sprintf("UPPER(TRIM(%s.datacall)) LIKE '%s%%'", alias, prefix)
+		}
+		return strings.Join(conds, " OR ")
 	}
 
 	return fmt.Sprintf(`NOT (
-          %s = 'SaaS'
+          COALESCE(%s, '') = 'SaaS'
           AND %s IN ('Devices', 'Applications')
           AND EXISTS (
               SELECT 1 FROM datacalls tdc
               WHERE tdc.datacallid = %s
-                AND tdc.deadline >= (
-                    SELECT MIN(fdc.deadline) FROM datacalls fdc WHERE %s
+                AND (
+                    (%s)
+                    OR tdc.deadline > (
+                        SELECT MAX(fdc.deadline) FROM datacalls fdc WHERE %s
+                    )
                 )
           )
-      )`, scoringKeyExpr, pillarExpr, dataCallExpr, strings.Join(prefixConds, " OR "))
+      )`,
+		scoringKeyExpr,
+		pillarExpr,
+		dataCallExpr,
+		prefixCond("tdc"),
+		prefixCond("fdc"),
+	)
 }

--- a/backend/internal/model/pillarscope.go
+++ b/backend/internal/model/pillarscope.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+// saasPillarScopeSQL excludes the Devices and Applications pillars for SaaS
+// systems from the FY26 cycle onward (ztmf-misc#289). Shared by the progress
+// counts and the export so they cannot disagree.
+//
+// Anchored on deadline, not datacallid: ids are not chronological, so a backfill
+// loaded later must still read as history. EXISTS rather than a bare comparison
+// because callers place this in a JOIN ... ON, where NULL drops the row - a
+// database with no FY26 call has to fall back to the full 40.
+//
+// Not scoped by OpDiv yet: CMS is expected to keep all 40, but the frontend
+// filter is OpDiv-blind, so exempting CMS here alone would leave those systems
+// unable to answer the 15 questions a 40 denominator demands. When confirmed, add
+// alongside the frontend change:
+//
+//	AND EXISTS (SELECT 1 FROM opdivs o WHERE o.opdiv_id = <system>.opdiv_id AND UPPER(o.code) <> rolloverHardcodeCMSOpDiv)
+//
+// Arguments are SQL expressions valid in the caller's scope. dataCallExpr is the
+// placeholder for the call being read ("$3" hand-built, "?" via squirrel).
+func saasPillarScopeSQL(scoringKeyExpr, pillarExpr, dataCallExpr string) string {
+	prefixConds := make([]string, len(rolloverHardcodeTargetPrefixes))
+	for i, prefix := range rolloverHardcodeTargetPrefixes {
+		prefixConds[i] = fmt.Sprintf("UPPER(fdc.datacall) LIKE '%s%%'", prefix)
+	}
+
+	return fmt.Sprintf(`NOT (
+          %s = 'SaaS'
+          AND %s IN ('Devices', 'Applications')
+          AND EXISTS (
+              SELECT 1 FROM datacalls tdc
+              WHERE tdc.datacallid = %s
+                AND tdc.deadline >= (
+                    SELECT MIN(fdc.deadline) FROM datacalls fdc WHERE %s
+                )
+          )
+      )`, scoringKeyExpr, pillarExpr, dataCallExpr, strings.Join(prefixConds, " OR "))
+}

--- a/backend/internal/model/pillarscope_integration_test.go
+++ b/backend/internal/model/pillarscope_integration_test.go
@@ -1,0 +1,76 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaaSPillarScopeNullSafetyIntegration evaluates the predicate in real
+// Postgres, because its correctness rests on three-valued logic that no
+// string assertion can pin: a NULL scoring key must yield FALSE (row kept), not
+// NULL, which a top-level WHERE would read as "drop".
+//
+// The regression this guards: scoring_key is nullable (DECOMMISSIONED maps to
+// NULL) and FindAnswers deliberately still exports decommissioned systems that
+// carry scores, so a NULL key used to silently remove 15 Devices/Applications
+// rows from a compliance export - on a non-SaaS system.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestSaaSPillarScopeNullSafetyIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+
+	fy26, prior, ok := fy26AndPriorDataCalls(ctx, t)
+	if !ok {
+		t.Skip("database has no FY26 call with an earlier cycle to compare against")
+	}
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// kept == true means the row survives, i.e. the full 40.
+	kept := func(t *testing.T, scoringKeyExpr, pillarExpr string, dataCallID int32) bool {
+		t.Helper()
+		var result *bool
+		require.NoError(t, conn.QueryRow(ctx,
+			`SELECT `+saasPillarScopeSQL(scoringKeyExpr, pillarExpr, "$1"), dataCallID,
+		).Scan(&result))
+		require.NotNil(t, result, "the predicate must never evaluate to NULL: a WHERE would drop the row and a JOIN ... ON would too")
+		return *result
+	}
+
+	t.Run("NullScoringKeyKeepsEveryPillar", func(t *testing.T) {
+		assert.True(t, kept(t, "NULL::varchar", "'Devices'", fy26),
+			"a system with no scoring key is not SaaS and must keep Devices")
+		assert.True(t, kept(t, "NULL::varchar", "'Applications'", fy26),
+			"a system with no scoring key is not SaaS and must keep Applications")
+	})
+
+	t.Run("SaaSDropsOnlyTheExcludedPillars", func(t *testing.T) {
+		assert.False(t, kept(t, "'SaaS'", "'Devices'", fy26))
+		assert.False(t, kept(t, "'SaaS'", "'Applications'", fy26))
+		assert.True(t, kept(t, "'SaaS'", "'Identity'", fy26))
+		assert.True(t, kept(t, "'SaaS'", "'CrossCutting'", fy26))
+	})
+
+	t.Run("OtherEnvironmentsAndPriorCyclesKeepEverything", func(t *testing.T) {
+		assert.True(t, kept(t, "'AWS'", "'Devices'", fy26),
+			"the scope is SaaS-only")
+		assert.True(t, kept(t, "'SaaS'", "'Devices'", prior),
+			"cycles earlier than FY26 keep the full question set")
+	})
+
+	t.Run("UnknownDataCallFallsBackToTheFullSet", func(t *testing.T) {
+		assert.True(t, kept(t, "'SaaS'", "'Devices'", -1),
+			"an unresolvable cycle must fail open to 40, never NULL")
+	})
+}

--- a/backend/internal/model/pillarscope_test.go
+++ b/backend/internal/model/pillarscope_test.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSaaSPillarScopeSQL_Shape(t *testing.T) {
+	sql := saasPillarScopeSQL("dce.scoring_key", "p.pillar", "$3")
+
+	// A nullable scoring key must not make the whole predicate NULL: a top-level
+	// WHERE reads NULL as false and would drop an excluded-pillar row for a
+	// non-SaaS system (DECOMMISSIONED maps to scoring_key NULL).
+	assert.Contains(t, sql, "COALESCE(dce.scoring_key, '') = 'SaaS'",
+		"the scoring key is nullable, so the comparison must be NULL-safe")
+
+	// In scope when named FY26 or dated after every FY26 cycle - never "at or
+	// after the earliest FY26 deadline", which a mis-dated FY26 call would use to
+	// drag a closed cycle into scope.
+	assert.Contains(t, sql, "SELECT MAX(fdc.deadline) FROM datacalls fdc",
+		"the cycle gate anchors on the LAST FY26 deadline")
+	assert.NotContains(t, sql, "MIN(fdc.deadline)",
+		"an earliest-deadline anchor would restate closed cycles")
+	assert.Contains(t, sql, "tdc.deadline >", "later cycles are in scope by deadline")
+
+	// Names are matched the way matchesRolloverHardcodeTarget does.
+	assert.Equal(t, 2, strings.Count(sql, "UPPER(TRIM(tdc.datacall)) LIKE 'FY2026%'")+
+		strings.Count(sql, "UPPER(TRIM(fdc.datacall)) LIKE 'FY2026%'"),
+		"both the target and the anchor must trim and upper the name")
+
+	// EXISTS, so a database with no FY26 cycle yields false rather than NULL.
+	assert.Contains(t, sql, "EXISTS (")
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(sql), "NOT ("),
+		"callers append this after AND, so it must be a single parenthesized term")
+}
+
+func TestSaaSPillarScopeSQL_UsesCallerExpressions(t *testing.T) {
+	sql := saasPillarScopeSQL("(SELECT x FROM y)", "pillars.pillar", "?")
+
+	assert.Contains(t, sql, "COALESCE((SELECT x FROM y), '') = 'SaaS'")
+	assert.Contains(t, sql, "pillars.pillar IN ('Devices', 'Applications')")
+	assert.Contains(t, sql, "tdc.datacallid = ?")
+	assert.NotContains(t, sql, "dce.scoring_key",
+		"no alias may be hardcoded; the export has no dce in scope")
+}

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -185,7 +185,7 @@ func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
 
 	sql := fmt.Sprintf(`
 WITH scoped_systems AS (
-    SELECT fs.fismasystemid, fs.datacenterenvironment, fs.opdiv_id
+    SELECT fs.fismasystemid, fs.datacenterenvironment
     FROM fismasystems fs
     WHERE %s
 ),

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -177,9 +177,15 @@ func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
 	// applicable after an environment change (that answer simply fails the
 	// applicability join). COUNT(DISTINCT) on all guards against fan-out from
 	// the environment mapping.
+	//
+	// The SaaS pillar scope belongs to that shared set, so it is rendered once and
+	// interpolated into BOTH CTEs. In expected's alone it would leave a numerator
+	// of 40 against a denominator of 25, reporting a false "Complete".
+	pillarScope := saasPillarScopeSQL("dce.scoring_key", "p.pillar", fmt.Sprintf("$%d", dataCallArg))
+
 	sql := fmt.Sprintf(`
 WITH scoped_systems AS (
-    SELECT fs.fismasystemid, fs.datacenterenvironment
+    SELECT fs.fismasystemid, fs.datacenterenvironment, fs.opdiv_id
     FROM fismasystems fs
     WHERE %s
 ),
@@ -190,6 +196,7 @@ expected AS (
     INNER JOIN functions f ON f.datacenterenvironment = dce.scoring_key
     INNER JOIN questions q ON q.questionid = f.questionid
     INNER JOIN pillars p ON p.pillarid = q.pillarid
+      AND %s
     GROUP BY ss.fismasystemid
 ),
 updated AS (
@@ -211,6 +218,8 @@ updated AS (
                                          AND dce.scoring_key = f.datacenterenvironment
     INNER JOIN questions q ON q.questionid = f.questionid
     INNER JOIN pillars p ON p.pillarid = q.pillarid
+      -- Identical to expected's; see the note above the query.
+      AND %s
     -- One newest in-app edit per score row (LIMIT 1 keeps the lateral on the
     -- index fast path); the outer MAX then picks the newest across the
     -- system's rows. LEFT now (not the old filtering INNER): it feeds only
@@ -240,7 +249,7 @@ FROM scoped_systems ss
 LEFT JOIN expected ex ON ex.fismasystemid = ss.fismasystemid
 LEFT JOIN updated u ON u.fismasystemid = ss.fismasystemid
 ORDER BY ss.fismasystemid
-`, strings.Join(conds, " AND "), dataCallArg)
+`, strings.Join(conds, " AND "), pillarScope, dataCallArg, pillarScope)
 
 	return sql, args
 }

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -635,10 +635,13 @@ func TestFindScoreProgressSaaSScopeIntegration(t *testing.T) {
 
 		assert.Equal(t, inScope, rows[0].QuestionsExpected,
 			"the FY26 denominator must drop the %d Devices/Applications functions", outOfScope)
+		// answered is the assertion that catches an unfiltered updated CTE: it
+		// counts carried-forward rows, which are status = 'not_started' and so
+		// invisible to questionsupdated.
 		assert.LessOrEqual(t, rows[0].QuestionsAnswered, rows[0].QuestionsExpected,
-			"answered draws from the same scoped set")
-		assert.LessOrEqual(t, rows[0].QuestionsUpdated, rows[0].QuestionsExpected,
 			"fails if only the expected CTE were filtered")
+		assert.LessOrEqual(t, rows[0].QuestionsUpdated, rows[0].QuestionsExpected,
+			"updated draws from the same scoped set")
 	})
 
 	t.Run("NonCMSUnchangedOnPriorCycle", func(t *testing.T) {

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -535,3 +535,145 @@ func TestScoreProgressLastUpdatedIgnoresImportedEventsIntegration(t *testing.T) 
 	}
 	assert.Equal(t, len(importedOnly), checked, "every imported-only system must appear in the progress result")
 }
+
+// saasScopeFixture finds a live SaaS system in (or outside) the CMS OpDiv with
+// its in-scope and out-of-scope function counts. ok=false when the database has
+// no SaaS function set, so callers skip - the empire seed has none.
+func saasScopeFixture(ctx context.Context, t *testing.T, cms bool) (systemID, inScope, outOfScope int32, ok bool) {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	cmsCmp := "<>"
+	if cms {
+		cmsCmp = "="
+	}
+
+	err = conn.QueryRow(ctx, fmt.Sprintf(`
+		SELECT fs.fismasystemid,
+		       COUNT(DISTINCT f.functionid) FILTER (
+		           WHERE p.pillar NOT IN ('Devices', 'Applications')),
+		       COUNT(DISTINCT f.functionid) FILTER (
+		           WHERE p.pillar IN ('Devices', 'Applications'))
+		FROM fismasystems fs
+		INNER JOIN opdivs o ON o.opdiv_id = fs.opdiv_id AND UPPER(o.code) %s 'CMS'
+		INNER JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+		INNER JOIN functions f ON f.datacenterenvironment = dce.scoring_key
+		INNER JOIN questions q ON q.questionid = f.questionid
+		INNER JOIN pillars p ON p.pillarid = q.pillarid
+		WHERE fs.decommissioned = FALSE AND dce.scoring_key = 'SaaS'
+		GROUP BY fs.fismasystemid
+		HAVING COUNT(DISTINCT f.functionid) FILTER (
+		           WHERE p.pillar IN ('Devices', 'Applications')) > 0
+		LIMIT 1
+	`, cmsCmp)).Scan(&systemID, &inScope, &outOfScope)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	return systemID, inScope, outOfScope, true
+}
+
+// fy26AndPriorDataCalls returns the earliest FY26-prefixed call (where the
+// reduced scope starts) and one with a strictly earlier deadline.
+func fy26AndPriorDataCalls(ctx context.Context, t *testing.T) (fy26, prior int32, ok bool) {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	var fy26Deadline time.Time
+	err = conn.QueryRow(ctx, `
+		SELECT datacallid, deadline FROM datacalls
+		 WHERE UPPER(datacall) LIKE 'FY2026%' OR UPPER(datacall) LIKE 'FY26%'
+		 ORDER BY deadline ASC, datacallid ASC LIMIT 1
+	`).Scan(&fy26, &fy26Deadline)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	err = conn.QueryRow(ctx, `
+		SELECT datacallid FROM datacalls WHERE deadline < $1 ORDER BY deadline DESC LIMIT 1
+	`, fy26Deadline).Scan(&prior)
+	if err != nil {
+		return fy26, 0, false
+	}
+	return fy26, prior, true
+}
+
+// TestFindScoreProgressSaaSScopeIntegration pins the SaaS scope (ztmf-misc#289)
+// against real data: reduced on the FY26 cycle, full on earlier ones. Expected
+// counts come from a control query, so the test pins the rule rather than today's
+// catalogue size.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindScoreProgressSaaSScopeIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+
+	fy26, prior, haveCalls := fy26AndPriorDataCalls(ctx, t)
+	if !haveCalls {
+		t.Skip("database has no FY26 call with an earlier cycle to compare against")
+	}
+
+	t.Run("NonCMSReducedOnCurrentCycle", func(t *testing.T) {
+		systemID, inScope, outOfScope, ok := saasScopeFixture(ctx, t, false)
+		if !ok {
+			t.Skip("no non-CMS SaaS system with Devices/Applications functions")
+		}
+
+		rows, err := FindScoreProgress(ctx, FindScoreProgressInput{
+			DataCallID:    &fy26,
+			FismaSystemID: &systemID,
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+
+		assert.Equal(t, inScope, rows[0].QuestionsExpected,
+			"the FY26 denominator must drop the %d Devices/Applications functions", outOfScope)
+		assert.LessOrEqual(t, rows[0].QuestionsAnswered, rows[0].QuestionsExpected,
+			"answered draws from the same scoped set")
+		assert.LessOrEqual(t, rows[0].QuestionsUpdated, rows[0].QuestionsExpected,
+			"fails if only the expected CTE were filtered")
+	})
+
+	t.Run("NonCMSUnchangedOnPriorCycle", func(t *testing.T) {
+		systemID, inScope, outOfScope, ok := saasScopeFixture(ctx, t, false)
+		if !ok {
+			t.Skip("no non-CMS SaaS system with Devices/Applications functions")
+		}
+
+		rows, err := FindScoreProgress(ctx, FindScoreProgressInput{
+			DataCallID:    &prior,
+			FismaSystemID: &systemID,
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+
+		assert.Equal(t, inScope+outOfScope, rows[0].QuestionsExpected,
+			"a cycle earlier than FY26 must keep reporting against the full question set")
+	})
+
+	// CMS is not exempt yet (see saasPillarScopeSQL). Pinned so re-adding the
+	// OpDiv gate has to change a test rather than silently flip 11 systems.
+	t.Run("CMSAlsoReducedWhileExemptionIsUndecided", func(t *testing.T) {
+		systemID, inScope, _, ok := saasScopeFixture(ctx, t, true)
+		if !ok {
+			t.Skip("no CMS SaaS system with Devices/Applications functions")
+		}
+
+		rows, err := FindScoreProgress(ctx, FindScoreProgressInput{
+			DataCallID:    &fy26,
+			FismaSystemID: &systemID,
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+
+		assert.Equal(t, inScope, rows[0].QuestionsExpected,
+			"until CMS confirms, its denominator matches what the OpDiv-blind frontend asks")
+	})
+}

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -76,9 +76,9 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	// would face a numerator of 40, reporting a false "Complete" on a closed call.
 	assert.Equal(t, 2, strings.Count(sql, "p.pillar IN ('Devices', 'Applications')"),
 		"the SaaS pillar scope (ztmf-misc#289) must appear in both the expected and updated CTEs")
-	assert.Equal(t, 2, strings.Count(sql, "SELECT MIN(fdc.deadline) FROM datacalls fdc"),
+	assert.Equal(t, 2, strings.Count(sql, "SELECT MAX(fdc.deadline) FROM datacalls fdc"),
 		"the scope applies from FY26 onward only; closed cycles keep reporting against 40")
-	assert.Equal(t, 2, strings.Count(sql, "UPPER(fdc.datacall) LIKE 'FY2026%' OR UPPER(fdc.datacall) LIKE 'FY26%'"),
+	assert.Equal(t, 2, strings.Count(sql, "UPPER(TRIM(fdc.datacall)) LIKE 'FY2026%'"),
 		"the FY26 anchor must come from rolloverHardcodeTargetPrefixes")
 	assert.NotContains(t, sql, "tdc.datacallid >=",
 		"the cycle comparison must be on deadline, not datacallid - ids are not chronological")

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -79,7 +79,7 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	assert.Equal(t, 2, strings.Count(sql, "SELECT MAX(fdc.deadline) FROM datacalls fdc"),
 		"the scope applies from FY26 onward only; closed cycles keep reporting against 40")
 	assert.Equal(t, 2, strings.Count(sql, "UPPER(TRIM(fdc.datacall)) LIKE 'FY2026%'"),
-		"the FY26 anchor must come from rolloverHardcodeTargetPrefixes")
+		"the FY26 anchor must come from reducedPillarScopeCyclePrefixes, not the ztmf#502 rollover block")
 	assert.NotContains(t, sql, "tdc.datacallid >=",
 		"the cycle comparison must be on deadline, not datacallid - ids are not chronological")
 

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -45,6 +45,7 @@ func TestFindScoreProgressInputValidate(t *testing.T) {
 //     (status = 'done'), excluding pre-populated rows, rather than requiring
 //     an edit event; the events lateral is now LEFT and feeds only
 //     lastupdatedat;
+//   - the SaaS pillar scope appears in both halves, never one;
 //   - both halves LEFT JOIN back onto scoped_systems so a zero-activity or
 //     unmapped-environment system still returns a row (0 of N).
 func TestBuildScoreProgressSQL_Shape(t *testing.T) {
@@ -71,7 +72,18 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 	assert.Contains(t, sql, "COALESCE(u.questionsupdated, 0)", "zero-activity systems report 0 updated, not NULL")
 	assert.Contains(t, sql, "COALESCE(ex.questionsexpected, 0)", "unmapped-environment systems report 0 expected, not NULL")
 
-	// No scope filters: the single arg is the data call id.
+	// Both count halves, never one: in expected's alone a SaaS denominator of 25
+	// would face a numerator of 40, reporting a false "Complete" on a closed call.
+	assert.Equal(t, 2, strings.Count(sql, "p.pillar IN ('Devices', 'Applications')"),
+		"the SaaS pillar scope (ztmf-misc#289) must appear in both the expected and updated CTEs")
+	assert.Equal(t, 2, strings.Count(sql, "SELECT MIN(fdc.deadline) FROM datacalls fdc"),
+		"the scope applies from FY26 onward only; closed cycles keep reporting against 40")
+	assert.Equal(t, 2, strings.Count(sql, "UPPER(fdc.datacall) LIKE 'FY2026%' OR UPPER(fdc.datacall) LIKE 'FY26%'"),
+		"the FY26 anchor must come from rolloverHardcodeTargetPrefixes")
+	assert.NotContains(t, sql, "tdc.datacallid >=",
+		"the cycle comparison must be on deadline, not datacallid - ids are not chronological")
+
+	// The pillar scope adds no bind parameters.
 	assert.Equal(t, []any{int32(4)}, args)
 }
 


### PR DESCRIPTION
Part of CMS-Enterprise/ztmf-misc#289 — phase 1 of 2. **Deploy before ztmf-ui#690.**

## Problem

Devices and Applications do not apply to a SaaS-hosted system, so the consumer answers 25 questions, not 40. That is program-approved, but it was enforced only in the frontend (ztmf-ui#430) — every backend query still resolved 40. So the dashboard showed a permanent `25/40` that could never reach Complete (the chip is gated on `answered >= expected`, and the other 15 questions are unreachable in the UI), those systems stayed ranked as laggards by `progressSortValue` and matched the "Not updated" facet, and the export returned 15 questions nobody was asked.

## Approach

One predicate, `saasPillarScopeSQL` (`internal/model/pillarscope.go`), applied to **both** `buildScoreProgressSQL` CTEs and to `FindAnswers` as a top-level `WHERE`.

In scope from the FY26 cycle onward only: a cycle qualifies when it is named FY26 or its deadline falls after every FY26 cycle. Anchored on deadline, not `datacallid`, because ids are not chronological — `findPreviousDataCall` documents the same trap. Closed cycles were collected and reported against 40 and keep reading 40.

Three details are load-bearing rather than stylistic:

- **Both progress CTEs.** In `expected` alone, a denominator of 25 would face a numerator of 40 from carried-forward answers — breaking the documented answered-cannot-exceed-expected invariant and reporting a false "Complete" on a closed call.
- **Top-level `WHERE` in the export.** That functions join is applicable-OR-answered (#528), so filtering one branch would export 40 rows for a system whose excluded answers were carried forward and 25 for a freshly created one.
- **`COALESCE` on the scoring key.** It is nullable (`DECOMMISSIONED` maps to NULL) and `NOT(NULL AND …)` is NULL, which a `WHERE` reads as false. Without it, a decommissioned system carrying FY26 answers — which `FindAnswers` deliberately still exports — silently lost 15 rows, on a **non-SaaS** system.

**Scoring (`scores.go`) and the questionnaire endpoint (`questions.go`) are untouched, so no score moves.** Those, plus seeding the rule as data instead of a literal, are #545 — the issue's remaining two acceptance criteria (SaaS presenting exactly 25 questions from the API, and not being scored for the excluded pillars) belong to that PR, not this one. No rows are deleted here either: the retained answers stay in the database and stop counting.

## Acceptance criteria

- [x] Progress/completion calculates against 25 for SaaS systems — 25 for every SaaS system on FY2026, with the numerators drawn from the same set so `answered`/`updated` can never exceed it. A fully-answered closed call now reaches Complete instead of a permanent 25/40.
- [x] All other environments unchanged (40) — every other environment value, and non-SaaS export row counts byte-identical.
- [x] Closed historical calls unchanged — FY25 ZTM and FY2025 Q3 report 40 and export identical counts. The gate anchors on the *last* FY26 deadline rather than the first precisely so a mis-dated FY26 call cannot restate a closed cycle.
- [x] The export returns only the in-scope questions for FY26 onward (post-issue decision from Mack/Allie). See the row-count note below.

## Testing

- `make test-unit` — pass. `make test-integration` — pass.
- Against a production-shaped database: on FY2026 every SaaS system reports 25 and every other environment 40; on FY25 ZTM and FY2025 Q3 every system still reports 40; **no** row on any cycle has `answered`/`updated` exceeding `expected`; the FY2026 export drop matches the excluded-pillar count exactly, per system, with prior-cycle counts byte-identical; `/scores/aggregate` output unchanged.
- New: `pillarscope_test.go`; `pillarscope_integration_test.go`, which evaluates the predicate in Postgres because its correctness rests on three-valued logic no string assertion can pin — verified to fail when the `COALESCE` is removed; progress and export integration subtests covering the carried-forward case, a prior cycle, and a non-SaaS control.
- `EXPLAIN ANALYZE`: the `MAX(deadline)` and `EXISTS` plan as InitPlans with `loops=1`, evaluated once per query rather than per row. Export 1.79s vs 2.13s baseline (faster — fewer rows); whole-dashboard progress 57ms vs 25ms. No new indexes.

## Reviewer notes

- **CMS is deliberately not exempt.** The reduced scope is understood to be an HHS-OpDiv rule with CMS answering all 40, but that is unconfirmed — and exempting CMS here alone would give CMS SaaS systems a 40 denominator with 15 questions their ISSOs cannot see, since the frontend filter is OpDiv-blind. All SaaS systems read 25 for now; the clause to add is in `pillarscope.go` and the current behavior is pinned by `CMSAlsoReducedWhileExemptionIsUndecided` so re-adding it has to change a test.

