### PR TITLE
fix: declare CloudFront price class and assert it

### DIFF
--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -243,6 +243,12 @@ resource "aws_cloudfront_distribution" "ztmf" {
     error_caching_min_ttl = 10
   }
 
+  // Declared rather than inherited: the provider does default this to
+  // PriceClass_All, but that default is undocumented in the registry and lives
+  // only in the SDK schema, so leaving it implicit makes the effective value
+  // invisible here and dependent on an upstream choice we do not control.
+  price_class = "PriceClass_All"
+
   restrictions {
     geo_restriction {
       restriction_type = "whitelist"
@@ -255,5 +261,15 @@ resource "aws_cloudfront_distribution" "ztmf" {
     acm_certificate_arn      = local.ztmf_acm_certificate_arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  // Assert the value above rather than trusting the literal to survive future
+  // edits. The postcondition evaluates against refreshed state, so it also
+  // catches an out-of-band change, not just a bad diff.
+  lifecycle {
+    postcondition {
+      condition     = self.price_class == "PriceClass_All"
+      error_message = "CloudFront price_class must be PriceClass_All."
+    }
   }
 }


### PR DESCRIPTION
## What

Declares `price_class` on the CloudFront distribution and adds a `lifecycle` postcondition asserting it. Two additions, twelve lines, no other change.

## Why

`price_class` was inherited from the AWS provider's schema default rather than declared. That default is not stated in the provider's published argument reference — it exists only in the SDK schema — so the effective value was implicit and dependent on an upstream choice, while `terraform.tf` permits any 5.x minor.

Declared as a literal rather than a variable so the value is identical in every environment. Placed adjacent to `restrictions` to match the canonical example in the registry docs.

The postcondition evaluates against refreshed state during `plan`, so it catches an out-of-band change as well as a bad diff, and it fails at plan time rather than at apply.

## Verification

- `terraform plan` against dev reports `No changes. Your infrastructure matches the configuration.` both before and after this commit. This is a no-op against live state.
- `price_class` carries no `ForceNew` in the provider schema, so it cannot trigger distribution replacement under any value change. No recreate, no new distribution ID or domain name, no propagation event.
- Postcondition negative-tested by falsifying the assertion — Terraform correctly fails the plan, confirming the guard is live rather than inert.
- `terraform fmt -check` clean.

## Scope

The `restrictions` block is untouched and unasserted. An earlier revision of this PR also asserted the geo restriction; that was dropped deliberately. Geo enforcement interacts with the WAF layer in ways that an assertion here would prematurely lock in, so the distribution's geo posture is left free to change independently of this PR.

Tracked in CMS-Enterprise/ztmf-misc#293.
