### PR TITLE
fix(scores): tag the server-owned fields on FindScoresInput as non-bindable

### DIFF
--- a/backend/cmd/api/internal/controller/scores_authz_test.go
+++ b/backend/cmd/api/internal/controller/scores_authz_test.go
@@ -1,0 +1,73 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFindScoresInput_QueryCannotWiden pins that the scores list endpoints'
+// server-owned scope fields are not bindable from the query string.
+//
+// ListScores and GetScoresAggregate decode the client query onto the input
+// before ApplyTier runs, and ApplyTier only overwrites UserID for the tiers that
+// need self-scope. For every other tier it returns false and leaves the decoded
+// value in place, so the tag is what keeps a client-supplied value out of the
+// query in the first place.
+func TestFindScoresInput_QueryCannotWiden(t *testing.T) {
+	for _, q := range []string{"UserID", "FismaSystemIDs"} {
+		t.Run(q, func(t *testing.T) {
+			input := model.FindScoresInput{}
+			err := decoder.Decode(&input, url.Values{q: {"1"}})
+
+			assert.Error(t, err,
+				"a server-owned scope field must not be bindable from the query string")
+		})
+	}
+}
+
+// TestFindScoresInput_LegitimateQueryParamsStillDecode is the companion positive
+// case: tagging the server-owned fields must not break the parameters callers
+// are supposed to be able to send.
+func TestFindScoresInput_LegitimateQueryParamsStillDecode(t *testing.T) {
+	input := model.FindScoresInput{}
+	err := decoder.Decode(&input, url.Values{
+		"fismasystemid":   {"7"},
+		"datacallid":      {"3"},
+		"include_pillars": {"true"},
+	})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, input.FismaSystemID) {
+		assert.Equal(t, int32(7), *input.FismaSystemID)
+	}
+	if assert.NotNil(t, input.DataCallID) {
+		assert.Equal(t, int32(3), *input.DataCallID)
+	}
+	if assert.NotNil(t, input.IncludePillars) {
+		assert.True(t, *input.IncludePillars)
+	}
+}
+
+// TestListScores_ScopeFieldsRejectedFromQuery pins the same boundary at the
+// handler: a request naming a server-owned scope field returns 400 for the
+// unknown key rather than 200 with redirected scope. Decode failing short
+// circuits before the query runs, so this needs no database.
+func TestListScores_ScopeFieldsRejectedFromQuery(t *testing.T) {
+	for _, q := range []string{"UserID=victim-uuid", "userid=victim-uuid", "FismaSystemIDs=1"} {
+		t.Run(q, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/scores?"+q, nil)
+			r = withUser(r, issoUser)
+			w := httptest.NewRecorder()
+
+			ListScores(w, r)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code,
+				"a server-owned scope field in the query must 400, not redirect scope")
+		})
+	}
+}

--- a/backend/internal/model/scores.go
+++ b/backend/internal/model/scores.go
@@ -52,13 +52,13 @@ const (
 )
 
 type Score struct {
-	ScoreID          int32           `json:"scoreid"`
-	FismaSystemID    int32           `json:"fismasystemid"`
-	DateCalculated   float64         `json:"datecalculated"`
-	Notes            *string         `json:"notes"`
-	NotesIsAISummary *bool           `json:"notes_is_ai_summary" db:"notes_is_ai_summary"`
-	FunctionOptionID int32           `json:"functionoptionid"`
-	DataCallID       int32           `json:"datacallid"`
+	ScoreID          int32   `json:"scoreid"`
+	FismaSystemID    int32   `json:"fismasystemid"`
+	DateCalculated   float64 `json:"datecalculated"`
+	Notes            *string `json:"notes"`
+	NotesIsAISummary *bool   `json:"notes_is_ai_summary" db:"notes_is_ai_summary"`
+	FunctionOptionID int32   `json:"functionoptionid"`
+	DataCallID       int32   `json:"datacallid"`
 	// Status is the answer's review state for its data call: 'not_started' for
 	// a row carried forward by copyPreviousScores and untouched this cycle,
 	// 'done' once saved or confirmed this cycle (ztmf#435, values pinned by
@@ -564,11 +564,11 @@ func Tier(score float64) string {
 
 type FindScoresInput struct {
 	input
-	FismaSystemID  *int32 `schema:"fismasystemid"`
-	FismaSystemIDs []*int32
-	DataCallID     *int32 `schema:"datacallid"`
-	UserID         *string
-	IncludePillars *bool `schema:"include_pillars"`
+	FismaSystemID  *int32   `schema:"fismasystemid"`
+	FismaSystemIDs []*int32 `schema:"-"`
+	DataCallID     *int32   `schema:"datacallid"`
+	UserID         *string  `schema:"-"`
+	IncludePillars *bool    `schema:"include_pillars"`
 	OpDivScope
 }
 


### PR DESCRIPTION
## What

Adds `schema:"-"` to the two server-owned fields on `FindScoresInput`, and pins the boundary with tests.

```diff
 type FindScoresInput struct {
 	input
 	FismaSystemID  *int32   `schema:"fismasystemid"`
-	FismaSystemIDs []*int32
+	FismaSystemIDs []*int32 `schema:"-"`
 	DataCallID     *int32   `schema:"datacallid"`
-	UserID         *string
+	UserID         *string  `schema:"-"`
 	IncludePillars *bool    `schema:"include_pillars"`
 	OpDivScope
 }
```

## Why

`FindScoresInput` is the one query-input struct without this tagging. Its siblings — `FindAnswersInput`, `FindFismaSystemsInput`, `FindScoreDiffInput`, `FindScoreProgressInput`, `FindSystemInsightsInput` — all carry it.

Both fields are populated by the server, never by a caller: `UserID` from the session via `ApplyTier`, and `FismaSystemIDs` from `user.AssignedFismaSystems` (`controller/scores.go:322`, its only assignment anywhere). Since neither is a parameter callers are meant to send, decode should reject them rather than accept them silently. `ApplyTier` assigns `UserID` only for the tiers needing self-scope, so for any other tier a decoded value would otherwise persist into the query.

## Tests

Three cases, mirroring the shape `datacalls_export_authz_test.go` already uses for the export input:

- **Negative** — the two tagged fields fail to decode from the query string.
- **Positive** — `fismasystemid`, `datacallid` and `include_pillars` still decode normally, so the tagging doesn't cost callers anything they legitimately send.
- **Handler** — `ListScores` answers 400 for a request naming a server-owned field, rather than proceeding. Decode failing short-circuits before the query runs, so this needs no database.

## Verification

- `go build ./...` and `go vet ./...` clean
- `go test -short ./...` — **630 passed across 19 packages**, up from 622 by exactly the eight added here
- Confirmed `FismaSystemIDs` has no caller that sets it from a request, so the tag breaks nothing

Small and self-contained; no behavior change for any legitimate request.
