### PR TITLE
feat(#545): seed the reduced-pillar rule and apply it to scoring and the questionnaire

### DIFF
--- a/backend/_test_data_empire.sql
+++ b/backend/_test_data_empire.sql
@@ -1137,6 +1137,17 @@ INSERT INTO public.datacalls (datacallid, datacall, datecreated, deadline) VALUE
  (104,'FY26 ZTM','2025-10-01 00:00:00+00','2026-09-11 00:00:00+00')
 ON CONFLICT DO NOTHING;
 
+-- The seeded reduced-scope rule (ztmf#545), anchored at the fixture FY26 cycle.
+-- Migration 0057 seeds these rows only in environments that already hold an
+-- FY26-named call when it runs; this file's data calls are inserted after
+-- migrations, so the local/test rule rows are owned here. The clean re-run
+-- DELETE above cascades them (effective_datacallid is ON DELETE CASCADE).
+INSERT INTO public.reducedpillarscopes (scoring_key, pillarid, effective_datacallid)
+SELECT 'SaaS', p.pillarid, 104
+  FROM public.pillars p
+ WHERE p.pillar IN ('Devices', 'Applications')
+ON CONFLICT DO NOTHING;
+
 -- One SaaS function per pillar, derived rather than hardcoded: ids 7101-7106 sit
 -- above every explicit id in this file, and each function borrows an existing
 -- question in its pillar so the applicability join (which reads
@@ -1166,9 +1177,9 @@ VALUES
  (2016,'5A1A5000-0000-4000-8000-000000002016','MOCK-SAAS','Mock SaaS Reduced Scope System','SaaS',
   'mock.isso2016@example.empire', TRUE,
   (SELECT opdiv_id FROM public.opdivs WHERE UPPER(code) <> 'CMS' ORDER BY opdiv_id LIMIT 1),'Mock ISSO 2016'),
- -- CMS counterpart: the reduced scope is understood to be an HHS-OpDiv rule with
- -- CMS keeping all 40, but that is undecided, so both currently read 25. Without a
- -- CMS SaaS system the subtest pinning that interim behaviour skips.
+ -- CMS counterpart: CMS follows every other OpDiv - no exemption, per the
+ -- decision recorded on ztmf-misc#289 (2026-08-11) - so both systems read 25.
+ -- Without a CMS SaaS system the subtest pinning that skips.
  (2017,'5A1A5000-0000-4000-8000-000000002017','MOCK-SAAS-CMS','Mock CMS SaaS Reduced Scope System','SaaS',
   'mock.isso2017@example.empire', TRUE,
   (SELECT opdiv_id FROM public.opdivs WHERE UPPER(code) = 'CMS' LIMIT 1),'Mock ISSO 2017')

--- a/backend/cmd/api/internal/controller/questions.go
+++ b/backend/cmd/api/internal/controller/questions.go
@@ -16,7 +16,9 @@ import (
 //	@Produce	json
 //	@Security	bearerAuth
 //	@Param		fismasystemid	path		int	true	"FISMA system ID"
+//	@Param		datacallid		query		int	false	"Apply the reduced-pillar rule for this data call; omitted returns the environment's full catalog"
 //	@Success	200				{object}	apiResponse[[]model.Question]
+//	@Failure	400				{object}	apiResponse[any]
 //	@Failure	404				{object}	apiResponse[any]
 //	@Failure	500				{object}	apiResponse[any]
 //	@Router		/fismasystems/{fismasystemid}/questions [get]
@@ -29,7 +31,14 @@ func ListFismaSystemQuestions(w http.ResponseWriter, r *http.Request) {
 		fmt.Sscan(v, &fismaSystemID)
 	}
 
-	questions, err := model.FindQuestionsByFismaSystem(r.Context(), fismaSystemID)
+	var questions []*model.Question
+	input := model.FindQuestionsByFismaSystemInput{}
+
+	err := decoder.Decode(&input, r.URL.Query())
+	if err == nil {
+		questions, err = model.FindQuestionsByFismaSystem(r.Context(), fismaSystemID, input)
+	}
+
 	respond(w, r, questions, err)
 }
 

--- a/backend/cmd/api/internal/migrations/0057reducedpillarscopes.go
+++ b/backend/cmd/api/internal/migrations/0057reducedpillarscopes.go
@@ -1,0 +1,55 @@
+package migrations
+
+func init() {
+	appendMigration(
+		"create reducedpillarscopes and seed the SaaS rule",
+		`
+-- The reduced-pillar rule as data (ztmf#545, ztmf-misc#289). A row means:
+-- systems scored under scoring_key exclude pillarid from every data call whose
+-- deadline is on or after the anchor call's deadline. The predicate that reads
+-- this table (reducedPillarScopeSQL in internal/model/pillarscope.go) is shared
+-- by the progress counts, the export, the scoring aggregate and the
+-- questionnaire, so a future reduced-scope environment is a row here, not a
+-- code change.
+--
+-- The anchor is a datacalls FK rather than a stored date so the boundary is an
+-- auditable reference to the cycle where the rule took effect, and so a
+-- mis-dated or FY26-named call created later cannot move it - the failure mode
+-- the interim name-prefix predicate this replaces had to defend against.
+-- ON DELETE CASCADE because a rule without its anchor is undefined; deleting a
+-- data call is already an admin-only destructive act and takes its rules along.
+CREATE TABLE reducedpillarscopes (
+    scoring_key          TEXT NOT NULL,
+    pillarid             INT  NOT NULL REFERENCES pillars(pillarid),
+    effective_datacallid INT  NOT NULL REFERENCES datacalls(datacallid) ON DELETE CASCADE,
+    PRIMARY KEY (scoring_key, pillarid)
+);
+
+-- Seed the SaaS rule: Devices and Applications leave scope from the FY26 cycle
+-- onward. The name-prefix lookup below is the LAST use of name matching: it
+-- runs once, here, to locate the anchor in the data each environment already
+-- has, mirroring the prefixes the interim predicate matched (both year forms,
+-- trimmed and uppercased). Earliest by (deadline, datacallid) is "the first
+-- FY26 cycle", the same choice the FY26 rollover hardcode pins.
+--
+-- An environment with no FY26-named call at migration time seeds nothing: the
+-- ephemeral local/test databases get their rule rows from the populate seed
+-- (_test_data_empire.sql), which owns the fixture cycles and runs after
+-- migrations; a deployed environment without the call gets the rule when the
+-- row is inserted alongside the cycle that needs it.
+INSERT INTO reducedpillarscopes (scoring_key, pillarid, effective_datacallid)
+SELECT 'SaaS', p.pillarid, anchor.datacallid
+FROM pillars p
+CROSS JOIN (
+    SELECT datacallid FROM datacalls
+     WHERE UPPER(TRIM(datacall)) LIKE 'FY2026%' OR UPPER(TRIM(datacall)) LIKE 'FY26%'
+     ORDER BY deadline ASC, datacallid ASC
+     LIMIT 1
+) anchor
+WHERE p.pillar IN ('Devices', 'Applications');
+`,
+		`
+DROP TABLE reducedpillarscopes;
+`,
+	)
+}

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -3112,3 +3112,134 @@ tests:
     method: GET
     expect:
       status: 401
+
+  # ==========================================================================
+  # Reduced pillar scope (ztmf#545 / ztmf-misc#289). MOCK-SAAS (2016) is the
+  # seeded SaaS fixture; 104 is the FY26 fixture cycle the seeded rule anchors
+  # on; 103 is the prior full-set cycle. The questionnaire endpoint serves the
+  # reduced set only when asked for an in-scope cycle, and the aggregate stops
+  # scoring the excluded pillars from the anchor cycle onward.
+  #
+  # Row order note: on seeded test databases pillars.ordr and questions.ordr
+  # are 0 (migration 0056 runs before the populate seed), so the questionnaire
+  # sorts by its questionid tiebreaker and the aggregate by pillarid - both of
+  # which happen to walk the fixture pillars as Devices, Applications,
+  # Networks, Data, CrossCutting, Identity.
+  # ==========================================================================
+
+  # Without a data call the environment's full catalog returns - the pre-#545
+  # contract the frontend's own filter expects. Exact array length: a 4-row
+  # response here means the reduction leaked into the unparameterized path.
+  - url: http://localhost:8080/api/v1/fismasystems/2016/questions
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - pillar:
+                pillar: "Devices"
+            - pillar:
+                pillar: "Applications"
+            - pillar:
+                pillar: "Networks"
+            - pillar:
+                pillar: "Data"
+            - pillar:
+                pillar: "CrossCutting"
+            - pillar:
+                pillar: "Identity"
+
+  # The anchor cycle serves the reduced set: Devices and Applications drop,
+  # order otherwise unchanged.
+  - url: http://localhost:8080/api/v1/fismasystems/2016/questions?datacallid=104
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - pillar:
+                pillar: "Networks"
+            - pillar:
+                pillar: "Data"
+            - pillar:
+                pillar: "CrossCutting"
+            - pillar:
+                pillar: "Identity"
+
+  # A cycle deadlined before the anchor keeps the full catalog.
+  - url: http://localhost:8080/api/v1/fismasystems/2016/questions?datacallid=103
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - pillar:
+                pillar: "Devices"
+            - pillar:
+                pillar: "Applications"
+            - pillar:
+                pillar: "Networks"
+            - pillar:
+                pillar: "Data"
+            - pillar:
+                pillar: "CrossCutting"
+            - pillar:
+                pillar: "Identity"
+
+  # Scoring: on the anchor cycle the aggregate carries exactly the four
+  # in-scope pillar scores, even though the seed leaves carried-forward
+  # answers on the excluded pillars. The prior cycle keeps all six.
+  - url: "http://localhost:8080/api/v1/scores/aggregate?fismasystemid=2016&datacallid=104&include_pillars=true"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - fismasystemid: 2016
+              datacallid: 104
+              pillarscores:
+                - pillar: "Networks"
+                - pillar: "Data"
+                - pillar: "CrossCutting"
+                - pillar: "Identity"
+
+  - url: "http://localhost:8080/api/v1/scores/aggregate?fismasystemid=2016&datacallid=103&include_pillars=true"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - fismasystemid: 2016
+              datacallid: 103
+              pillarscores:
+                - pillar: "Devices"
+                - pillar: "Applications"
+                - pillar: "Networks"
+                - pillar: "Data"
+                - pillar: "CrossCutting"
+                - pillar: "Identity"

--- a/backend/internal/model/answers.go
+++ b/backend/internal/model/answers.go
@@ -58,7 +58,7 @@ func FindAnswers(ctx context.Context, input FindAnswersInput) ([]*Answer, error)
 		// fresh one. The scoring key needs a subquery because no dce alias is in
 		// scope here.
 		Where(
-			saasPillarScopeSQL(
+			reducedPillarScopeSQL(
 				"(SELECT dcescope.scoring_key FROM datacenterenvironments dcescope WHERE dcescope.datacenterenvironment=fismasystems.datacenterenvironment)",
 				"pillars.pillar",
 				"?",

--- a/backend/internal/model/answers_integration_test.go
+++ b/backend/internal/model/answers_integration_test.go
@@ -199,9 +199,9 @@ func TestFindAnswersSaaSPillarScopeIntegration(t *testing.T) {
 
 	ctx := context.Background()
 
-	fy26, prior, ok := fy26AndPriorDataCalls(ctx, t)
+	fy26, prior, ok := reducedScopeAnchorAndPriorDataCalls(ctx, t)
 	if !ok {
-		t.Skip("database has no FY26 call with an earlier cycle to compare against")
+		t.Skip("database has no seeded reduced-scope rule with an earlier cycle to compare against")
 	}
 
 	conn, err := db.Conn(ctx)

--- a/backend/internal/model/ordering_integration_test.go
+++ b/backend/internal/model/ordering_integration_test.go
@@ -51,11 +51,11 @@ func TestFindQuestionsByFismaSystemOrderingIntegration(t *testing.T) {
 		LIMIT 1
 	`).Scan(&fismaSystemID), "seed must contain a system with a multi-pillar questionnaire")
 
-	first, err := FindQuestionsByFismaSystem(ctx, fismaSystemID)
+	first, err := FindQuestionsByFismaSystem(ctx, fismaSystemID, FindQuestionsByFismaSystemInput{})
 	require.NoError(t, err)
 	require.NotEmpty(t, first)
 
-	second, err := FindQuestionsByFismaSystem(ctx, fismaSystemID)
+	second, err := FindQuestionsByFismaSystem(ctx, fismaSystemID, FindQuestionsByFismaSystemInput{})
 	require.NoError(t, err)
 
 	require.Equal(t, questionOrderKeys(first), questionOrderKeys(second),

--- a/backend/internal/model/pillarscope.go
+++ b/backend/internal/model/pillarscope.go
@@ -2,70 +2,42 @@ package model
 
 import (
 	"fmt"
-	"strings"
 )
 
-// reducedPillarScopeCyclePrefixes identifies the cycle the reduced scope starts
-// at. Owned here rather than borrowed from rolloverHardcodeTargetPrefixes: that
-// slice sits inside the TEMPORARY HARD-CODE block ztmf#502 is queued to delete,
-// and depending on it from outside would have blocked that removal.
+// reducedPillarScopeSQL excludes the pillars a seeded rule removes from a
+// system's question set (ztmf#545, ztmf-misc#289). A reducedpillarscopes row
+// (scoring_key, pillarid, effective_datacallid) puts a pillar out of scope for
+// systems scored under that key, on every data call whose deadline is on or
+// after the anchor call's. Shared by the progress counts, the export, the
+// scoring aggregate and the questionnaire so they cannot disagree.
 //
-// INTERIM, and not a pattern to copy: matching a cycle by name is a stand-in for
-// data. ztmf#545 replaces this with a seeded rule carrying the effective data
-// call, at which point this variable and the name matching below both come out.
-var reducedPillarScopeCyclePrefixes = []string{"FY2026", "FY26"}
-
-// saasPillarScopeSQL excludes the Devices and Applications pillars for SaaS
-// systems from the FY26 cycle onward (ztmf-misc#289). Shared by the progress
-// counts and the export so they cannot disagree.
+// NOT EXISTS carries the NULL-safety the callers rely on: it never evaluates
+// to NULL, and a NULL scoring key (DECOMMISSIONED maps to NULL) fails the
+// equality inside the subquery, so the row is kept. Every caller puts this in
+// a WHERE or a JOIN ... ON, both of which read NULL as "drop the row".
 //
-// COALESCE on the scoring key is load-bearing: it is nullable (DECOMMISSIONED
-// maps to NULL), and NOT(NULL AND ...) is NULL, which a top-level WHERE treats as
-// false - silently dropping an excluded-pillar row for a non-SaaS system. Every
-// condition must resolve to true or false, never NULL, because callers put this in
-// both a WHERE and a JOIN ... ON.
+// The boundary is the seeded anchor's deadline, nothing else: a cycle created
+// later with a misleading name or date cannot move it, which is the hazard the
+// interim name-prefix predicate this replaces had to anchor on MAX(deadline)
+// to avoid. An unknown data-call id joins to nothing and falls open to the
+// full question set, matching how other endpoints treat unresolvable filters.
 //
-// A cycle is in scope when it is named FY26 or its deadline falls after every FY26
-// cycle. Deliberately not "deadline >= the earliest FY26 deadline": an FY26 call
-// mis-dated before a closed cycle would drag that closed cycle into scope and
-// restate it. Names are trimmed and uppercased before matching.
-//
-// Not scoped by OpDiv yet: CMS is expected to keep all 40, but the frontend filter
-// is OpDiv-blind, so exempting CMS here alone would leave those systems unable to
-// answer the 15 questions a 40 denominator demands. When confirmed, add alongside
-// the frontend change:
-//
-//	AND EXISTS (SELECT 1 FROM opdivs o WHERE o.opdiv_id = <system>.opdiv_id AND UPPER(o.code) <> 'CMS')
-//
-// Arguments are SQL expressions valid in the caller's scope. dataCallExpr is the
-// placeholder for the call being read ("$3" hand-built, "?" via squirrel).
-func saasPillarScopeSQL(scoringKeyExpr, pillarExpr, dataCallExpr string) string {
-	prefixCond := func(alias string) string {
-		conds := make([]string, len(reducedPillarScopeCyclePrefixes))
-		for i, prefix := range reducedPillarScopeCyclePrefixes {
-			conds[i] = fmt.Sprintf("UPPER(TRIM(%s.datacall)) LIKE '%s%%'", alias, prefix)
-		}
-		return strings.Join(conds, " OR ")
-	}
-
-	return fmt.Sprintf(`NOT (
-          COALESCE(%s, '') = 'SaaS'
-          AND %s IN ('Devices', 'Applications')
-          AND EXISTS (
-              SELECT 1 FROM datacalls tdc
-              WHERE tdc.datacallid = %s
-                AND (
-                    (%s)
-                    OR tdc.deadline > (
-                        SELECT MAX(fdc.deadline) FROM datacalls fdc WHERE %s
-                    )
-                )
-          )
+// Arguments are SQL expressions valid in the caller's scope. dataCallExpr is
+// the placeholder or column for the call being read ("$3" hand-built, "?" via
+// squirrel, "sp.datacallid" inside a CTE).
+func reducedPillarScopeSQL(scoringKeyExpr, pillarExpr, dataCallExpr string) string {
+	return fmt.Sprintf(`NOT EXISTS (
+          SELECT 1
+          FROM reducedpillarscopes rps
+          INNER JOIN pillars rp ON rp.pillarid = rps.pillarid
+          INNER JOIN datacalls eff ON eff.datacallid = rps.effective_datacallid
+          INNER JOIN datacalls tdc ON tdc.datacallid = %s
+          WHERE rps.scoring_key = %s
+            AND rp.pillar = %s
+            AND tdc.deadline >= eff.deadline
       )`,
+		dataCallExpr,
 		scoringKeyExpr,
 		pillarExpr,
-		dataCallExpr,
-		prefixCond("tdc"),
-		prefixCond("fdc"),
 	)
 }

--- a/backend/internal/model/pillarscope_integration_test.go
+++ b/backend/internal/model/pillarscope_integration_test.go
@@ -9,68 +9,82 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSaaSPillarScopeNullSafetyIntegration evaluates the predicate in real
-// Postgres, because its correctness rests on three-valued logic that no
-// string assertion can pin: a NULL scoring key must yield FALSE (row kept), not
-// NULL, which a top-level WHERE would read as "drop".
+// TestReducedPillarScopeNullSafetyIntegration evaluates the predicate in real
+// Postgres, because its correctness rests on three-valued logic that no string
+// assertion can pin: a NULL scoring key must yield TRUE (row kept), never NULL,
+// which a top-level WHERE would read as "drop". NOT EXISTS provides that by
+// construction, and this test is what fails if a refactor trades it away.
 //
 // The regression this guards: scoring_key is nullable (DECOMMISSIONED maps to
 // NULL) and FindAnswers deliberately still exports decommissioned systems that
-// carry scores, so a NULL key used to silently remove 15 Devices/Applications
+// carry scores, so a NULL key mishandled here silently removes excluded-pillar
 // rows from a compliance export - on a non-SaaS system.
 //
 // Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
 // `go test -short`.
-func TestSaaSPillarScopeNullSafetyIntegration(t *testing.T) {
+func TestReducedPillarScopeNullSafetyIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping database integration test")
 	}
 
 	ctx := context.Background()
 
-	fy26, prior, ok := fy26AndPriorDataCalls(ctx, t)
+	anchor, prior, ok := reducedScopeAnchorAndPriorDataCalls(ctx, t)
 	if !ok {
-		t.Skip("database has no FY26 call with an earlier cycle to compare against")
+		t.Skip("database has no seeded reduced-scope rule with an earlier cycle to compare against")
 	}
 
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err, "DB connection required for integration test; ensure DB_* env vars are set")
 	defer conn.Release()
 
-	// kept == true means the row survives, i.e. the full 40.
+	// kept == true means the row survives, i.e. the full question set.
 	kept := func(t *testing.T, scoringKeyExpr, pillarExpr string, dataCallID int32) bool {
 		t.Helper()
 		var result *bool
 		require.NoError(t, conn.QueryRow(ctx,
-			`SELECT `+saasPillarScopeSQL(scoringKeyExpr, pillarExpr, "$1"), dataCallID,
+			`SELECT `+reducedPillarScopeSQL(scoringKeyExpr, pillarExpr, "$1"), dataCallID,
 		).Scan(&result))
 		require.NotNil(t, result, "the predicate must never evaluate to NULL: a WHERE would drop the row and a JOIN ... ON would too")
 		return *result
 	}
 
+	t.Run("SeededRuleRowsPresent", func(t *testing.T) {
+		// Pins the seed wiring end to end: migration 0057 creates the table, and
+		// either its name-lookup (deployed envs) or the populate seed (local/test
+		// envs) provides exactly the two SaaS rows the rest of this test relies on.
+		var n int
+		require.NoError(t, conn.QueryRow(ctx, `
+			SELECT COUNT(*) FROM reducedpillarscopes rps
+			INNER JOIN pillars p ON p.pillarid = rps.pillarid
+			WHERE rps.scoring_key = 'SaaS' AND p.pillar IN ('Devices', 'Applications')
+		`).Scan(&n))
+		assert.Equal(t, 2, n, "the SaaS rule is two rows: Devices and Applications")
+	})
+
 	t.Run("NullScoringKeyKeepsEveryPillar", func(t *testing.T) {
-		assert.True(t, kept(t, "NULL::varchar", "'Devices'", fy26),
+		assert.True(t, kept(t, "NULL::varchar", "'Devices'", anchor),
 			"a system with no scoring key is not SaaS and must keep Devices")
-		assert.True(t, kept(t, "NULL::varchar", "'Applications'", fy26),
+		assert.True(t, kept(t, "NULL::varchar", "'Applications'", anchor),
 			"a system with no scoring key is not SaaS and must keep Applications")
 	})
 
 	t.Run("SaaSDropsOnlyTheExcludedPillars", func(t *testing.T) {
-		assert.False(t, kept(t, "'SaaS'", "'Devices'", fy26))
-		assert.False(t, kept(t, "'SaaS'", "'Applications'", fy26))
-		assert.True(t, kept(t, "'SaaS'", "'Identity'", fy26))
-		assert.True(t, kept(t, "'SaaS'", "'CrossCutting'", fy26))
+		assert.False(t, kept(t, "'SaaS'", "'Devices'", anchor))
+		assert.False(t, kept(t, "'SaaS'", "'Applications'", anchor))
+		assert.True(t, kept(t, "'SaaS'", "'Identity'", anchor))
+		assert.True(t, kept(t, "'SaaS'", "'CrossCutting'", anchor))
 	})
 
 	t.Run("OtherEnvironmentsAndPriorCyclesKeepEverything", func(t *testing.T) {
-		assert.True(t, kept(t, "'AWS'", "'Devices'", fy26),
-			"the scope is SaaS-only")
+		assert.True(t, kept(t, "'AWS'", "'Devices'", anchor),
+			"only environments with a rule row are reduced")
 		assert.True(t, kept(t, "'SaaS'", "'Devices'", prior),
-			"cycles earlier than FY26 keep the full question set")
+			"cycles deadlined before the anchor keep the full question set")
 	})
 
 	t.Run("UnknownDataCallFallsBackToTheFullSet", func(t *testing.T) {
 		assert.True(t, kept(t, "'SaaS'", "'Devices'", -1),
-			"an unresolvable cycle must fail open to 40, never NULL")
+			"an unresolvable cycle must fail open to the full set, never NULL")
 	})
 }

--- a/backend/internal/model/pillarscope_test.go
+++ b/backend/internal/model/pillarscope_test.go
@@ -7,40 +7,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSaaSPillarScopeSQL_Shape(t *testing.T) {
-	sql := saasPillarScopeSQL("dce.scoring_key", "p.pillar", "$3")
+func TestReducedPillarScopeSQL_Shape(t *testing.T) {
+	sql := reducedPillarScopeSQL("dce.scoring_key", "p.pillar", "$3")
 
-	// A nullable scoring key must not make the whole predicate NULL: a top-level
-	// WHERE reads NULL as false and would drop an excluded-pillar row for a
-	// non-SaaS system (DECOMMISSIONED maps to scoring_key NULL).
-	assert.Contains(t, sql, "COALESCE(dce.scoring_key, '') = 'SaaS'",
-		"the scoring key is nullable, so the comparison must be NULL-safe")
+	// NOT EXISTS can never evaluate to NULL, which is what protects the
+	// nullable scoring key (DECOMMISSIONED maps to NULL): a top-level WHERE
+	// reads NULL as false and would drop an excluded-pillar row for a non-SaaS
+	// system. The three-valued behavior itself is pinned in Postgres by
+	// TestReducedPillarScopeNullSafetyIntegration.
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(sql), "NOT EXISTS ("),
+		"callers append this after AND, so it must be a single never-NULL parenthesized term")
 
-	// In scope when named FY26 or dated after every FY26 cycle - never "at or
-	// after the earliest FY26 deadline", which a mis-dated FY26 call would use to
-	// drag a closed cycle into scope.
-	assert.Contains(t, sql, "SELECT MAX(fdc.deadline) FROM datacalls fdc",
-		"the cycle gate anchors on the LAST FY26 deadline")
-	assert.NotContains(t, sql, "MIN(fdc.deadline)",
-		"an earliest-deadline anchor would restate closed cycles")
-	assert.Contains(t, sql, "tdc.deadline >", "later cycles are in scope by deadline")
+	// In scope at or after the seeded anchor's deadline. >= includes the anchor
+	// cycle itself.
+	assert.Contains(t, sql, "tdc.deadline >= eff.deadline",
+		"the anchor cycle and everything after it are in scope")
 
-	// Names are matched the way matchesRolloverHardcodeTarget does.
-	assert.Equal(t, 2, strings.Count(sql, "UPPER(TRIM(tdc.datacall)) LIKE 'FY2026%'")+
-		strings.Count(sql, "UPPER(TRIM(fdc.datacall)) LIKE 'FY2026%'"),
-		"both the target and the anchor must trim and upper the name")
-
-	// EXISTS, so a database with no FY26 cycle yields false rather than NULL.
-	assert.Contains(t, sql, "EXISTS (")
-	assert.True(t, strings.HasPrefix(strings.TrimSpace(sql), "NOT ("),
-		"callers append this after AND, so it must be a single parenthesized term")
+	// The rule is data (ztmf#545): no cycle names, environments, or pillars may
+	// be compiled in.
+	assert.Contains(t, sql, "FROM reducedpillarscopes")
+	assert.NotContains(t, sql, "LIKE", "name matching came out with the interim predicate")
+	assert.NotContains(t, sql, "FY26", "no cycle name may be hardcoded; the anchor is a seeded row")
+	assert.NotContains(t, sql, "'SaaS'", "no environment may be hardcoded; the rule rows carry it")
+	assert.NotContains(t, sql, "'Devices'", "no pillar may be hardcoded; the rule rows carry it")
 }
 
-func TestSaaSPillarScopeSQL_UsesCallerExpressions(t *testing.T) {
-	sql := saasPillarScopeSQL("(SELECT x FROM y)", "pillars.pillar", "?")
+func TestReducedPillarScopeSQL_UsesCallerExpressions(t *testing.T) {
+	sql := reducedPillarScopeSQL("(SELECT x FROM y)", "pillars.pillar", "?")
 
-	assert.Contains(t, sql, "COALESCE((SELECT x FROM y), '') = 'SaaS'")
-	assert.Contains(t, sql, "pillars.pillar IN ('Devices', 'Applications')")
+	assert.Contains(t, sql, "rps.scoring_key = (SELECT x FROM y)")
+	assert.Contains(t, sql, "rp.pillar = pillars.pillar")
 	assert.Contains(t, sql, "tdc.datacallid = ?")
 	assert.NotContains(t, sql, "dce.scoring_key",
 		"no alias may be hardcoded; the export has no dce in scope")

--- a/backend/internal/model/questions.go
+++ b/backend/internal/model/questions.go
@@ -76,9 +76,20 @@ func FindQuestionByID(ctx context.Context, questionID int32) (*Question, error) 
 	return queryRow(ctx, sqlb, pgx.RowToStructByNameLax[Question])
 }
 
+// FindQuestionsByFismaSystemInput carries the optional query filters for the
+// nested questions listing.
+type FindQuestionsByFismaSystemInput struct {
+	// DataCallID applies the reduced-pillar rule for the cycle being answered
+	// (ztmf#545): questions on a pillar a seeded rule excludes for this
+	// system's environment are omitted. Absent, the full catalog for the
+	// environment is returned, which is the pre-#545 contract the frontend's
+	// own pillar filter still expects.
+	DataCallID *int32 `schema:"datacallid"`
+}
+
 // FindQuestionsByFismaSystem joins questions with functions to return questions relevant to the fismasystem as determined by the datacenterenvironment.
 // It is used by all users to list questions relevant to the specified fisma system
-func FindQuestionsByFismaSystem(ctx context.Context, fismaSystemID int32) ([]*Question, error) {
+func FindQuestionsByFismaSystem(ctx context.Context, fismaSystemID int32, input FindQuestionsByFismaSystemInput) ([]*Question, error) {
 	// The system's raw datacenterenvironment is resolved to a scoring vocabulary
 	// through the datacenterenvironments mapping (ztmf#392); functions are matched
 	// on that key. This is the same indirection the scoring aggregate uses, so the
@@ -94,6 +105,10 @@ func FindQuestionsByFismaSystem(ctx context.Context, fismaSystemID int32) ([]*Qu
 		// migration 0056 found no canonical rank) still list deterministically
 		// rather than in heap order. See FindAnswers for the same tiebreaker.
 		OrderBy("pillars.ordr, questions.ordr, questions.questionid ASC")
+
+	if input.DataCallID != nil {
+		sqlb = sqlb.Where(reducedPillarScopeSQL("dce.scoring_key", "pillars.pillar", "?"), *input.DataCallID)
+	}
 
 	return query(ctx, sqlb, func(row pgx.CollectableRow) (*Question, error) {
 		q := Question{

--- a/backend/internal/model/questions_integration_test.go
+++ b/backend/internal/model/questions_integration_test.go
@@ -1,0 +1,106 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindQuestionsByFismaSystemReducedScopeIntegration pins ztmf#545's
+// questionnaire contract in real Postgres: with a data call supplied, questions
+// on a pillar the seeded rule excludes are omitted from the anchor cycle
+// onward; without one, or for cycles before the anchor, the environment's full
+// catalog is returned unchanged (the pre-#545 contract the frontend's own
+// pillar filter still expects).
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindQuestionsByFismaSystemReducedScopeIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+
+	anchor, prior, ok := reducedScopeAnchorAndPriorDataCalls(ctx, t)
+	if !ok {
+		t.Skip("database has no seeded reduced-scope rule with an earlier cycle to compare against")
+	}
+
+	systemID, found := findSystemIDByAcronym(ctx, t, "MOCK-SAAS")
+	if !found {
+		t.Skip("fixture system MOCK-SAAS not seeded")
+	}
+
+	questionsFor := func(t *testing.T, systemID int32, dataCallID *int32) []*Question {
+		t.Helper()
+		qs, err := FindQuestionsByFismaSystem(ctx, systemID, FindQuestionsByFismaSystemInput{DataCallID: dataCallID})
+		require.NoError(t, err)
+		require.NotEmpty(t, qs)
+		return qs
+	}
+
+	countOnExcludedPillars := func(qs []*Question) int {
+		n := 0
+		for _, q := range qs {
+			if q.Pillar.Pillar == "Devices" || q.Pillar.Pillar == "Applications" {
+				n++
+			}
+		}
+		return n
+	}
+
+	baseline := questionsFor(t, systemID, nil)
+	require.Positive(t, countOnExcludedPillars(baseline),
+		"the fixture catalog must have questions on the excluded pillars, or this test proves nothing")
+
+	t.Run("NoDataCallKeepsTheFullCatalog", func(t *testing.T) {
+		// baseline above IS the assertion: the nil path returned excluded-pillar
+		// questions, so the endpoint without the param is byte-compatible with
+		// the pre-#545 contract.
+		assert.Positive(t, countOnExcludedPillars(baseline))
+	})
+
+	t.Run("AnchorCycleServesTheReducedSet", func(t *testing.T) {
+		reduced := questionsFor(t, systemID, &anchor)
+		assert.Zero(t, countOnExcludedPillars(reduced),
+			"questions on an excluded pillar must not be served for the anchor cycle")
+		assert.Len(t, reduced, len(baseline)-countOnExcludedPillars(baseline),
+			"exactly the excluded pillars' questions drop; everything else stays")
+	})
+
+	t.Run("PriorCycleKeepsTheFullCatalog", func(t *testing.T) {
+		full := questionsFor(t, systemID, &prior)
+		assert.Len(t, full, len(baseline),
+			"cycles deadlined before the anchor keep the full question set")
+		assert.Positive(t, countOnExcludedPillars(full))
+	})
+
+	t.Run("OtherEnvironmentsUnreducedOnTheAnchorCycle", func(t *testing.T) {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Release()
+
+		// Any system scored under a key with no rule row serves as the control.
+		var controlID int32
+		err = conn.QueryRow(ctx, `
+			SELECT fs.fismasystemid
+			FROM fismasystems fs
+			INNER JOIN datacenterenvironments dce ON dce.datacenterenvironment = fs.datacenterenvironment
+			WHERE dce.scoring_key IS NOT NULL
+			  AND dce.scoring_key NOT IN (SELECT scoring_key FROM reducedpillarscopes)
+			ORDER BY fs.fismasystemid LIMIT 1
+		`).Scan(&controlID)
+		if err != nil {
+			t.Skip("no non-reduced system to use as a control")
+		}
+
+		ctrlBaseline := questionsFor(t, controlID, nil)
+		ctrlOnAnchor := questionsFor(t, controlID, &anchor)
+		assert.Len(t, ctrlOnAnchor, len(ctrlBaseline),
+			"a system without a rule row keeps its full catalog on the anchor cycle")
+	})
+}

--- a/backend/internal/model/scoreprogress.go
+++ b/backend/internal/model/scoreprogress.go
@@ -178,10 +178,10 @@ func buildScoreProgressSQL(input FindScoreProgressInput) (string, []any) {
 	// applicability join). COUNT(DISTINCT) on all guards against fan-out from
 	// the environment mapping.
 	//
-	// The SaaS pillar scope belongs to that shared set, so it is rendered once and
-	// interpolated into BOTH CTEs. In expected's alone it would leave a numerator
-	// of 40 against a denominator of 25, reporting a false "Complete".
-	pillarScope := saasPillarScopeSQL("dce.scoring_key", "p.pillar", fmt.Sprintf("$%d", dataCallArg))
+	// The reduced pillar scope belongs to that shared set, so it is rendered once
+	// and interpolated into BOTH CTEs. In expected's alone it would leave a
+	// numerator of 40 against a denominator of 25, reporting a false "Complete".
+	pillarScope := reducedPillarScopeSQL("dce.scoring_key", "p.pillar", fmt.Sprintf("$%d", dataCallArg))
 
 	sql := fmt.Sprintf(`
 WITH scoped_systems AS (

--- a/backend/internal/model/scoreprogress_integration_test.go
+++ b/backend/internal/model/scoreprogress_integration_test.go
@@ -574,31 +574,32 @@ func saasScopeFixture(ctx context.Context, t *testing.T, cms bool) (systemID, in
 	return systemID, inScope, outOfScope, true
 }
 
-// fy26AndPriorDataCalls returns the earliest FY26-prefixed call (where the
-// reduced scope starts) and one with a strictly earlier deadline.
-func fy26AndPriorDataCalls(ctx context.Context, t *testing.T) (fy26, prior int32, ok bool) {
+// reducedScopeAnchorAndPriorDataCalls returns the earliest seeded anchor call
+// (where the reduced scope starts, per the reducedpillarscopes table) and one
+// with a strictly earlier deadline.
+func reducedScopeAnchorAndPriorDataCalls(ctx context.Context, t *testing.T) (anchor, prior int32, ok bool) {
 	t.Helper()
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
 	defer conn.Release()
 
-	var fy26Deadline time.Time
+	var anchorDeadline time.Time
 	err = conn.QueryRow(ctx, `
-		SELECT datacallid, deadline FROM datacalls
-		 WHERE UPPER(datacall) LIKE 'FY2026%' OR UPPER(datacall) LIKE 'FY26%'
-		 ORDER BY deadline ASC, datacallid ASC LIMIT 1
-	`).Scan(&fy26, &fy26Deadline)
+		SELECT dc.datacallid, dc.deadline FROM datacalls dc
+		 WHERE dc.datacallid IN (SELECT effective_datacallid FROM reducedpillarscopes)
+		 ORDER BY dc.deadline ASC, dc.datacallid ASC LIMIT 1
+	`).Scan(&anchor, &anchorDeadline)
 	if err != nil {
 		return 0, 0, false
 	}
 
 	err = conn.QueryRow(ctx, `
 		SELECT datacallid FROM datacalls WHERE deadline < $1 ORDER BY deadline DESC LIMIT 1
-	`, fy26Deadline).Scan(&prior)
+	`, anchorDeadline).Scan(&prior)
 	if err != nil {
-		return fy26, 0, false
+		return anchor, 0, false
 	}
-	return fy26, prior, true
+	return anchor, prior, true
 }
 
 // TestFindScoreProgressSaaSScopeIntegration pins the SaaS scope (ztmf-misc#289)
@@ -615,9 +616,9 @@ func TestFindScoreProgressSaaSScopeIntegration(t *testing.T) {
 
 	ctx := context.Background()
 
-	fy26, prior, haveCalls := fy26AndPriorDataCalls(ctx, t)
+	fy26, prior, haveCalls := reducedScopeAnchorAndPriorDataCalls(ctx, t)
 	if !haveCalls {
-		t.Skip("database has no FY26 call with an earlier cycle to compare against")
+		t.Skip("database has no seeded reduced-scope rule with an earlier cycle to compare against")
 	}
 
 	t.Run("NonCMSReducedOnCurrentCycle", func(t *testing.T) {
@@ -661,9 +662,10 @@ func TestFindScoreProgressSaaSScopeIntegration(t *testing.T) {
 			"a cycle earlier than FY26 must keep reporting against the full question set")
 	})
 
-	// CMS is not exempt yet (see saasPillarScopeSQL). Pinned so re-adding the
-	// OpDiv gate has to change a test rather than silently flip 11 systems.
-	t.Run("CMSAlsoReducedWhileExemptionIsUndecided", func(t *testing.T) {
+	// CMS follows every other OpDiv: no exemption, decision recorded on
+	// ztmf-misc#289 (2026-08-11). Pinned so an OpDiv gate cannot sneak back in
+	// without changing a test.
+	t.Run("CMSReducedLikeEveryOtherOpDiv", func(t *testing.T) {
 		systemID, inScope, _, ok := saasScopeFixture(ctx, t, true)
 		if !ok {
 			t.Skip("no CMS SaaS system with Devices/Applications functions")
@@ -677,6 +679,6 @@ func TestFindScoreProgressSaaSScopeIntegration(t *testing.T) {
 		require.Len(t, rows, 1)
 
 		assert.Equal(t, inScope, rows[0].QuestionsExpected,
-			"until CMS confirms, its denominator matches what the OpDiv-blind frontend asks")
+			"CMS is not exempt; its denominator matches every other OpDiv's")
 	})
 }

--- a/backend/internal/model/scoreprogress_test.go
+++ b/backend/internal/model/scoreprogress_test.go
@@ -74,12 +74,12 @@ func TestBuildScoreProgressSQL_Shape(t *testing.T) {
 
 	// Both count halves, never one: in expected's alone a SaaS denominator of 25
 	// would face a numerator of 40, reporting a false "Complete" on a closed call.
-	assert.Equal(t, 2, strings.Count(sql, "p.pillar IN ('Devices', 'Applications')"),
-		"the SaaS pillar scope (ztmf-misc#289) must appear in both the expected and updated CTEs")
-	assert.Equal(t, 2, strings.Count(sql, "SELECT MAX(fdc.deadline) FROM datacalls fdc"),
-		"the scope applies from FY26 onward only; closed cycles keep reporting against 40")
-	assert.Equal(t, 2, strings.Count(sql, "UPPER(TRIM(fdc.datacall)) LIKE 'FY2026%'"),
-		"the FY26 anchor must come from reducedPillarScopeCyclePrefixes, not the ztmf#502 rollover block")
+	assert.Equal(t, 2, strings.Count(sql, "FROM reducedpillarscopes"),
+		"the reduced pillar scope (ztmf-misc#289) must appear in both the expected and updated CTEs")
+	assert.Equal(t, 2, strings.Count(sql, "tdc.deadline >= eff.deadline"),
+		"the scope applies from the seeded anchor onward only; closed cycles keep reporting against the full set")
+	assert.NotContains(t, sql, "LIKE",
+		"the anchor is a seeded rule (ztmf#545), never a cycle-name match")
 	assert.NotContains(t, sql, "tdc.datacallid >=",
 		"the cycle comparison must be on deadline, not datacallid - ids are not chronological")
 

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -859,6 +859,15 @@ func buildPillarScoresSQL(input FindScoresInput) (string, []any) {
 		argN++
 	}
 
+	// Reduced pillar scope (ztmf#545): pillars a seeded rule excludes never
+	// enter the expected set, so a reduced system's pillar_scores rows simply
+	// don't exist for them and the system score's window AVG divides by the
+	// pillars that remain. Carried-forward answers on an excluded pillar stop
+	// counting too, because the answers CTE is only read through the LEFT JOIN
+	// from expected. Cycles deadlined before the rule's anchor keep every
+	// pillar, so closed calls are untouched.
+	conds = append(conds, reducedPillarScopeSQL("dce.scoring_key", "p.pillar", "sp.datacallid"))
+
 	var userJoin string
 	if input.UserID != nil {
 		userJoin = fmt.Sprintf("INNER JOIN users_fismasystems ufs ON ufs.fismasystemid = fs.fismasystemid AND ufs.userid = $%d", argN)

--- a/backend/internal/model/scores_reducedscope_integration_test.go
+++ b/backend/internal/model/scores_reducedscope_integration_test.go
@@ -1,0 +1,108 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findSystemIDByAcronym resolves a seeded fixture system. Discovery + skip
+// rather than a hardcoded id, matching saasScopeFixture: the test pins the
+// rule, not the seed file's numbering.
+func findSystemIDByAcronym(ctx context.Context, t *testing.T, acronym string) (int32, bool) {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	var id int32
+	if err := conn.QueryRow(ctx,
+		`SELECT fismasystemid FROM fismasystems WHERE fismaacronym = $1`, acronym,
+	).Scan(&id); err != nil {
+		return 0, false
+	}
+	return id, true
+}
+
+// TestFindScoresAggregateReducedScopeIntegration pins ztmf#545's scoring
+// contract in real Postgres: from the seeded anchor cycle onward a reduced
+// system carries no pillar score for the excluded pillars and its system score
+// averages over the pillars that remain, while cycles before the anchor keep
+// every pillar. The fixture deliberately carries FY26 answers on the excluded
+// pillars (carried forward as 'not_started'), so this also proves those
+// answers stop counting rather than resurfacing through the answers CTE.
+//
+// Requires DB_* env vars pointing at a seeded ZTMF database. Skipped under
+// `go test -short`.
+func TestFindScoresAggregateReducedScopeIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+
+	ctx := context.Background()
+
+	anchor, prior, ok := reducedScopeAnchorAndPriorDataCalls(ctx, t)
+	if !ok {
+		t.Skip("database has no seeded reduced-scope rule with an earlier cycle to compare against")
+	}
+
+	aggregateFor := func(t *testing.T, systemID, dataCallID int32) *ScoreAggregate {
+		t.Helper()
+		aggs, err := FindScoresAggregate(ctx, FindScoresInput{
+			DataCallID:     &dataCallID,
+			FismaSystemID:  &systemID,
+			IncludePillars: boolPtr(true),
+		})
+		require.NoError(t, err)
+		require.Len(t, aggs, 1, "one aggregate per (datacall, system) pair")
+		require.NotEmpty(t, aggs[0].PillarScores)
+		return aggs[0]
+	}
+
+	pillarNames := func(a *ScoreAggregate) []string {
+		names := make([]string, 0, len(a.PillarScores))
+		for _, p := range a.PillarScores {
+			names = append(names, p.Pillar)
+		}
+		return names
+	}
+
+	// The CMS twin asserts the ztmf-misc#289 decision (2026-08-11): CMS follows
+	// every other OpDiv, so both fixtures must behave identically.
+	for name, acronym := range map[string]string{
+		"NonCMS":                        "MOCK-SAAS",
+		"CMSReducedLikeEveryOtherOpDiv": "MOCK-SAAS-CMS",
+	} {
+		t.Run(name, func(t *testing.T) {
+			systemID, found := findSystemIDByAcronym(ctx, t, acronym)
+			if !found {
+				t.Skipf("fixture system %s not seeded", acronym)
+			}
+
+			onPrior := aggregateFor(t, systemID, prior)
+			assert.Contains(t, pillarNames(onPrior), "Devices",
+				"cycles before the anchor keep every pillar")
+			assert.Contains(t, pillarNames(onPrior), "Applications")
+
+			onAnchor := aggregateFor(t, systemID, anchor)
+			assert.NotContains(t, pillarNames(onAnchor), "Devices",
+				"an excluded pillar must not carry a score from the anchor cycle onward, even with carried-forward answers present")
+			assert.NotContains(t, pillarNames(onAnchor), "Applications")
+			assert.Len(t, onAnchor.PillarScores, len(onPrior.PillarScores)-2,
+				"exactly the two excluded pillars drop; the rest remain")
+
+			// The system score is the average of the pillars present - the
+			// existing divisor-follows-the-pillar-count contract, now over 4.
+			sum := 0.0
+			for _, p := range onAnchor.PillarScores {
+				sum += p.Score
+			}
+			assert.InDelta(t, sum/float64(len(onAnchor.PillarScores)), onAnchor.SystemScore, 1e-9,
+				"the system score must average only the in-scope pillars")
+			assert.Equal(t, Tier(onAnchor.SystemScore), onAnchor.SystemTier)
+		})
+	}
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1876,6 +1876,12 @@ paths:
         required: true
         schema:
           type: integer
+      - description: Apply the reduced-pillar rule for this data call; omitted returns
+          the environment's full catalog
+        in: query
+        name: datacallid
+        schema:
+          type: integer
       responses:
         "200":
           content:
@@ -1883,6 +1889,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/controller.apiResponse-array_model_Question'
           description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
         "404":
           content:
             application/json:


### PR DESCRIPTION
Closes #545. Phase 2 of CMS-Enterprise/ztmf-misc#289.

## What

The reduced-pillar rule moves from a name-matching SQL literal into a seeded table, and the two consumers #546 deliberately left untouched now honor it. Migration 0057 creates `reducedpillarscopes` (scoring_key, pillarid, effective_datacallid): a row excludes that pillar for systems scored under that key, on every data call whose deadline is on or after the anchor call's. The shared predicate now reads the table, so the progress counts, the export, the scoring aggregate and the questionnaire resolve the same rule from the same rows, and a future reduced-scope environment is an INSERT, not a code change.

Scoring: the aggregate's expected CTE applies the predicate, so an excluded pillar produces no pillar score and the system score averages the pillars that remain (the divisor already followed the actual pillar count). Carried-forward answers on excluded pillars stop counting because the answers CTE is only read through the join from expected.

Questionnaire: `GET /fismasystems/{id}/questions` accepts an optional `datacallid` and serves the reduced set for in-scope cycles, so the frontend can delete its client-side pillar filter (tracked separately in ztmf-ui). Without the param the response is byte-identical to today, which keeps the current frontend correct until it passes the param.

Seeding: in deployed environments migration 0057 locates the FY26 anchor by the same name prefixes the interim predicate matched, once, at migration time; after that the rule is pure data. The ephemeral local/test databases get their rule rows from the empire seed, which owns the fixture cycles and runs after migrations. A deployed environment with no FY26-named call at migration time seeds nothing and keeps the full set until a rule row is inserted alongside the cycle that needs it; that environment-dependence is inherent to rule-as-data and deliberate.

Per the decision recorded on ztmf-misc#289 (2026-08-11), CMS is not exempt and there is no OpDiv awareness anywhere in this change. The interim `CMSAlsoReducedWhileExemptionIsUndecided` pin is renamed to assert the now-permanent behavior.

## Visible behavior changes

`/scores/aggregate` returns four pillar entries and a four-pillar system score for SaaS systems on FY26-onward cycles. Roughly 113 SaaS systems' current scores and tiers move when this deploys mid-call, so it needs a low-traffic window and a heads-up before it ships (flagged on #545). The questionnaire endpoint changes only when the new param is passed. Progress and export behavior is unchanged, now sourced from the seeded table instead of name matching.

## Acceptance criteria

- [x] The reduced-pillar rule is seeded data, not a SQL literal or a frontend constant. No cycle name, environment, or pillar is compiled in; pinned by the shape tests.
- [x] FY26-onward reduced-scope systems carry no Devices or Applications pillar scores. Integration-pinned for the SaaS fixture and its CMS twin, with carried-forward excluded answers present.
- [x] The questionnaire endpoint returns the reduced set for reduced-scope systems and the full set for everything else, keyed by the new optional `datacallid` param.
- [x] Closed data calls are unchanged: pillar scores, system scores, tiers, exports, and question sets all pinned on a pre-anchor cycle.
- [x] Emberfall updated for the changed API contracts (five new pinned cases).

## Testing

`make test-unit`, `make test-integration`, and `make test-e2e` all green locally (e2e: 206 ran, 0 failed, 0 skipped). New integration coverage: aggregate reduction, questionnaire reduction with and without the param plus a non-reduced control system, and a pin that the seed wiring produced exactly the two SaaS rule rows. `openapi.yaml` regenerated via `make generate-openapi`; redocly lint valid.
