### PR TITLE
Return assignedopdivids as an empty array instead of null

### DIFF
--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -135,7 +135,7 @@ updatedUserData: &updatedUserData
   fullname: "Updated Test User"
   role: "ISSO"
 
-# Response-only anchors, so the ztmf#346 always-array assertion can live here.
+# Response-only anchors, so the always-array assertion can live here.
 # userData / updatedUserData double as request bodies, so theirs is spelled at
 # each expect site instead.
 deletedUserData: &deletedUserData
@@ -278,7 +278,7 @@ tests:
             role: "OWNER"
             identity_provider: "okta"
 
-  # ztmf#346 on the caller's own record - the frontend reads this into
+  # The caller's own record - the frontend reads this into
   # callerGrantIds (ztmf-ui#642). Served from the auth middleware's context
   # user, so no /users test would catch a regression here. Delegate.User holds
   # no grants, so the expectation is stable against the opdivs serial.
@@ -518,8 +518,8 @@ tests:
       headers:
         content-type: "application/json"
 
-  # ztmf#346 stops at the /users resource on purpose. An ISSO is 403'd on GET
-  # /users but can read their own system's roster, so populating OpDiv
+  # The always-array contract stops at /users on purpose. An ISSO is 403'd on
+  # GET /users but can read their own system's roster, so populating OpDiv
   # membership here would leak exactly what that 403 withholds. Pinned as null
   # so re-adding the subquery to the delegate paths fails loudly.
   - url: http://localhost:8080/api/v1/fismasystems/1001/delegates
@@ -1393,7 +1393,7 @@ tests:
         json:
           data:
             <<: *userData
-            # ztmf#346: a brand-new user holds no grants; still [], not null.
+            # A brand-new user holds no grants; still [], not null.
             assignedopdivids: []
 
   - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
@@ -1414,7 +1414,7 @@ tests:
             # passing an explicit identity_provider (see the override gate).
             identity_provider: "okta"
 
-  # ztmf#346 on the list path. Before the PUT below so the email filter still
+  # The list path. Before the PUT below so the email filter still
   # matches this user.
   - url: "http://localhost:8080/api/v1/users?email=New.User@example.com"
     method: GET

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -135,15 +135,9 @@ updatedUserData: &updatedUserData
   fullname: "Updated Test User"
   role: "ISSO"
 
-# deletedUserData / restoredUserData are response-only anchors, so the ztmf#346
-# always-array assertion lives here. userData / updatedUserData are also used as
-# POST/PUT request bodies, so their assignedopdivids expectation is spelled at
-# each expect site instead - it must not be sent up as input.
-#
-# emberfall v0.4.1 enforces `assignedopdivids: []` as a real constraint (it
-# reports "expected ... to be an array, got <nil>" against a null), so these are
-# not vacuous. The nil-vs-empty distinction on the Go side is pinned separately
-# in internal/model/users_opdivarray_integration_test.go.
+# Response-only anchors, so the ztmf#346 always-array assertion can live here.
+# userData / updatedUserData double as request bodies, so theirs is spelled at
+# each expect site instead.
 deletedUserData: &deletedUserData
   email: "updated.user@example.com"
   fullname: "Updated Test User"
@@ -283,6 +277,25 @@ tests:
             email: "Test.User@nowhere.xyz"
             role: "OWNER"
             identity_provider: "okta"
+
+  # ztmf#346 on the caller's own record - the frontend reads this into
+  # callerGrantIds (ztmf-ui#642). Served from the auth middleware's context
+  # user, so no /users test would catch a regression here. Delegate.User holds
+  # no grants, so the expectation is stable against the opdivs serial.
+  - url: http://localhost:8080/api/v1/users/current
+    method: GET
+    headers:
+      <<: *delegateHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            email: "Delegate.User@nowhere.xyz"
+            role: "SYSTEM_DELEGATE"
+            assignedopdivids: []
 
   # Pre-auth IdP lookup - unauthenticated; routes the landing page to the
   # correct ALB login path. No Authorization header on these by design.
@@ -1362,8 +1375,7 @@ tests:
         json:
           data:
             <<: *userData
-            # ztmf#346: a brand-new user holds no OpDiv grants, and the create
-            # response must still spell that [] rather than null.
+            # ztmf#346: a brand-new user holds no grants; still [], not null.
             assignedopdivids: []
 
   - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
@@ -1384,9 +1396,8 @@ tests:
             # passing an explicit identity_provider (see the override gate).
             identity_provider: "okta"
 
-  # ztmf#346 on the list path. Placed before the PUT below so the email filter
-  # still matches this user, and pinned as an array item (which emberfall
-  # supports since aquia-inc/emberfall#36 closed in v0.4.1).
+  # ztmf#346 on the list path. Before the PUT below so the email filter still
+  # matches this user.
   - url: "http://localhost:8080/api/v1/users?email=New.User@example.com"
     method: GET
     headers:

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -518,10 +518,10 @@ tests:
       headers:
         content-type: "application/json"
 
-  # ztmf#346 off the /users resource. These responses already carried
-  # assignedopdivids (as null, since the query never selected it), so the
-  # always-array contract has to hold here too or `?? []` stays load-bearing.
-  # Delegate.User is seeded onto 1001 without a grant.
+  # ztmf#346 stops at the /users resource on purpose. An ISSO is 403'd on GET
+  # /users but can read their own system's roster, so populating OpDiv
+  # membership here would leak exactly what that 403 withholds. Pinned as null
+  # so re-adding the subquery to the delegate paths fails loudly.
   - url: http://localhost:8080/api/v1/fismasystems/1001/delegates
     method: GET
     headers:
@@ -534,7 +534,7 @@ tests:
         json:
           data:
             - email: "Delegate.User@nowhere.xyz"
-              assignedopdivids: []
+              assignedopdivids: null
 
   # Success-path sequence (must run in order): Isso.User is assigned to Shield Gen
   # (1003, EMPIRE, capability enabled). Reuse.Delegate is a seeded EMPIRE delegate

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -518,6 +518,24 @@ tests:
       headers:
         content-type: "application/json"
 
+  # ztmf#346 off the /users resource. These responses already carried
+  # assignedopdivids (as null, since the query never selected it), so the
+  # always-array contract has to hold here too or `?? []` stays load-bearing.
+  # Delegate.User is seeded onto 1001 without a grant.
+  - url: http://localhost:8080/api/v1/fismasystems/1001/delegates
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - email: "Delegate.User@nowhere.xyz"
+              assignedopdivids: []
+
   # Success-path sequence (must run in order): Isso.User is assigned to Shield Gen
   # (1003, EMPIRE, capability enabled). Reuse.Delegate is a seeded EMPIRE delegate
   # not yet on any system, so the ISSO can attach (201), renew (200), then remove

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -135,17 +135,28 @@ updatedUserData: &updatedUserData
   fullname: "Updated Test User"
   role: "ISSO"
 
+# deletedUserData / restoredUserData are response-only anchors, so the ztmf#346
+# always-array assertion lives here. userData / updatedUserData are also used as
+# POST/PUT request bodies, so their assignedopdivids expectation is spelled at
+# each expect site instead - it must not be sent up as input.
+#
+# emberfall v0.4.1 enforces `assignedopdivids: []` as a real constraint (it
+# reports "expected ... to be an array, got <nil>" against a null), so these are
+# not vacuous. The nil-vs-empty distinction on the Go side is pinned separately
+# in internal/model/users_opdivarray_integration_test.go.
 deletedUserData: &deletedUserData
   email: "updated.user@example.com"
   fullname: "Updated Test User"
   role: "ISSO"
   deleted: true
+  assignedopdivids: []
 
 restoredUserData: &restoredUserData
   email: "updated.user@example.com"
   fullname: "Updated Test User"
   role: "ISSO"
   deleted: false
+  assignedopdivids: []
 
 questionData: &questionData
   question: "How do you manage user identities?"
@@ -1351,7 +1362,10 @@ tests:
         json:
           data:
             <<: *userData
-  
+            # ztmf#346: a brand-new user holds no OpDiv grants, and the create
+            # response must still spell that [] rather than null.
+            assignedopdivids: []
+
   - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
     method: GET
     headers:
@@ -1364,10 +1378,28 @@ tests:
         json:
           data:
             <<: *userData
+            assignedopdivids: []
             # No explicit IdP supplied on create, so it defaults to the CMS
             # baseline (okta). HHS users are routed to entra by an HHS-wide actor
             # passing an explicit identity_provider (see the override gate).
             identity_provider: "okta"
+
+  # ztmf#346 on the list path. Placed before the PUT below so the email filter
+  # still matches this user, and pinned as an array item (which emberfall
+  # supports since aquia-inc/emberfall#36 closed in v0.4.1).
+  - url: "http://localhost:8080/api/v1/users?email=New.User@example.com"
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      headers:
+        content-type: "application/json"
+      body:
+        json:
+          data:
+            - email: "New.User@example.com"
+              assignedopdivids: []
 
   - url: "http://localhost:8080/api/v1/users/{{.createUser.Response.data.userid}}"
     method: PUT
@@ -1392,7 +1424,8 @@ tests:
         json:
           data:
             <<: *updatedUserData
-  
+            assignedopdivids: []
+
   - url: http://localhost:8080/api/v1/users
     method: GET
     headers:

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -52,7 +52,7 @@ type User struct {
 // /users paths only. The delegate paths must not select it: an ISSO is 403'd on
 // GET /users but can read their own system's roster, so serving OpDiv
 // membership there leaks what that 403 withholds.
-const assignedOpDivIDsSubquery = `(SELECT COALESCE(ARRAY_AGG(opdiv_id), '{}') FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids`
+const assignedOpDivIDsSubquery = `(SELECT COALESCE(ARRAY_AGG(opdiv_id), '{}'::integer[]) FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids`
 
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
 // READONLY_ADMIN values were removed in Stage D, so the checks below only

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -46,6 +46,23 @@ type User struct {
 	LastSeen *time.Time `json:"last_seen" db:"last_seen"`
 }
 
+// assignedOpDivIDsSubquery loads a user's OpDiv grants. The COALESCE is the
+// contract, not an optimisation: ARRAY_AGG over zero rows is SQL NULL, which
+// scans into a nil slice and serializes as JSON null, spelling "holds no
+// grants" exactly like "field absent" (ztmf#346). Resolves against the outer
+// row in SELECT, UPDATE ... RETURNING, and INSERT ... RETURNING alike, so the
+// one expression covers the read and write paths both.
+//
+// Selected by the /users paths only - list, detail, save, restore - so
+// assignedopdivids is an always-array there. The delegate-resource paths
+// deliberately do NOT select it: a system-scoped actor reading a roster has no
+// need for a delegate's OpDiv memberships, and since a delegate is granted the
+// OpDiv of every system they are attached to, serving it there would tell an
+// ISSO in one OpDiv which other OpDivs a shared delegate works in. Those
+// responses keep spelling the field null, which is why a client's `?? []`
+// stays load-bearing.
+const assignedOpDivIDsSubquery = `(SELECT COALESCE(ARRAY_AGG(opdiv_id), '{}') FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids`
+
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
 // READONLY_ADMIN values were removed in Stage D, so the checks below only
 // match the new tier names. Callers gate access with IsAdmin / HasAdminRead at
@@ -330,7 +347,7 @@ func (u *User) Save(ctx context.Context) (*User, error) {
 			Insert("users").
 			Columns("email", "fullname", "role", "identity_provider", "access_expires_at").
 			Values(u.Email, u.FullName, u.Role, idp, exp).
-			Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at")
+			Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at, " + assignedOpDivIDsSubquery)
 	} else {
 		// identity_provider is intentionally not updatable through Save() in
 		// Stage C. A user's IdP is set at provisioning time and only changes
@@ -356,7 +373,7 @@ func (u *User) Save(ctx context.Context) (*User, error) {
 		}
 		sqlb = ub.
 			Where("userid=?", u.UserID).
-			Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at")
+			Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at, " + assignedOpDivIDsSubquery)
 	}
 
 	saved, err := queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
@@ -449,7 +466,7 @@ func FindUsers(ctx context.Context, fui *FindUsersInput) ([]*User, error) {
 			"users.deleted",
 			"users.identity_provider",
 			"users.access_expires_at",
-			"(SELECT ARRAY_AGG(opdiv_id) FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids",
+			assignedOpDivIDsSubquery,
 			// Same correlated-subquery shape as assignedopdivids above. Served
 			// by events_user_activity_idx (0054) as an index-only descent to
 			// the newest entry, so this stays a few milliseconds across the
@@ -518,8 +535,12 @@ func findUser(ctx context.Context, where string, args []any) (*User, error) {
 			"users.identity_provider",
 			"users.access_expires_at",
 			"NULL::timestamptz AS last_seen",
+			// assignedfismasystems keeps the bare ARRAY_AGG: it is json:"-"
+			// (server-side authz only) and never crosses the wire, so the
+			// nil-vs-empty distinction the COALESCE below removes does not
+			// arise for it.
 			"(SELECT ARRAY_AGG(fismasystemid) FROM users_fismasystems WHERE userid = users.userid) AS assignedfismasystems",
-			"(SELECT ARRAY_AGG(opdiv_id)      FROM users_opdivs       WHERE userid = users.userid) AS assignedopdivids",
+			assignedOpDivIDsSubquery,
 		).
 		From("users").
 		Where(where, args...)
@@ -591,9 +612,9 @@ func RestoreUser(ctx context.Context, userid string) (*User, error) {
 
 	var restored User
 	err = tx.QueryRow(ctx,
-		"UPDATE users SET deleted=false WHERE userid=$1 RETURNING userid, email, fullname, role, deleted",
+		"UPDATE users SET deleted=false WHERE userid=$1 RETURNING userid, email, fullname, role, deleted, "+assignedOpDivIDsSubquery,
 		userid,
-	).Scan(&restored.UserID, &restored.Email, &restored.FullName, &restored.Role, &restored.Deleted)
+	).Scan(&restored.UserID, &restored.Email, &restored.FullName, &restored.Role, &restored.Deleted, &restored.AssignedOpDivIDs)
 	if err != nil {
 		return nil, trapError(err)
 	}

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -50,10 +50,11 @@ type User struct {
 // serializes as JSON null - "holds no grants" spelled like "field absent"
 // (ztmf#346). Resolves against the outer row in SELECT and RETURNING alike.
 //
-// Selected by the /users paths only. The delegate paths deliberately skip it: a
-// delegate is granted the OpDiv of every system they are attached to, so
-// serving it on a roster any system viewer can read would tell an ISSO in one
-// OpDiv which other OpDivs a shared delegate works in.
+// Selected by every path that returns a User, including the delegate ones.
+// Those already carried assignedopdivids in their responses - as null, since
+// they never selected it - so this corrects a value rather than exposing a new
+// field, and it is what makes a client's `?? []` a provable no-op instead of a
+// guess about which endpoint produced the record.
 const assignedOpDivIDsSubquery = `(SELECT COALESCE(ARRAY_AGG(opdiv_id), '{}') FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids`
 
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
@@ -686,7 +687,7 @@ func SetDelegateExpiry(ctx context.Context, userid string, expiresAt *time.Time)
 		// deleted=false: never renew a soft-deleted delegate. A non-delegate, a
 		// missing id, or a soft-deleted row all match nothing -> ErrNoData -> 404.
 		Where("userid=? AND role='SYSTEM_DELEGATE' AND deleted=false", userid).
-		Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at")
+		Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at, " + assignedOpDivIDsSubquery)
 
 	return queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
 }
@@ -705,6 +706,7 @@ func FindDelegatesByFismaSystem(ctx context.Context, fismasystemid int32) ([]*Us
 			"users.deleted",
 			"users.identity_provider",
 			"users.access_expires_at",
+			assignedOpDivIDsSubquery,
 		).
 		From("users").
 		Join("users_fismasystems ufs ON ufs.userid = users.userid").
@@ -733,6 +735,7 @@ func FindDelegateCandidatesForSystem(ctx context.Context, fismasystemid, opdivID
 			"users.deleted",
 			"users.identity_provider",
 			"users.access_expires_at",
+			assignedOpDivIDsSubquery,
 		).
 		From("users").
 		Where("users.role='SYSTEM_DELEGATE'").
@@ -837,9 +840,9 @@ func AddSystemDelegate(ctx context.Context, sys *FismaSystem, opdiv *OpDiv, acto
 	err = tx.QueryRow(ctx,
 		`INSERT INTO users (email, fullname, role, identity_provider, access_expires_at)
 		 VALUES ($1, $2, $3, $4, $5)
-		 RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at`,
+		 RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at, `+assignedOpDivIDsSubquery,
 		email, fullname, "SYSTEM_DELEGATE", idp, exp,
-	).Scan(&created.UserID, &created.Email, &created.FullName, &created.Role, &created.Deleted, &created.IdentityProvider, &created.AccessExpiresAt)
+	).Scan(&created.UserID, &created.Email, &created.FullName, &created.Role, &created.Deleted, &created.IdentityProvider, &created.AccessExpiresAt, &created.AssignedOpDivIDs)
 	if err != nil {
 		e := trapError(err)
 		// A concurrent request may have created this email between the FindUserByEmail

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -50,11 +50,11 @@ type User struct {
 // serializes as JSON null - "holds no grants" spelled like "field absent"
 // (ztmf#346). Resolves against the outer row in SELECT and RETURNING alike.
 //
-// Selected by every path that returns a User, including the delegate ones.
-// Those already carried assignedopdivids in their responses - as null, since
-// they never selected it - so this corrects a value rather than exposing a new
-// field, and it is what makes a client's `?? []` a provable no-op instead of a
-// guess about which endpoint produced the record.
+// Selected by the /users paths only. The delegate paths must NOT select it: an
+// ISSO is 403'd on GET /users but can read their own system's delegate roster,
+// so populating it there would hand them the OpDiv membership that 403 exists
+// to withhold. Those responses keep spelling the field null - the key is in the
+// schema either way, and null discloses nothing.
 const assignedOpDivIDsSubquery = `(SELECT COALESCE(ARRAY_AGG(opdiv_id), '{}') FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids`
 
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
@@ -687,7 +687,7 @@ func SetDelegateExpiry(ctx context.Context, userid string, expiresAt *time.Time)
 		// deleted=false: never renew a soft-deleted delegate. A non-delegate, a
 		// missing id, or a soft-deleted row all match nothing -> ErrNoData -> 404.
 		Where("userid=? AND role='SYSTEM_DELEGATE' AND deleted=false", userid).
-		Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at, " + assignedOpDivIDsSubquery)
+		Suffix("RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at")
 
 	return queryRow(ctx, sqlb, pgx.RowToStructByNameLax[User])
 }
@@ -706,7 +706,6 @@ func FindDelegatesByFismaSystem(ctx context.Context, fismasystemid int32) ([]*Us
 			"users.deleted",
 			"users.identity_provider",
 			"users.access_expires_at",
-			assignedOpDivIDsSubquery,
 		).
 		From("users").
 		Join("users_fismasystems ufs ON ufs.userid = users.userid").
@@ -735,7 +734,6 @@ func FindDelegateCandidatesForSystem(ctx context.Context, fismasystemid, opdivID
 			"users.deleted",
 			"users.identity_provider",
 			"users.access_expires_at",
-			assignedOpDivIDsSubquery,
 		).
 		From("users").
 		Where("users.role='SYSTEM_DELEGATE'").
@@ -840,9 +838,9 @@ func AddSystemDelegate(ctx context.Context, sys *FismaSystem, opdiv *OpDiv, acto
 	err = tx.QueryRow(ctx,
 		`INSERT INTO users (email, fullname, role, identity_provider, access_expires_at)
 		 VALUES ($1, $2, $3, $4, $5)
-		 RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at, `+assignedOpDivIDsSubquery,
+		 RETURNING userid, email, fullname, role, deleted, identity_provider, access_expires_at`,
 		email, fullname, "SYSTEM_DELEGATE", idp, exp,
-	).Scan(&created.UserID, &created.Email, &created.FullName, &created.Role, &created.Deleted, &created.IdentityProvider, &created.AccessExpiresAt, &created.AssignedOpDivIDs)
+	).Scan(&created.UserID, &created.Email, &created.FullName, &created.Role, &created.Deleted, &created.IdentityProvider, &created.AccessExpiresAt)
 	if err != nil {
 		e := trapError(err)
 		// A concurrent request may have created this email between the FindUserByEmail

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -47,14 +47,11 @@ type User struct {
 }
 
 // ARRAY_AGG over zero rows is SQL NULL, which scans to a nil slice and
-// serializes as JSON null - "holds no grants" spelled like "field absent"
-// (ztmf#346). Resolves against the outer row in SELECT and RETURNING alike.
+// serializes as JSON null - "no grants" spelled like "field absent" (ztmf#346).
 //
-// Selected by the /users paths only. The delegate paths must NOT select it: an
-// ISSO is 403'd on GET /users but can read their own system's delegate roster,
-// so populating it there would hand them the OpDiv membership that 403 exists
-// to withhold. Those responses keep spelling the field null - the key is in the
-// schema either way, and null discloses nothing.
+// /users paths only. The delegate paths must not select it: an ISSO is 403'd on
+// GET /users but can read their own system's roster, so serving OpDiv
+// membership there leaks what that 403 withholds.
 const assignedOpDivIDsSubquery = `(SELECT COALESCE(ARRAY_AGG(opdiv_id), '{}') FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids`
 
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /

--- a/backend/internal/model/users.go
+++ b/backend/internal/model/users.go
@@ -46,21 +46,14 @@ type User struct {
 	LastSeen *time.Time `json:"last_seen" db:"last_seen"`
 }
 
-// assignedOpDivIDsSubquery loads a user's OpDiv grants. The COALESCE is the
-// contract, not an optimisation: ARRAY_AGG over zero rows is SQL NULL, which
-// scans into a nil slice and serializes as JSON null, spelling "holds no
-// grants" exactly like "field absent" (ztmf#346). Resolves against the outer
-// row in SELECT, UPDATE ... RETURNING, and INSERT ... RETURNING alike, so the
-// one expression covers the read and write paths both.
+// ARRAY_AGG over zero rows is SQL NULL, which scans to a nil slice and
+// serializes as JSON null - "holds no grants" spelled like "field absent"
+// (ztmf#346). Resolves against the outer row in SELECT and RETURNING alike.
 //
-// Selected by the /users paths only - list, detail, save, restore - so
-// assignedopdivids is an always-array there. The delegate-resource paths
-// deliberately do NOT select it: a system-scoped actor reading a roster has no
-// need for a delegate's OpDiv memberships, and since a delegate is granted the
-// OpDiv of every system they are attached to, serving it there would tell an
-// ISSO in one OpDiv which other OpDivs a shared delegate works in. Those
-// responses keep spelling the field null, which is why a client's `?? []`
-// stays load-bearing.
+// Selected by the /users paths only. The delegate paths deliberately skip it: a
+// delegate is granted the OpDiv of every system they are attached to, so
+// serving it on a roster any system viewer can read would tell an ISSO in one
+// OpDiv which other OpDivs a shared delegate works in.
 const assignedOpDivIDsSubquery = `(SELECT COALESCE(ARRAY_AGG(opdiv_id), '{}') FROM users_opdivs WHERE userid = users.userid) AS assignedopdivids`
 
 // Role helpers for the multi-OpDiv role taxonomy. The legacy ADMIN /
@@ -535,10 +528,7 @@ func findUser(ctx context.Context, where string, args []any) (*User, error) {
 			"users.identity_provider",
 			"users.access_expires_at",
 			"NULL::timestamptz AS last_seen",
-			// assignedfismasystems keeps the bare ARRAY_AGG: it is json:"-"
-			// (server-side authz only) and never crosses the wire, so the
-			// nil-vs-empty distinction the COALESCE below removes does not
-			// arise for it.
+			// Bare ARRAY_AGG is fine here: json:"-", never crosses the wire.
 			"(SELECT ARRAY_AGG(fismasystemid) FROM users_fismasystems WHERE userid = users.userid) AS assignedfismasystems",
 			assignedOpDivIDsSubquery,
 		).

--- a/backend/internal/model/users_opdivarray_integration_test.go
+++ b/backend/internal/model/users_opdivarray_integration_test.go
@@ -1,0 +1,192 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assignedopdivids is an always-array on the wire (ztmf#346). ARRAY_AGG over
+// zero rows is SQL NULL, so without the COALESCE in assignedOpDivIDsSubquery a
+// user with no OpDiv grants serializes as null - the same shape a response that
+// omitted the field entirely would have. A client cannot tell "empty scope"
+// from "unknown" apart, which matters because ztmf-ui#642 makes this field the
+// save-time preserve boundary in the Assign OpDivs modal.
+//
+// The nil-vs-empty distinction is invisible to Go's own consumers (len() and
+// range treat them alike) and, as the emberfall note explains, is not reliably
+// assertable from the YAML smokes either. So it is pinned here, on both the
+// scanned slice and the marshalled JSON - the latter because the JSON is the
+// actual contract and survives a future change of the Go field type.
+
+const noGrantUserEmail = "No.Grants.User@empire.test"
+
+// grantlessUserID resolves a seeded user holding no OpDiv grants, rather than
+// hardcoding an id, so the test cannot pass vacuously against a fixture where
+// every user happens to be granted.
+func grantlessUserID(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	var userID string
+	err = conn.QueryRow(ctx, `
+		SELECT u.userid FROM public.users u
+		WHERE NOT EXISTS (SELECT 1 FROM public.users_opdivs uo WHERE uo.userid = u.userid)
+		LIMIT 1
+	`).Scan(&userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		t.Skip("fixture has no user without OpDiv grants; nothing to assert here")
+	}
+	require.NoError(t, err)
+	return userID
+}
+
+// assertEmptyArray pins both halves of the contract: a non-nil empty slice in
+// Go, and a literal [] in the JSON the frontend actually reads.
+func assertEmptyArray(t *testing.T, u *User, where string) {
+	t.Helper()
+	assert.NotNil(t, u.AssignedOpDivIDs, "%s: a grantless user must scan an empty slice, not nil", where)
+	assert.Empty(t, u.AssignedOpDivIDs, "%s: a grantless user must have no grants", where)
+
+	b, err := json.Marshal(u)
+	require.NoError(t, err)
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &wire))
+	raw, ok := wire["assignedopdivids"]
+	require.True(t, ok, "%s: assignedopdivids must be present in the response", where)
+	assert.JSONEq(t, `[]`, string(raw), "%s: must serialize as [], never null", where)
+}
+
+func TestAssignedOpDivIDsEmptyArrayIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	userID := grantlessUserID(t, ctx)
+
+	t.Run("FindUsers", func(t *testing.T) {
+		users, err := FindUsers(ctx, &FindUsersInput{})
+		require.NoError(t, err)
+		require.NotEmpty(t, users)
+
+		var subject *User
+		for _, u := range users {
+			if u.UserID == userID {
+				subject = u
+				break
+			}
+		}
+		require.NotNil(t, subject, "the grantless user should appear in the list")
+		assertEmptyArray(t, subject, "FindUsers")
+	})
+
+	t.Run("FindUserByID", func(t *testing.T) {
+		u, err := FindUserByID(ctx, userID)
+		require.NoError(t, err)
+		require.NotNil(t, u)
+		assertEmptyArray(t, u, "findUser")
+	})
+
+	// Real grants must still come through. A COALESCE that flattened every user
+	// to empty would satisfy both assertions above, so check the list against
+	// the actual junction-table counts for every seeded user at once.
+	t.Run("GrantsAreNotFlattened", func(t *testing.T) {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Release()
+
+		rows, err := conn.Query(ctx, `
+			SELECT userid, count(*) FROM public.users_opdivs GROUP BY userid
+		`)
+		require.NoError(t, err)
+		want := map[string]int{}
+		for rows.Next() {
+			var id string
+			var n int
+			require.NoError(t, rows.Scan(&id, &n))
+			want[id] = n
+		}
+		require.NoError(t, rows.Err())
+		require.NotEmpty(t, want, "fixture must grant at least one OpDiv")
+
+		// Deleted=false is the default filter, so check both halves of the
+		// fixture to cover every granted user.
+		var matched int
+		for _, deleted := range []bool{false, true} {
+			users, err := FindUsers(ctx, &FindUsersInput{Deleted: deleted})
+			require.NoError(t, err)
+			for _, u := range users {
+				assert.NotNil(t, u.AssignedOpDivIDs, "%s: never nil, grants or not", u.UserID)
+				assert.Len(t, u.AssignedOpDivIDs, want[u.UserID],
+					"%s: list must report the user's actual grant count", u.UserID)
+				if want[u.UserID] > 0 {
+					matched++
+				}
+			}
+		}
+		assert.Equal(t, len(want), matched, "every granted user should have been checked")
+	})
+}
+
+// The write paths are the half the issue's acceptance criteria did not name:
+// Save, RestoreUser, and the delegate paths omitted assignedopdivids from their
+// RETURNING clauses entirely, so under lax scanning they returned null too.
+func TestAssignedOpDivIDsWritePathsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+
+	hardDeleteUserByEmail(t, noGrantUserEmail)
+	t.Cleanup(func() { hardDeleteUserByEmail(t, noGrantUserEmail) })
+
+	u := &User{Email: noGrantUserEmail, FullName: "No Grants User", Role: "ISSO"}
+	created, err := u.Save(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assertEmptyArray(t, created, "Save (create)")
+
+	created.FullName = "No Grants User Renamed"
+	updated, err := created.Save(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assertEmptyArray(t, updated, "Save (update)")
+
+	require.NoError(t, DeleteUser(ctx, created.UserID))
+	restored, err := RestoreUser(ctx, created.UserID)
+	require.NoError(t, err)
+	require.NotNil(t, restored)
+	assertEmptyArray(t, restored, "RestoreUser")
+
+	// Same user, now granted: the write paths must report the grant, not a
+	// blanket empty array. This is the detail-path counterpart of the list
+	// check in GrantsAreNotFlattened - done against a user this test created so
+	// it has a v4 userid (FindUserByID rejects the fixture's 3333-style ids).
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+	var opdivID int32
+	require.NoError(t, conn.QueryRow(ctx, "SELECT opdiv_id FROM opdivs ORDER BY opdiv_id LIMIT 1").Scan(&opdivID))
+	_, err = conn.Exec(ctx,
+		"INSERT INTO users_opdivs (userid, opdiv_id, granted_by) VALUES ($1, $2, $1)",
+		created.UserID, opdivID)
+	require.NoError(t, err)
+
+	detail, err := FindUserByID(ctx, created.UserID)
+	require.NoError(t, err)
+	require.Len(t, detail.AssignedOpDivIDs, 1, "findUser must report the grant")
+	require.NotNil(t, detail.AssignedOpDivIDs[0])
+	assert.Equal(t, opdivID, *detail.AssignedOpDivIDs[0])
+
+	granted, err := detail.Save(ctx)
+	require.NoError(t, err)
+	assert.Len(t, granted.AssignedOpDivIDs, 1, "Save (update) must report the grant")
+}

--- a/backend/internal/model/users_opdivarray_integration_test.go
+++ b/backend/internal/model/users_opdivarray_integration_test.go
@@ -12,14 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// assignedopdivids is an always-array on the wire (ztmf#346). The nil-vs-empty
-// distinction is invisible to Go's own consumers - len() and range treat them
-// alike - so it is pinned on both the scanned slice and the marshalled JSON.
+// assignedopdivids is an always-array on the wire. The nil-vs-empty distinction
+// is invisible to Go's own consumers - len() and range treat them alike - so it
+// is pinned on both the scanned slice and the marshalled JSON.
 
 const noGrantUserEmail = "No.Grants.User@empire.test"
 
 // Resolved rather than hardcoded so the test cannot pass vacuously against a
-// fixture where every user happens to be granted.
+// fixture where every user happens to be granted. Constrained to a live user
+// because the FindUsers subtest below reads the default deleted=false list, and
+// ordered so a failure names the same user twice running.
 func grantlessUserID(t *testing.T, ctx context.Context) string {
 	t.Helper()
 	conn, err := db.Conn(ctx)
@@ -29,7 +31,9 @@ func grantlessUserID(t *testing.T, ctx context.Context) string {
 	var userID string
 	err = conn.QueryRow(ctx, `
 		SELECT u.userid FROM public.users u
-		WHERE NOT EXISTS (SELECT 1 FROM public.users_opdivs uo WHERE uo.userid = u.userid)
+		WHERE u.deleted = false
+		  AND NOT EXISTS (SELECT 1 FROM public.users_opdivs uo WHERE uo.userid = u.userid)
+		ORDER BY u.userid
 		LIMIT 1
 	`).Scan(&userID)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/model/users_opdivarray_integration_test.go
+++ b/backend/internal/model/users_opdivarray_integration_test.go
@@ -12,24 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// assignedopdivids is an always-array on the wire (ztmf#346). ARRAY_AGG over
-// zero rows is SQL NULL, so without the COALESCE in assignedOpDivIDsSubquery a
-// user with no OpDiv grants serializes as null - the same shape a response that
-// omitted the field entirely would have. A client cannot tell "empty scope"
-// from "unknown" apart, which matters because ztmf-ui#642 makes this field the
-// save-time preserve boundary in the Assign OpDivs modal.
-//
-// The nil-vs-empty distinction is invisible to Go's own consumers (len() and
-// range treat them alike) and, as the emberfall note explains, is not reliably
-// assertable from the YAML smokes either. So it is pinned here, on both the
-// scanned slice and the marshalled JSON - the latter because the JSON is the
-// actual contract and survives a future change of the Go field type.
+// assignedopdivids is an always-array on the wire (ztmf#346). The nil-vs-empty
+// distinction is invisible to Go's own consumers - len() and range treat them
+// alike - so it is pinned on both the scanned slice and the marshalled JSON.
 
 const noGrantUserEmail = "No.Grants.User@empire.test"
 
-// grantlessUserID resolves a seeded user holding no OpDiv grants, rather than
-// hardcoding an id, so the test cannot pass vacuously against a fixture where
-// every user happens to be granted.
+// Resolved rather than hardcoded so the test cannot pass vacuously against a
+// fixture where every user happens to be granted.
 func grantlessUserID(t *testing.T, ctx context.Context) string {
 	t.Helper()
 	conn, err := db.Conn(ctx)
@@ -49,8 +39,7 @@ func grantlessUserID(t *testing.T, ctx context.Context) string {
 	return userID
 }
 
-// assertEmptyArray pins both halves of the contract: a non-nil empty slice in
-// Go, and a literal [] in the JSON the frontend actually reads.
+// Both halves of the contract: a non-nil empty slice, and a literal [] on the wire.
 func assertEmptyArray(t *testing.T, u *User, where string) {
 	t.Helper()
 	assert.NotNil(t, u.AssignedOpDivIDs, "%s: a grantless user must scan an empty slice, not nil", where)
@@ -95,9 +84,8 @@ func TestAssignedOpDivIDsEmptyArrayIntegration(t *testing.T) {
 		assertEmptyArray(t, u, "findUser")
 	})
 
-	// Real grants must still come through. A COALESCE that flattened every user
-	// to empty would satisfy both assertions above, so check the list against
-	// the actual junction-table counts for every seeded user at once.
+	// A COALESCE that flattened everyone to empty would satisfy both assertions
+	// above, so check every user against the actual junction-table counts.
 	t.Run("GrantsAreNotFlattened", func(t *testing.T) {
 		conn, err := db.Conn(ctx)
 		require.NoError(t, err)
@@ -136,9 +124,8 @@ func TestAssignedOpDivIDsEmptyArrayIntegration(t *testing.T) {
 	})
 }
 
-// The write paths are the half the issue's acceptance criteria did not name:
-// Save, RestoreUser, and the delegate paths omitted assignedopdivids from their
-// RETURNING clauses entirely, so under lax scanning they returned null too.
+// The half the acceptance criteria did not name: Save and RestoreUser omitted
+// assignedopdivids from RETURNING entirely, so lax scanning returned null.
 func TestAssignedOpDivIDsWritePathsIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping database integration test")
@@ -166,10 +153,9 @@ func TestAssignedOpDivIDsWritePathsIntegration(t *testing.T) {
 	require.NotNil(t, restored)
 	assertEmptyArray(t, restored, "RestoreUser")
 
-	// Same user, now granted: the write paths must report the grant, not a
-	// blanket empty array. This is the detail-path counterpart of the list
-	// check in GrantsAreNotFlattened - done against a user this test created so
-	// it has a v4 userid (FindUserByID rejects the fixture's 3333-style ids).
+	// Same user, now granted: the write paths must report it, not a blanket
+	// empty array. Uses a user this test created so the id is a v4 UUID
+	// (FindUserByID rejects the fixture's 3333-style ids).
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
 	defer conn.Release()


### PR DESCRIPTION
## Summary

Closes #346.

`ARRAY_AGG` over zero rows is SQL `NULL`, which scans into a nil slice and serializes as JSON `null`. A user holding no OpDiv grants was therefore indistinguishable from a response that omitted the field. Wraps the subquery in `COALESCE(..., '{}')` and lifts it to a shared const so the paths cannot drift.

The spec was already on the fixed side of this. `backend/openapi.yaml` has always declared the field as a plain array:

```yaml
assignedopdivids:
  items:
    type: integer
  type: array
```

No `nullable: true`. So the API was returning `null` for a field its own published contract declared non-nullable. This brings the implementation into conformance with the schema rather than the other way round — which also means the spec needs no regeneration (verified: regenerating is byte-identical).

## Changes

* **`internal/model/users.go`:** `assignedOpDivIDsSubquery` const, applied to the `/users` paths — `FindUsers`, `findUser`, `Save` (insert and update), and `RestoreUser`. Scans realigned where the `RETURNING` list grew. The delegate paths deliberately do not select it; see below.
* **`internal/model/users_opdivarray_integration_test.go` (new):** pins the contract on both the scanned slice and the marshalled JSON.
* **`emberfall_tests.yml`:** assertions on create, get, list, update, restore, and `/users/current`, plus a delegates-roster assertion pinning the field as `null` there.

## Why this stops at the /users resource

The delegate paths deliberately do **not** select the field, because populating it there would leak data an authorization gate already withholds:

* An ISSO is `403`'d on `GET /users` — user management is restricted, and that is where OpDiv membership is otherwise exposed.
* That same ISSO **can** read their own system's delegate roster: `ListDelegates` gates only on `CanAccessFismaSystem`.
* A delegate is granted the OpDiv of every system they are attached to (`AddSystemDelegate` inserts into `users_opdivs`), so a shared delegate's other-OpDiv memberships would become visible to a system-scoped viewer.

The counter-argument — that these responses already carry `assignedopdivids` as `null`, so selecting it merely corrects a value — is about schema conformance, not confidentiality. `null` discloses nothing; a populated array discloses real membership. Those are separate questions, and the confidentiality one wins.

So the delegate responses keep spelling the field `null`. The consequence is that a client's `?? []` stays load-bearing off the `/users` resource, which is the right trade. The emberfall roster assertion pins the `null`, so adding the subquery to those paths fails loudly — verified by adding it and watching the assertion go red.

## Acceptance criteria

* [x] `assignedopdivids` is always a JSON array (`[]` when no grants), never `null`
* [x] Applied to both `FindUsers` (list) and `findUser` (detail)
* [x] Implemented with `COALESCE(ARRAY_AGG(opdiv_id), '{}')` in the subquery
* [x] Emberfall assertion added so the shape cannot regress

## Testing

`go build`, `go vet`, `go test -short ./...`, `make test-integration`, and `make test-e2e` (211 cases) all clean.

Both layers verified non-vacuous by reverting the COALESCE:

| Check | Result |
| --- | --- |
| Go integration, COALESCE reverted | 4 subtests red |
| emberfall, COALESCE reverted | 23 red |
| emberfall, subquery re-added to a delegate path | roster assertion red |

The Go test resolves a grantless user by query rather than hardcoding an id, so it cannot pass vacuously against a fixture where everyone is granted, and `GrantsAreNotFlattened` cross-checks every seeded user's array length against the `users_opdivs` counts — so a COALESCE that flattened everyone to `[]` would fail too.
