### PR TITLE
fix(datacalls): scope the data-call export by tier and stop query params redirecting scope

### DIFF
--- a/backend/cmd/api/internal/controller/datacalls.go
+++ b/backend/cmd/api/internal/controller/datacalls.go
@@ -60,20 +60,26 @@ func GetDatacallExport(w http.ResponseWriter, r *http.Request) {
 	user := model.UserFromContext(r.Context())
 	findAnswersInput := model.FindAnswersInput{}
 
-	if !user.HasAdminRead() {
-		findAnswersInput.UserID = &user.UserID
-	}
-
-	vars := mux.Vars(r)
-	if v, ok := vars["datacallid"]; ok {
-		fmt.Sscan(v, &findAnswersInput.DataCallID)
-	}
-
+	// Decode the client query FIRST, then set the path id and the caller's scope,
+	// so nothing client-supplied can widen or redirect them. This is the ordering
+	// every other list handler uses (see scopeScoreProgressInput); the export was
+	// the one place scope was set before decode, which let a query param overwrite
+	// it (ztmf-misc#268). The scope fields carry schema:"-" so a decode attempt on
+	// them is a 400, but the ordering is the real guard.
 	err := decoder.Decode(&findAnswersInput, r.URL.Query())
 	if err != nil {
 		respond(w, r, nil, err)
 		return
 	}
+
+	// The path is authoritative for the data call; set it after decode so
+	// ?DataCallID= cannot redirect the export.
+	vars := mux.Vars(r)
+	if v, ok := vars["datacallid"]; ok {
+		fmt.Sscan(v, &findAnswersInput.DataCallID)
+	}
+
+	scopeFindAnswersInput(user, &findAnswersInput)
 
 	answers, err := model.FindAnswers(r.Context(), findAnswersInput)
 	if err != nil {
@@ -106,6 +112,20 @@ func GetDatacallExport(w http.ResponseWriter, r *http.Request) {
 	// it so server-side observability catches mid-stream disconnects.
 	if err := file.Write(w); err != nil {
 		log.Printf("GetDatacallExport: error writing xlsx to response (datacallid=%d): %v", findAnswersInput.DataCallID, err)
+	}
+}
+
+// scopeFindAnswersInput applies the caller's tier to the export query input,
+// the same three-way split ListScores and scopeScoreProgressInput use: unscoped
+// admins (OWNER, HHS_ADMIN, HHS_READONLY_ADMIN) see every OpDiv; OpDiv tiers
+// fail-closed to their granted OpDivs; everyone else is limited to their
+// assigned systems. Before this the export used a two-way HasAdminRead() branch
+// that dropped both OpDiv tiers into the unscoped path, so an OpDiv admin
+// exported every OpDiv's answers (ztmf-misc#267). Extracted so the role matrix
+// is unit-testable without a database.
+func scopeFindAnswersInput(user *model.User, input *model.FindAnswersInput) {
+	if input.ApplyTier(user) {
+		input.UserID = user.UserIDPtr()
 	}
 }
 

--- a/backend/cmd/api/internal/controller/datacalls_export_authz_test.go
+++ b/backend/cmd/api/internal/controller/datacalls_export_authz_test.go
@@ -1,0 +1,129 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func int32PtrExport(v int32) *int32 { return &v }
+
+// TestScopeFindAnswersInput pins the role matrix the data-call export applies to
+// its query input. This is the security boundary for GET /datacalls/{id}/export:
+// the SQL is tested separately, so what matters here is that each tier populates
+// exactly the scope fields FindAnswers keys on, and that no tier is dropped into
+// the wrong branch (ztmf-misc#267).
+func TestScopeFindAnswersInput(t *testing.T) {
+	t.Run("OwnerUnrestricted", func(t *testing.T) {
+		input := model.FindAnswersInput{}
+		scopeFindAnswersInput(adminUser, &input)
+
+		assert.False(t, input.RestrictToOpDivIDs, "OWNER must not be OpDiv-restricted")
+		assert.Empty(t, input.OpDivIDs)
+		assert.Nil(t, input.UserID, "OWNER must not be limited to assigned systems")
+	})
+
+	t.Run("HHSReadonlyAdminUnrestricted", func(t *testing.T) {
+		input := model.FindAnswersInput{}
+		scopeFindAnswersInput(readonlyAdmin, &input)
+
+		assert.False(t, input.RestrictToOpDivIDs, "HHS_READONLY_ADMIN has unscoped read")
+		assert.Empty(t, input.OpDivIDs)
+		assert.Nil(t, input.UserID)
+	})
+
+	t.Run("OpDivAdminScopedToGrants", func(t *testing.T) {
+		opdivAdmin := &model.User{
+			UserID:           "44444444-4444-4444-4444-444444444444",
+			Role:             "OPDIV_ADMIN",
+			AssignedOpDivIDs: []*int32{int32PtrExport(7), int32PtrExport(9)},
+		}
+		input := model.FindAnswersInput{}
+		scopeFindAnswersInput(opdivAdmin, &input)
+
+		assert.True(t, input.RestrictToOpDivIDs, "OPDIV_ADMIN must be OpDiv-restricted (ztmf-misc#267)")
+		assert.Equal(t, []int32{7, 9}, input.OpDivIDs)
+		assert.Nil(t, input.UserID, "OpDiv tier scopes by OpDiv, not by assignment")
+	})
+
+	t.Run("OpDivReadonlyAdminScopedLikeOpDivAdmin", func(t *testing.T) {
+		opdivReadonly := &model.User{
+			UserID:           "66666666-6666-6666-6666-666666666666",
+			Role:             "OPDIV_READONLY_ADMIN",
+			AssignedOpDivIDs: []*int32{int32PtrExport(3)},
+		}
+		input := model.FindAnswersInput{}
+		scopeFindAnswersInput(opdivReadonly, &input)
+
+		assert.True(t, input.RestrictToOpDivIDs)
+		assert.Equal(t, []int32{3}, input.OpDivIDs)
+		assert.Nil(t, input.UserID)
+	})
+
+	t.Run("OpDivAdminWithNoGrantsFailsClosed", func(t *testing.T) {
+		opdivAdmin := &model.User{
+			UserID: "55555555-5555-5555-5555-555555555555",
+			Role:   "OPDIV_ADMIN",
+		}
+		input := model.FindAnswersInput{}
+		scopeFindAnswersInput(opdivAdmin, &input)
+
+		assert.True(t, input.RestrictToOpDivIDs)
+		assert.Empty(t, input.OpDivIDs, "no grants must leave the id list empty so the query fails closed")
+	})
+
+	t.Run("ISSOScopedToAssignedSystems", func(t *testing.T) {
+		input := model.FindAnswersInput{}
+		scopeFindAnswersInput(issoUser, &input)
+
+		assert.False(t, input.RestrictToOpDivIDs)
+		if assert.NotNil(t, input.UserID, "ISSO must be limited to their assigned systems") {
+			assert.Equal(t, issoUser.UserID, *input.UserID)
+		}
+	})
+}
+
+// TestScopeFindAnswersInput_QueryCannotWiden is the negative case: an ISSO sends
+// a hostile query, the handler decodes it and then scopes, and the caller's own
+// identity must win. This pins the decode-then-scope ordering that ztmf-misc#268
+// was about, at the unit level, without a database or the full handler.
+func TestScopeFindAnswersInput_QueryCannotWiden(t *testing.T) {
+	// Mimic the handler: decode the client query onto the input, THEN scope.
+	input := model.FindAnswersInput{}
+	err := decoder.Decode(&input, url.Values{"UserID": {"victim-uuid"}})
+	// UserID is schema:"-", so it is an unknown key and decode rejects it. Even
+	// if that changed, the scope step below would still overwrite it.
+	assert.Error(t, err, "a server-owned field must not be bindable from the query string")
+
+	input = model.FindAnswersInput{UserID: int32StrPtr("victim-uuid")}
+	scopeFindAnswersInput(issoUser, &input)
+	if assert.NotNil(t, input.UserID) {
+		assert.Equal(t, issoUser.UserID, *input.UserID,
+			"scope runs after decode, so the caller's own id must win over any client value")
+	}
+}
+
+func int32StrPtr(s string) *string { return &s }
+
+// TestGetDatacallExport_ScopeFieldsRejectedFromQuery pins that the export's
+// server-owned scope fields cannot be set from the query string: a request that
+// tries returns 400 (unknown key) rather than 200 with redirected scope. fsids
+// remains the one legitimate query parameter.
+func TestGetDatacallExport_ScopeFieldsRejectedFromQuery(t *testing.T) {
+	for _, q := range []string{"UserID=victim-uuid", "userid=victim-uuid", "RestrictToOpDivIDs=false", "OpDivIDs=1"} {
+		t.Run(q, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/datacalls/1/export?"+q, nil)
+			r = withUser(r, issoUser)
+			w := httptest.NewRecorder()
+
+			GetDatacallExport(w, r)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code,
+				"a server-owned scope field in the query must 400, not redirect scope")
+		})
+	}
+}

--- a/backend/cmd/api/internal/controller/datacentermismatches.go
+++ b/backend/cmd/api/internal/controller/datacentermismatches.go
@@ -28,13 +28,7 @@ func ListDataCenterMismatches(w http.ResponseWriter, r *http.Request) {
 
 	// Scope by tier: unscoped admins see all; OpDiv tiers fail-closed to their
 	// granted OpDivs' systems; ISSO/ISSM are not the report's audience -> 403.
-	switch {
-	case user.HasUnscopedRead():
-		// no scope filter
-	case user.IsOpDivTier():
-		in.RestrictToOpDivIDs = true
-		_, in.OpDivIDs = user.EffectiveOpDivScope()
-	default:
+	if in.ApplyTier(user) {
 		respond(w, r, nil, ErrForbidden)
 		return
 	}

--- a/backend/cmd/api/internal/controller/fismasystems.go
+++ b/backend/cmd/api/internal/controller/fismasystems.go
@@ -44,18 +44,8 @@ func ListFismaSystems(w http.ResponseWriter, r *http.Request) {
 	//     (users_fismasystems). They may also carry a CMS OpDiv grant from
 	//     the 0034 seed, but we deliberately do not honor it here so their
 	//     scope stays system-level as it was pre-multi-OpDiv.
-	switch {
-	case user.HasUnscopedRead():
-		// no scope filter
-	case user.IsOpDivTier():
-		input.RestrictToOpDivIDs = true
-		for _, id := range user.AssignedOpDivIDs {
-			if id != nil {
-				input.OpDivIDs = append(input.OpDivIDs, *id)
-			}
-		}
-	default:
-		input.UserID = &user.UserID
+	if input.ApplyTier(user) {
+		input.UserID = user.UserIDPtr()
 	}
 
 	fismasystems, err := model.FindFismaSystems(r.Context(), input)

--- a/backend/cmd/api/internal/controller/insights.go
+++ b/backend/cmd/api/internal/controller/insights.go
@@ -29,14 +29,8 @@ func ListSystemInsights(w http.ResponseWriter, r *http.Request) {
 	// Scope by tier AFTER decode so a client cannot widen scope via query
 	// params: unscoped admins see all; OpDiv tiers fail-closed to their granted
 	// OpDivs' systems; ISSO/ISSM keep the per-system (UserID) path.
-	switch {
-	case user.HasUnscopedRead():
-		// no scope filter
-	case user.IsOpDivTier():
-		in.RestrictToOpDivIDs = true
-		_, in.OpDivIDs = user.EffectiveOpDivScope()
-	default:
-		in.UserID = &user.UserID
+	if in.ApplyTier(user) {
+		in.UserID = user.UserIDPtr()
 	}
 
 	if err == nil {

--- a/backend/cmd/api/internal/controller/scores.go
+++ b/backend/cmd/api/internal/controller/scores.go
@@ -31,17 +31,11 @@ func ListScores(w http.ResponseWriter, r *http.Request) {
 
 	err = decoder.Decode(&findScoresInput, r.URL.Query())
 
-	// Scope by tier AFTER decode so a client cannot widen scope via query
-	// params: unscoped admins see all; OPDIV tiers fail-closed to their granted
-	// OpDivs' systems; ISSO/ISSM keep the per-system (UserID) path.
-	switch {
-	case user.HasUnscopedRead():
-		// no scope filter
-	case user.IsOpDivTier():
-		findScoresInput.RestrictToOpDivIDs = true
-		_, findScoresInput.OpDivIDs = user.EffectiveOpDivScope()
-	default:
-		findScoresInput.UserID = &user.UserID
+	// Scope by tier AFTER decode so a client cannot widen scope via query params:
+	// unscoped admins see all; OPDIV tiers fail-closed to their granted OpDivs'
+	// systems; ISSO/ISSM keep the per-system (UserID) path.
+	if findScoresInput.ApplyTier(user) {
+		findScoresInput.UserID = user.UserIDPtr()
 	}
 
 	if err == nil {
@@ -247,17 +241,9 @@ func GetScoresDiff(w http.ResponseWriter, r *http.Request) {
 	err = decoder.Decode(&input, r.URL.Query())
 
 	// Same tier scoping as ListScores, applied AFTER decode so a client cannot
-	// widen scope via query params: unscoped admins see all; OPDIV tiers
-	// fail-closed to their granted OpDivs' systems; ISSO/ISSM keep the
-	// per-system (UserID) path.
-	switch {
-	case user.HasUnscopedRead():
-		// no scope filter
-	case user.IsOpDivTier():
-		input.RestrictToOpDivIDs = true
-		_, input.OpDivIDs = user.EffectiveOpDivScope()
-	default:
-		input.UserID = &user.UserID
+	// widen scope via query params.
+	if input.ApplyTier(user) {
+		input.UserID = user.UserIDPtr()
 	}
 
 	if err == nil {
@@ -304,14 +290,8 @@ func GetScoresProgress(w http.ResponseWriter, r *http.Request) {
 // their granted OpDivs' systems; ISSO/ISSM keep the per-system (UserID) path.
 // Extracted so the role matrix is unit-testable without a database.
 func scopeScoreProgressInput(user *model.User, input *model.FindScoreProgressInput) {
-	switch {
-	case user.HasUnscopedRead():
-		// no scope filter
-	case user.IsOpDivTier():
-		input.RestrictToOpDivIDs = true
-		_, input.OpDivIDs = user.EffectiveOpDivScope()
-	default:
-		input.UserID = &user.UserID
+	if input.ApplyTier(user) {
+		input.UserID = user.UserIDPtr()
 	}
 }
 
@@ -336,16 +316,9 @@ func GetScoresAggregate(w http.ResponseWriter, r *http.Request) {
 
 	err = decoder.Decode(&findScoresInput, r.URL.Query())
 
-	// Same tier scoping as ListScores, applied AFTER decode: unscoped admins see
-	// all; OPDIV tiers fail-closed to their OpDivs; ISSO/ISSM keep the
-	// assigned-systems path.
-	switch {
-	case user.HasUnscopedRead():
-		// no scope filter
-	case user.IsOpDivTier():
-		findScoresInput.RestrictToOpDivIDs = true
-		_, findScoresInput.OpDivIDs = user.EffectiveOpDivScope()
-	default:
+	// Same tier scoping as ListScores, applied AFTER decode. This endpoint's
+	// self-scope default is the assigned-systems list, not UserID.
+	if findScoresInput.ApplyTier(user) {
 		findScoresInput.FismaSystemIDs = user.AssignedFismaSystems
 	}
 

--- a/backend/cmd/api/internal/controller/usersfismasystems.go
+++ b/backend/cmd/api/internal/controller/usersfismasystems.go
@@ -81,7 +81,7 @@ func ListAssignableFismaSystems(w http.ResponseWriter, r *http.Request) {
 	// unconditionally so a target with no OpDiv grants fails closed (no rows)
 	// rather than falling through to an unscoped read - mirroring the write guard,
 	// which rejects any system whose OpDiv the target does not hold (#449).
-	input := model.FindFismaSystemsInput{RestrictToOpDivIDs: true}
+	input := model.FindFismaSystemsInput{OpDivScope: model.OpDivScope{RestrictToOpDivIDs: true}}
 	for _, id := range target.AssignedOpDivIDs {
 		if id != nil {
 			input.OpDivIDs = append(input.OpDivIDs, *id)

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -954,6 +954,30 @@ tests:
       headers:
         content-type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
+  # Export as an OpDiv-scoped admin (ztmf-misc#267): the caller falls into the
+  # OpDiv-restricted branch, not the unscoped admin path, so the request still
+  # succeeds and returns a valid xlsx scoped to the caller's OpDiv. The prior
+  # case covers the unscoped admin path; this pins that the tier split reaches
+  # the export at all. Row-level OpDiv containment is asserted in the model
+  # integration tests, which can read opdiv_id back per system.
+  - url: "http://localhost:8080/api/v1/datacalls/{{.createDataCall.Response.data.datacallid}}/export"
+    method: GET
+    headers:
+      <<: *opDivAdminHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+  # A server-owned scope field supplied in the query is a 400, not a redirect
+  # (ztmf-misc#268). UserID carries schema:"-", so it is an unknown key.
+  - url: "http://localhost:8080/api/v1/datacalls/{{.createDataCall.Response.data.datacallid}}/export?UserID=00000000-0000-0000-0000-000000000000"
+    method: GET
+    headers:
+      <<: *issoHeaders
+    expect:
+      status: 400
+
   # Decommission FISMA system with custom date and notes
   - id: decommissionFismaSystem
     url: "http://localhost:8080/api/v1/fismasystems/{{.createFismaSystem.Response.data.fismasystemid}}"

--- a/backend/internal/model/answers.go
+++ b/backend/internal/model/answers.go
@@ -35,7 +35,12 @@ type Answer struct {
 type FindAnswersInput struct {
 	FismaSystemIDs []*int32 `schema:"fsids"`
 	DataCallID     int32
-	UserID         *string
+	// UserID is the caller's per-user scope, set from the session by the
+	// controller, never from the request. schema:"-" so ?UserID= is a 400 unknown
+	// key rather than a silent scope redirect (ztmf-misc#268); OpDivScope carries
+	// the same guard for the OpDiv fields.
+	UserID *string `schema:"-"`
+	OpDivScope
 }
 
 // FindAnswers queries the DB and returns a fully comprehensive set of fields and values
@@ -79,6 +84,12 @@ func FindAnswers(ctx context.Context, input FindAnswersInput) ([]*Answer, error)
 
 	if input.UserID != nil {
 		sqlb = sqlb.InnerJoin("users_fismasystems ON users_fismasystems.userid=? AND users_fismasystems.fismasystemid=fismasystems.fismasystemid", input.UserID)
+	}
+
+	// OpDiv scope (fail-closed): an OpDiv-restricted caller with no grants gets
+	// no rows rather than every row. Shared with every other list query.
+	if f := input.OpDivWhere(squirrel.Eq{"fismasystems.opdiv_id": input.OpDivIDs}); f != nil {
+		sqlb = sqlb.Where(f)
 	}
 
 	if len(input.FismaSystemIDs) > 0 {

--- a/backend/internal/model/answers_integration_test.go
+++ b/backend/internal/model/answers_integration_test.go
@@ -9,6 +9,115 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestFindAnswersOpDivScopeIntegration pins the OpDiv scoping added for
+// ztmf-misc#267 and #268 against the real SQL: an OpDiv-restricted export sees
+// only systems in the granted OpDivs, an empty grant fails closed to no rows,
+// and an fsids list naming a system outside the grant does not leak it.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindAnswersOpDivScopeIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
+	defer conn.Release()
+
+	// A data call with scored systems in at least two distinct OpDivs, plus the
+	// two OpDiv ids to compare. Discovered rather than hardcoded so the test
+	// tracks whatever the seed provides.
+	var call, opdivA, opdivB int32
+	err = conn.QueryRow(ctx, `
+		WITH by_call AS (
+			SELECT s.datacallid, fs.opdiv_id, COUNT(DISTINCT fs.fismasystemid) n
+			FROM scores s
+			JOIN fismasystems fs ON fs.fismasystemid = s.fismasystemid
+			WHERE fs.opdiv_id IS NOT NULL
+			GROUP BY s.datacallid, fs.opdiv_id
+		)
+		SELECT a.datacallid, a.opdiv_id, b.opdiv_id
+		FROM by_call a
+		JOIN by_call b ON b.datacallid = a.datacallid AND b.opdiv_id > a.opdiv_id
+		ORDER BY a.datacallid, a.opdiv_id, b.opdiv_id
+		LIMIT 1
+	`).Scan(&call, &opdivA, &opdivB)
+	if err != nil {
+		t.Skip("seed has no data call with scored systems in two distinct OpDivs")
+	}
+
+	opdivOf := func(t *testing.T, answers []*Answer) map[int32]int32 {
+		t.Helper()
+		ids := map[int32]bool{}
+		for _, a := range answers {
+			ids[a.FismaSystemID] = true
+		}
+		result := map[int32]int32{}
+		for id := range ids {
+			var opdiv int32
+			require.NoError(t, conn.QueryRow(ctx,
+				`SELECT opdiv_id FROM fismasystems WHERE fismasystemid = $1`, id).Scan(&opdiv))
+			result[id] = opdiv
+		}
+		return result
+	}
+
+	t.Run("RestrictedToGrantSeesOnlyThatOpDiv", func(t *testing.T) {
+		answers, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID: call,
+			OpDivScope: OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: []int32{opdivA}},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, answers, "the granted OpDiv has scored systems, so the export must not be empty")
+		for id, opdiv := range opdivOf(t, answers) {
+			assert.Equal(t, opdivA, opdiv, "system %d is outside the granted OpDiv but was exported", id)
+		}
+	})
+
+	t.Run("EmptyGrantFailsClosed", func(t *testing.T) {
+		answers, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID: call,
+			OpDivScope: OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: nil},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, answers, "an OpDiv-restricted caller with no grants must get no rows, not every row")
+	})
+
+	t.Run("CrossOpDivFsidsReturnsNothing", func(t *testing.T) {
+		// Ask for a system in OpDiv B while granted only OpDiv A: the two filters
+		// conjoin, so the out-of-scope system is dropped rather than leaked.
+		var victim int32
+		err := conn.QueryRow(ctx, `
+			SELECT DISTINCT fs.fismasystemid
+			FROM fismasystems fs
+			JOIN scores s ON s.fismasystemid = fs.fismasystemid
+			WHERE fs.opdiv_id = $1 AND s.datacallid = $2
+			LIMIT 1`, opdivB, call).Scan(&victim)
+		require.NoError(t, err)
+
+		answers, err := FindAnswers(ctx, FindAnswersInput{
+			DataCallID:     call,
+			FismaSystemIDs: []*int32{&victim},
+			OpDivScope:     OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: []int32{opdivA}},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, answers, "a system in another OpDiv must not be exported even when named in fsids")
+	})
+
+	t.Run("UnrestrictedSeesBothOpDivs", func(t *testing.T) {
+		answers, err := FindAnswers(ctx, FindAnswersInput{DataCallID: call})
+		require.NoError(t, err)
+		seen := map[int32]bool{}
+		for _, opdiv := range opdivOf(t, answers) {
+			seen[opdiv] = true
+		}
+		assert.True(t, seen[opdivA] && seen[opdivB],
+			"an unscoped caller must still see systems from both OpDivs")
+	})
+}
+
 // TestFindAnswersIntegration pins the #526 behavior against the real SQL: the
 // export is anchored on the applicable-function set, not on scores, so a system
 // that has not answered a function still appears with a blank (nil) answer, and

--- a/backend/internal/model/datacentermismatches.go
+++ b/backend/internal/model/datacentermismatches.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -42,10 +43,7 @@ type DataCenterMismatch struct {
 // RestrictToOpDivIDs carry the auth'd user's access scope and are set by the
 // controller, never by the client, mirroring FindSystemInsightsInput.
 type FindDataCenterMismatchesInput struct {
-	// OpDiv scope for the per-OpDiv admin tiers. RestrictToOpDivIDs with an
-	// empty slice fails closed (no rows).
-	OpDivIDs           []int32
-	RestrictToOpDivIDs bool
+	OpDivScope
 }
 
 // FindDataCenterMismatches returns active systems whose CFACTS-reported data
@@ -95,11 +93,8 @@ func FindDataCenterMismatches(ctx context.Context, in FindDataCenterMismatchesIn
 
 	// OpDiv-scoped admin tiers (fail-closed): restrict to systems in the admin's
 	// granted OpDivs. Empty grants under RestrictToOpDivIDs -> no rows.
-	switch {
-	case in.RestrictToOpDivIDs && len(in.OpDivIDs) == 0:
-		sqlb = sqlb.Where("FALSE")
-	case len(in.OpDivIDs) > 0:
-		sqlb = sqlb.Where("fs.opdiv_id = ANY(?)", in.OpDivIDs)
+	if f := in.OpDivWhere(squirrel.Expr("fs.opdiv_id = ANY(?)", in.OpDivIDs)); f != nil {
+		sqlb = sqlb.Where(f)
 	}
 
 	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[DataCenterMismatch])

--- a/backend/internal/model/datacentermismatches_integration_test.go
+++ b/backend/internal/model/datacentermismatches_integration_test.go
@@ -81,7 +81,7 @@ func TestFindDataCenterMismatchesIntegration(t *testing.T) {
 	})
 
 	t.Run("OpDivScopeFailsClosed", func(t *testing.T) {
-		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{RestrictToOpDivIDs: true})
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{OpDivScope: OpDivScope{RestrictToOpDivIDs: true}})
 		require.NoError(t, err)
 		assert.Empty(t, rows, "RestrictToOpDivIDs with zero grants must return no rows")
 	})
@@ -95,7 +95,7 @@ func TestFindDataCenterMismatchesIntegration(t *testing.T) {
 		require.NoError(t, conn.QueryRow(ctx, `SELECT opdiv_id FROM opdivs WHERE code = 'EMPIRE'`).Scan(&empireID))
 		require.NoError(t, conn.QueryRow(ctx, `SELECT opdiv_id FROM opdivs WHERE code = 'REBELLION'`).Scan(&rebellionID))
 
-		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{RestrictToOpDivIDs: true, OpDivIDs: []int32{empireID}})
+		rows, err := FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{OpDivScope: OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: []int32{empireID}}})
 		require.NoError(t, err)
 		require.NotEmpty(t, rows, "EMPIRE-scoped admin should see the Shield Gen mismatch")
 		for _, r := range rows {
@@ -106,7 +106,7 @@ func TestFindDataCenterMismatchesIntegration(t *testing.T) {
 
 		// REBELLION grant alone yields nothing: its only mismatch row is behind
 		// the insights_enabled gate, which scope must not bypass.
-		rows, err = FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{RestrictToOpDivIDs: true, OpDivIDs: []int32{rebellionID}})
+		rows, err = FindDataCenterMismatches(ctx, FindDataCenterMismatchesInput{OpDivScope: OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: []int32{rebellionID}}})
 		require.NoError(t, err)
 		assert.Empty(t, rows)
 	})

--- a/backend/internal/model/fismasystems.go
+++ b/backend/internal/model/fismasystems.go
@@ -84,16 +84,13 @@ type FismaSystem struct {
 type FindFismaSystemsInput struct {
 	FismaSystemID *int32
 	FismaAcronym  *string
-	UserID        *string
-	OpDivIDs      []int32
-	// RestrictToOpDivIDs is the defense-in-depth flag the controller sets
-	// when the calling user is an OpDiv-scoped admin. With it set, an empty
-	// OpDivIDs slice produces a WHERE FALSE predicate (match no rows) rather
-	// than falling through to no-filter. Prevents a fail-open if an
-	// OPDIV_ADMIN ends up with zero grants in users_opdivs at any point in
-	// their lifecycle (mid-provisioning, all-revoked, etc.).
-	RestrictToOpDivIDs bool
-	Decommissioned     bool `schema:"decommissioned"`
+	UserID        *string `schema:"-"`
+	// OpDivScope is the OpDiv-tier filter (defense-in-depth): with
+	// RestrictToOpDivIDs set, an empty OpDivIDs slice fails closed to no rows
+	// rather than falling through to no-filter, so an OPDIV_ADMIN who ends up with
+	// zero grants (mid-provisioning, all-revoked) cannot read every system.
+	OpDivScope
+	Decommissioned bool `schema:"decommissioned"`
 	// ResolveISSOName swaps the raw isso_name column for the COALESCE that
 	// falls back to the ISSO's user record (see resolveISSONameColumn). Set by
 	// DISPLAY reads only - the list always resolves, the single-system GET
@@ -144,19 +141,20 @@ func FindFismaSystems(ctx context.Context, input FindFismaSystemsInput) ([]*Fism
 	//   - UserID set, OpDivIDs empty => legacy behavior, INNER JOIN to
 	//     users_fismasystems only (ISSO / ISSM in single-OpDiv state).
 	//   - Nothing set => no scope filter (unscoped admin tiers).
-	switch {
-	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
-		sqlb = sqlb.Where("FALSE")
-	case len(input.OpDivIDs) > 0:
-		if input.UserID != nil {
-			sqlb = sqlb.Where(
-				"(fismasystems.opdiv_id = ANY(?) OR fismasystems.fismasystemid IN (SELECT fismasystemid FROM users_fismasystems WHERE userid = ?))",
-				input.OpDivIDs, *input.UserID,
-			)
-		} else {
-			sqlb = sqlb.Where("fismasystems.opdiv_id = ANY(?)", input.OpDivIDs)
-		}
-	case input.UserID != nil:
+	// The grants predicate widens to also admit the caller's explicitly-assigned
+	// systems when they carry a UserID (an ISSO/ISSM who also belongs to an
+	// OpDiv). OpDivWhere owns the fail-closed decision; when it adds nothing
+	// (no OpDiv scope at all) fall through to the legacy UserID-only join.
+	grants := squirrel.Expr("fismasystems.opdiv_id = ANY(?)", input.OpDivIDs)
+	if input.UserID != nil {
+		grants = squirrel.Expr(
+			"(fismasystems.opdiv_id = ANY(?) OR fismasystems.fismasystemid IN (SELECT fismasystemid FROM users_fismasystems WHERE userid = ?))",
+			input.OpDivIDs, *input.UserID,
+		)
+	}
+	if f := input.OpDivWhere(grants); f != nil {
+		sqlb = sqlb.Where(f)
+	} else if input.UserID != nil {
 		sqlb = sqlb.InnerJoin("users_fismasystems ON users_fismasystems.fismasystemid = fismasystems.fismasystemid AND users_fismasystems.userid=?", *input.UserID)
 	}
 

--- a/backend/internal/model/opdivscope.go
+++ b/backend/internal/model/opdivscope.go
@@ -1,0 +1,88 @@
+package model
+
+import (
+	"github.com/Masterminds/squirrel"
+)
+
+// OpDivScope is the OpDiv-tier query scope shared by every list input. Embed it
+// in a FindXInput struct so the tier classification and the fail-closed OpDiv
+// decision live in exactly one place instead of being hand-copied per endpoint.
+//
+// The copies this replaces are how ztmf-misc#267 happened: the data-call export
+// predated the pattern, never adopted it, and shipped an OpDiv-blind query. A new
+// endpoint that embeds this and calls ApplyTier cannot make that mistake, and one
+// that forgets has no scope struct to build rather than a silently unscoped one.
+//
+// The fields carry schema:"-" so the query-string decoder can never bind them: an
+// OpDiv scope is set from the authenticated session, never from client input, and
+// a request that tries (?OpDivIDs=, ?RestrictToOpDivIDs=) is a 400 unknown key.
+type OpDivScope struct {
+	OpDivIDs           []int32 `schema:"-"`
+	RestrictToOpDivIDs bool    `schema:"-"`
+}
+
+// ApplyTier classifies the caller into the shared scope buckets and sets the
+// OpDiv-tier fields. It returns true when the caller is neither an unscoped admin
+// nor an OpDiv tier, i.e. the caller must still apply its own self-scope default
+// (limit to assigned systems by UserID, by FismaSystemIDs, or reject with 403) -
+// that last branch legitimately differs per endpoint, so it stays at the call
+// site. The two shared branches, which are the security-critical classification,
+// live here so they cannot drift or be mis-copied (ztmf-misc#267).
+func (s *OpDivScope) ApplyTier(u *User) (needsSelfScope bool) {
+	switch {
+	case u.HasUnscopedRead():
+		return false
+	case u.IsOpDivTier():
+		s.RestrictToOpDivIDs = true
+		_, s.OpDivIDs = u.EffectiveOpDivScope()
+		return false
+	default:
+		return true
+	}
+}
+
+// OpDivWhere owns the fail-closed decision for a squirrel-built query and returns
+// the predicate to apply, or nil when the caller is unrestricted (add nothing).
+// An OpDiv-restricted caller with no grants matches no rows (WHERE FALSE) rather
+// than falling through to unfiltered; a caller with grants gets the grants
+// predicate. That predicate is supplied by the site because the path from the
+// query's base table to opdiv_id differs per query (a direct opdiv_id column, a
+// fismasystemid subquery, an EXISTS against users_opdivs, ...); only the
+// fail-closed decision is shared, and it is what must never be mis-copied.
+//
+//	if f := in.OpDivWhere(squirrel.Eq{"fismasystems.opdiv_id": in.OpDivIDs}); f != nil {
+//	    sqlb = sqlb.Where(f)
+//	}
+func (s OpDivScope) OpDivWhere(grants squirrel.Sqlizer) squirrel.Sqlizer {
+	switch {
+	case s.RestrictToOpDivIDs && len(s.OpDivIDs) == 0:
+		return squirrel.Expr("FALSE")
+	case len(s.OpDivIDs) > 0:
+		return grants
+	default:
+		return nil
+	}
+}
+
+// AppendRawFilter is OpDivWhere for the hand-built `$N` query builders
+// (buildScoreProgressSQL, buildPillarScoresSQL, buildScoreDiffSQL). It appends the
+// fail-closed OpDiv predicate to the caller's conds/args: "FALSE" when restricted
+// with no grants, nothing when unrestricted, and otherwise the fragment returned
+// by grantsFrag with OpDivIDs bound as one arg. grantsFrag receives the next
+// placeholder number and returns the SQL using it; it is called, and *argN
+// advanced, only in the grants case so the caller's placeholder count stays in
+// sync.
+//
+//	in.AppendRawFilter(&conds, &args, &argN, func(n int) string {
+//	    return fmt.Sprintf("fs.opdiv_id = ANY($%d)", n)
+//	})
+func (s OpDivScope) AppendRawFilter(conds *[]string, args *[]any, argN *int, grantsFrag func(n int) string) {
+	switch {
+	case s.RestrictToOpDivIDs && len(s.OpDivIDs) == 0:
+		*conds = append(*conds, "FALSE")
+	case len(s.OpDivIDs) > 0:
+		*conds = append(*conds, grantsFrag(*argN))
+		*args = append(*args, s.OpDivIDs)
+		*argN++
+	}
+}

--- a/backend/internal/model/scorediff.go
+++ b/backend/internal/model/scorediff.go
@@ -46,12 +46,10 @@ type FindScoreDiffInput struct {
 	FromDataCallID *int32 `schema:"from"`
 	ToDataCallID   *int32 `schema:"to"`
 	// UserID restricts the diff to the requesting user's assigned systems
-	// (ISSO/ISSM tiers); set by the controller, not bindable from the query.
-	UserID *string
-	// OpDiv scope for OpDiv-scoped admin tiers, mirroring FindScores. Not
-	// schema-tagged - the controller sets them from the auth'd user.
-	OpDivIDs           []int32
-	RestrictToOpDivIDs bool
+	// (ISSO/ISSM tiers); set by the controller, schema:"-" so it is not bindable
+	// from the query.
+	UserID *string `schema:"-"`
+	OpDivScope
 }
 
 // FindScoreDiff compares the score (functionoption) answers of two data calls
@@ -192,16 +190,11 @@ func scoreCycleCTE(input FindScoreDiffInput, dataCallID int32, args *[]any, argN
 		*argN++
 	}
 
-	// OpDiv scope (fail-closed): empty grants under RestrictToOpDivIDs -> no
-	// rows. Expressed as a subquery predicate to match FindScores.
-	switch {
-	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
-		conds = append(conds, "FALSE")
-	case len(input.OpDivIDs) > 0:
-		conds = append(conds, fmt.Sprintf("s.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY($%d))", *argN))
-		*args = append(*args, input.OpDivIDs)
-		*argN++
-	}
+	// OpDiv scope (fail-closed): empty grants under RestrictToOpDivIDs -> no rows.
+	// Subquery predicate (scorediff reads scores, which has no opdiv_id).
+	input.AppendRawFilter(&conds, args, argN, func(n int) string {
+		return fmt.Sprintf("s.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY($%d))", n)
+	})
 
 	return fmt.Sprintf(`
     SELECT s.scoreid, s.fismasystemid, fo.functionid, s.functionoptionid,

--- a/backend/internal/model/scorediff_test.go
+++ b/backend/internal/model/scorediff_test.go
@@ -119,10 +119,9 @@ func TestBuildScoreDiffSQL_UserScope(t *testing.T) {
 func TestBuildScoreDiffSQL_OpDivScope(t *testing.T) {
 	t.Run("ScopedToGrantedOpDivs", func(t *testing.T) {
 		in := FindScoreDiffInput{
-			FromDataCallID:     int32Ptr(3),
-			ToDataCallID:       int32Ptr(4),
-			RestrictToOpDivIDs: true,
-			OpDivIDs:           []int32{7, 9},
+			FromDataCallID: int32Ptr(3),
+			ToDataCallID:   int32Ptr(4),
+			OpDivScope:     OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: []int32{7, 9}},
 		}
 		sql, args := buildScoreDiffSQL(in)
 
@@ -140,9 +139,9 @@ func TestBuildScoreDiffSQL_OpDivScope(t *testing.T) {
 
 	t.Run("RestrictedWithNoGrantsFailsClosed", func(t *testing.T) {
 		in := FindScoreDiffInput{
-			FromDataCallID:     int32Ptr(3),
-			ToDataCallID:       int32Ptr(4),
-			RestrictToOpDivIDs: true,
+			FromDataCallID: int32Ptr(3),
+			ToDataCallID:   int32Ptr(4),
+			OpDivScope:     OpDivScope{RestrictToOpDivIDs: true},
 		}
 		sql, _ := buildScoreDiffSQL(in)
 

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -72,12 +72,10 @@ type FindScoreProgressInput struct {
 	DataCallID    *int32 `schema:"datacallid"`
 	FismaSystemID *int32 `schema:"fismasystemid"`
 	// UserID restricts progress to the requesting user's assigned systems
-	// (ISSO/ISSM tiers); set by the controller, not bindable from the query.
-	UserID *string
-	// OpDiv scope for OpDiv-scoped admin tiers, mirroring FindScores. Not
-	// schema-tagged - the controller sets them from the auth'd user.
-	OpDivIDs           []int32
-	RestrictToOpDivIDs bool
+	// (ISSO/ISSM tiers); set by the controller, schema:"-" so it is not bindable
+	// from the query.
+	UserID *string `schema:"-"`
+	OpDivScope
 }
 
 func (i FindScoreProgressInput) validate() error {
@@ -150,16 +148,10 @@ func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
 		argN++
 	}
 
-	// OpDiv scope (fail-closed): empty grants under RestrictToOpDivIDs -> no
-	// rows, matching FindScores.
-	switch {
-	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
-		conds = append(conds, "FALSE")
-	case len(input.OpDivIDs) > 0:
-		conds = append(conds, fmt.Sprintf("fs.opdiv_id = ANY($%d)", argN))
-		args = append(args, input.OpDivIDs)
-		argN++
-	}
+	// OpDiv scope (fail-closed): empty grants under RestrictToOpDivIDs -> no rows.
+	input.AppendRawFilter(&conds, &args, &argN, func(n int) string {
+		return fmt.Sprintf("fs.opdiv_id = ANY($%d)", n)
+	})
 
 	dataCallArg := argN
 	args = append(args, *input.DataCallID)

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -123,9 +123,8 @@ func TestBuildScoreProgressSQL_UserScope(t *testing.T) {
 func TestBuildScoreProgressSQL_OpDivScope(t *testing.T) {
 	t.Run("ScopedToGrantedOpDivs", func(t *testing.T) {
 		in := FindScoreProgressInput{
-			DataCallID:         int32Ptr(4),
-			RestrictToOpDivIDs: true,
-			OpDivIDs:           []int32{7, 9},
+			DataCallID: int32Ptr(4),
+			OpDivScope: OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: []int32{7, 9}},
 		}
 		sql, args := buildScoreProgressSQL(in)
 
@@ -136,8 +135,8 @@ func TestBuildScoreProgressSQL_OpDivScope(t *testing.T) {
 
 	t.Run("RestrictedWithNoGrantsFailsClosed", func(t *testing.T) {
 		in := FindScoreProgressInput{
-			DataCallID:         int32Ptr(4),
-			RestrictToOpDivIDs: true,
+			DataCallID: int32Ptr(4),
+			OpDivScope: OpDivScope{RestrictToOpDivIDs: true},
 		}
 		sql, args := buildScoreProgressSQL(in)
 

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -569,11 +569,7 @@ type FindScoresInput struct {
 	DataCallID     *int32 `schema:"datacallid"`
 	UserID         *string
 	IncludePillars *bool `schema:"include_pillars"`
-	// OpDiv scope for OpDiv-scoped admin tiers. Restricts scores to systems in
-	// the admin's granted OpDivs; RestrictToOpDivIDs with an empty slice fails
-	// closed. Not schema-tagged - the controller sets them from the auth'd user.
-	OpDivIDs           []int32
-	RestrictToOpDivIDs bool
+	OpDivScope
 }
 
 func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
@@ -601,14 +597,11 @@ func FindScores(ctx context.Context, input FindScoresInput) ([]*Score, error) {
 	}
 
 	// OpDiv scope (fail-closed): restrict to scores whose system belongs to one
-	// of the admin's granted OpDivs. Empty grants under RestrictToOpDivIDs ->
-	// no rows. Expressed as a subquery predicate so it composes with the audit
-	// joins below without disturbing their arg ordering.
-	switch {
-	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
-		sqlb = sqlb.Where("FALSE")
-	case len(input.OpDivIDs) > 0:
-		sqlb = sqlb.Where("scores.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY(?))", input.OpDivIDs)
+	// of the admin's granted OpDivs. Expressed as a subquery predicate (scores has
+	// no opdiv_id) so it composes with the audit joins below without disturbing
+	// their arg ordering.
+	if f := input.OpDivWhere(squirrel.Expr("scores.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY(?))", input.OpDivIDs)); f != nil {
+		sqlb = sqlb.Where(f)
 	}
 
 	// Attach last-edit audit info. The lateral subquery picks the most recent
@@ -849,15 +842,10 @@ func buildPillarScoresSQL(input FindScoresInput) (string, []any) {
 	}
 
 	// OpDiv scope (fail-closed) on the expected CTE, which already joins
-	// fismasystems as fs. Empty grants under RestrictToOpDivIDs -> FALSE.
-	switch {
-	case input.RestrictToOpDivIDs && len(input.OpDivIDs) == 0:
-		conds = append(conds, "FALSE")
-	case len(input.OpDivIDs) > 0:
-		conds = append(conds, fmt.Sprintf("fs.opdiv_id = ANY($%d)", argN))
-		args = append(args, input.OpDivIDs)
-		argN++
-	}
+	// fismasystems as fs.
+	input.AppendRawFilter(&conds, &args, &argN, func(n int) string {
+		return fmt.Sprintf("fs.opdiv_id = ANY($%d)", n)
+	})
 
 	// Reduced pillar scope (ztmf#545): pillars a seeded rule excludes never
 	// enter the expected set, so a reduced system's pillar_scores rows simply

--- a/backend/internal/model/scores_test.go
+++ b/backend/internal/model/scores_test.go
@@ -278,8 +278,7 @@ func TestFindScoresAggregate_ISSOwithSpecificSystem(t *testing.T) {
 func TestBuildPillarScoresSQL_OpDivScope(t *testing.T) {
 	t.Run("ScopedToGrantedOpDivs", func(t *testing.T) {
 		input := normalizeInput(FindScoresInput{
-			RestrictToOpDivIDs: true,
-			OpDivIDs:           []int32{7, 9},
+			OpDivScope: OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: []int32{7, 9}},
 		})
 
 		sql, args := buildPillarScoresSQL(input)
@@ -298,8 +297,7 @@ func TestBuildPillarScoresSQL_OpDivScope(t *testing.T) {
 
 	t.Run("RestrictedWithNoGrantsFailsClosed", func(t *testing.T) {
 		input := normalizeInput(FindScoresInput{
-			RestrictToOpDivIDs: true,
-			OpDivIDs:           nil,
+			OpDivScope: OpDivScope{RestrictToOpDivIDs: true, OpDivIDs: nil},
 		})
 
 		sql, _ := buildPillarScoresSQL(input)

--- a/backend/internal/model/systeminsights.go
+++ b/backend/internal/model/systeminsights.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -28,11 +29,8 @@ type FindSystemInsightsInput struct {
 	input
 	FismaSystemID *int32 `schema:"fismasystemid"`
 	QuestionID    *int32 `schema:"questionid"`
-	UserID        *string
-	// OpDiv scope for the per-OpDiv admin tiers. RestrictToOpDivIDs with an
-	// empty slice fails closed (no rows).
-	OpDivIDs           []int32
-	RestrictToOpDivIDs bool
+	UserID *string `schema:"-"`
+	OpDivScope
 }
 
 // FindSystemInsights returns per-system x question insight rows, scoped both by
@@ -64,12 +62,9 @@ func FindSystemInsights(ctx context.Context, in FindSystemInsightsInput) ([]*Sys
 	}
 
 	// OpDiv-scoped admin tiers (fail-closed): restrict to systems in the admin's
-	// granted OpDivs. Empty grants under RestrictToOpDivIDs -> no rows.
-	switch {
-	case in.RestrictToOpDivIDs && len(in.OpDivIDs) == 0:
-		sqlb = sqlb.Where("FALSE")
-	case len(in.OpDivIDs) > 0:
-		sqlb = sqlb.Where("si.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY(?))", in.OpDivIDs)
+	// granted OpDivs. Subquery predicate (system_insights has no opdiv_id).
+	if f := in.OpDivWhere(squirrel.Expr("si.fismasystemid IN (SELECT fismasystemid FROM fismasystems WHERE opdiv_id = ANY(?))", in.OpDivIDs)); f != nil {
+		sqlb = sqlb.Where(f)
 	}
 
 	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[SystemInsight])

--- a/backend/internal/model/systeminsights_integration_test.go
+++ b/backend/internal/model/systeminsights_integration_test.go
@@ -80,7 +80,7 @@ func TestFindSystemInsightsIntegration(t *testing.T) {
 	assert.Empty(t, rows, "ISSO must get no rows for an unassigned system")
 
 	// Fail-closed OpDiv tier: restrict with no granted OpDivs -> empty.
-	failClosed, err := FindSystemInsights(ctx, FindSystemInsightsInput{QuestionID: &q1, RestrictToOpDivIDs: true})
+	failClosed, err := FindSystemInsights(ctx, FindSystemInsightsInput{QuestionID: &q1, OpDivScope: OpDivScope{RestrictToOpDivIDs: true}})
 	require.NoError(t, err)
 	assert.Empty(t, failClosed, "RestrictToOpDivIDs with empty OpDivIDs must fail closed to no rows")
 }

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -54,6 +54,16 @@ type User struct {
 
 func (u *User) IsOwner() bool { return u.Role == "OWNER" }
 
+// UserIDPtr returns a pointer to a COPY of the user's id, for setting the
+// self-scope UserID on a query input. Never take &u.UserID directly: that aims
+// at the session User's own field, so a later decode onto the same input struct
+// would mutate the authenticated identity (the ztmf-misc#268 pointer-mutation
+// finding). The copy severs that.
+func (u *User) UserIDPtr() *string {
+	id := u.UserID
+	return &id
+}
+
 // IsHHSTier reports membership in the HHS tier, covering both the write tier
 // (HHS_ADMIN) and the read-only tier (HHS_READONLY_ADMIN). It is a tier-
 // membership check, not a write-access gate. Use IsAdmin / HasAdminRead when
@@ -395,13 +405,9 @@ type FindUsersInput struct {
 	FullName *string `schema:"fullname"`
 	Role     *string `schema:"role"`
 	Deleted  bool    `schema:"deleted"`
-	// OpDivIDs / RestrictToOpDivIDs scope the list to users holding a grant in
-	// one of the acting admin's OpDivs. Mirror of FindFismaSystemsInput: when
-	// RestrictToOpDivIDs is set with an empty slice the query fails closed
-	// (WHERE FALSE) rather than returning every user. Not schema-tagged so a
-	// client cannot inject scope via query params - the controller sets them.
-	OpDivIDs           []int32
-	RestrictToOpDivIDs bool
+	// OpDivScope limits the list to users holding a grant in one of the acting
+	// admin's OpDivs; empty grants under RestrictToOpDivIDs fail closed.
+	OpDivScope
 }
 
 func (fui *FindUsersInput) validate() error {
@@ -465,14 +471,11 @@ func FindUsers(ctx context.Context, fui *FindUsersInput) ([]*User, error) {
 		sqlb = sqlb.Where("role=?", fui.Role)
 	}
 
-	// OpDiv scope (fail-closed): an OpDiv-scoped admin only sees users who hold
-	// a grant in one of their OpDivs. Empty grants under RestrictToOpDivIDs ->
-	// no rows. Unscoped admins set neither field and see everyone.
-	switch {
-	case fui.RestrictToOpDivIDs && len(fui.OpDivIDs) == 0:
-		sqlb = sqlb.Where("FALSE")
-	case len(fui.OpDivIDs) > 0:
-		sqlb = sqlb.Where("EXISTS (SELECT 1 FROM users_opdivs uod WHERE uod.userid = users.userid AND uod.opdiv_id = ANY(?))", fui.OpDivIDs)
+	// OpDiv scope (fail-closed): an OpDiv-scoped admin only sees users who hold a
+	// grant in one of their OpDivs, via the users_opdivs junction. Unscoped admins
+	// set neither field and see everyone.
+	if f := fui.OpDivWhere(squirrel.Expr("EXISTS (SELECT 1 FROM users_opdivs uod WHERE uod.userid = users.userid AND uod.opdiv_id = ANY(?))", fui.OpDivIDs)); f != nil {
+		sqlb = sqlb.Where(f)
 	}
 
 	return query(ctx, sqlb, pgx.RowToAddrOfStructByNameLax[User])


### PR DESCRIPTION
Fixes two authorization defects in `GetDatacallExport`, both filed against the same handler, and retires the copy-pasted scope pattern that let the first one happen.

## The defects

**CMS-Enterprise/ztmf-misc#267** (OpDiv scope): the export used a two-way `HasAdminRead()` branch that dropped both OpDiv-scoped tiers into the unscoped path, so an OPDIV_ADMIN or OPDIV_READONLY_ADMIN exported every OpDiv's answers. Now scoped by the same three-way tier split the rest of the codebase uses, with a fail-closed OpDiv predicate added to `FindAnswers`: an OpDiv-restricted caller with no grants gets no rows.

**CMS-Enterprise/ztmf-misc#268** (query-param scope override): scope was set before the client query string was decoded onto the same struct, so `?UserID=<other>` redirected the export to another user's answers, and the scope pointer aimed at the session `User` meant decode mutated the authenticated identity itself. Now decode-then-scope (the ordering every other list handler documents), server-owned fields tagged `schema:"-"` so they cannot be bound from the query at all, and `UserID` copied off the session rather than pointed at its field. The path is now authoritative for the data call id.

## Retiring the pattern

#267 happened because the export predated the tier-scoping pattern and never adopted it. The same two snippets were hand-copied across the codebase: the tier-classification switch (six controllers) and the fail-closed OpDiv predicate (nine model queries). This PR extracts both into an embedded `OpDivScope` type:

- `ApplyTier(user)` owns the role classification (unscoped / OpDiv / self-scope). The self-scope default stays at the call site because it legitimately differs per endpoint (by UserID, by assigned systems, or a 403).
- `OpDivWhere` / `AppendRawFilter` own the fail-closed decision (restricted-and-empty means no rows) for squirrel and hand-built queries respectively. The grants predicate stays at the call site because the path from each query's base table to `opdiv_id` differs (direct column, `fismasystemid` subquery, `EXISTS` against `users_opdivs`).

The fields carry `schema:"-"`, so a server-owned scope field supplied in any list endpoint's query is now a 400 rather than silently honored. A new list endpoint can no longer mis-classify a tier or forget the fail-closed predicate.

The per-resource access guards (`usersopdivs.go`, `users.go`, single-system checks) are a different pattern and are left for CMS-Enterprise/ztmf#427.

## Behavior changes

- OpDiv-tier exports are now scoped to granted OpDivs; a zero-grant OpDiv caller gets an empty export.
- `?UserID=` and `?DataCallID=` on the export return 400 instead of being honored; the path is authoritative.
- The `schema:"-"` hardening is codebase-wide: server-owned scope fields on the scores, progress, diff, insights, fismasystems, and users list endpoints are likewise no longer bindable from the query (they were set from the session already; this makes an attempt a 400 rather than a silent no-op).
- Unscoped admin (OWNER, HHS_ADMIN, HHS_READONLY_ADMIN) and ISSO/ISSM behavior is unchanged.

## Tests

- `datacalls_export_authz_test.go`: export role matrix and the query-override attempt as an explicit negative case.
- `answers_integration_test.go`: OpDiv scoping, empty-grant fail-closed, and cross-OpDiv `fsids` returning nothing.
- Emberfall cases for an OpDiv-scoped export and the 400 rejection.
- The existing per-query OpDiv and progress tests are repointed to the embedded struct and still pass.
- `make test-unit`, `make test-integration`, `make test-e2e` green; staticcheck clean; OpenAPI spec unchanged.

## Sequencing

These are scope fixes and should land before CMS-Enterprise/ztmf#427 (the ACL centralization), whose "preserve existing authorization behavior" criterion would otherwise carry #268 forward. Touches the same `FindAnswers` function as #546, so whichever merges second takes a small rebase.
