### PR TITLE
Surface the migration startup fatal in deploy output instead of a bare Terraform timeout

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -47,3 +47,47 @@ jobs:
 
       - name: Terraform apply
         run: terraform -chdir=infrastructure apply -no-color -var-file="tfvars/${ENV,,}.tfvars" -auto-approve
+
+      # On a failed apply (typically the 20m ECS steady-state timeout) pull what
+      # Terraform cannot show: why tasks stopped and whether the app named a
+      # known fatal. A migration-version crash loop prints its
+      # MIGRATION_VERSION_MISMATCH line here; genuine deploy contention shows no
+      # crash-looping stopped tasks. This repo is public, so raw application
+      # logs are never dumped into job output: only the controlled mismatch
+      # token is printed, everything else points at CloudWatch by name.
+      # Context: ztmf-misc#298.
+      - name: Deploy failure diagnostics
+        if: failure()
+        run: |
+          set +e
+          SFX=""; USFX=""
+          if [ "${ENV,,}" = "impl" ]; then SFX="-impl"; USFX="_impl"; fi
+          CLUSTER="ztmf${SFX}"
+          SERVICE="ztmf-api${SFX}"
+          LOG_GROUP="ztmf_api${USFX}"
+
+          echo "::group::ECS service events ($CLUSTER/$SERVICE)"
+          aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
+            --query 'services[0].events[:15].[createdAt,message]' --output text
+          echo "::endgroup::"
+
+          echo "::group::Stopped task reasons"
+          TASKS=$(aws ecs list-tasks --cluster "$CLUSTER" --service-name "$SERVICE" \
+            --desired-status STOPPED --query 'taskArns[:10]' --output text)
+          if [ -n "$TASKS" ] && [ "$TASKS" != "None" ]; then
+            aws ecs describe-tasks --cluster "$CLUSTER" --tasks $TASKS \
+              --query 'tasks[].{stoppedAt:stoppedAt,stoppedReason:stoppedReason,exitCode:containers[0].exitCode,reason:containers[0].reason}' \
+              --output table
+            echo "Repeated stops with an exit code mean a startup fatal; full logs: CloudWatch log group $LOG_GROUP"
+          else
+            echo "No recently stopped tasks: not a crash loop (deploy contention or capacity, not a startup fatal)."
+          fi
+          echo "::endgroup::"
+
+          echo "::group::Known startup fatals (last 30m of $LOG_GROUP)"
+          aws logs filter-log-events --log-group-name "$LOG_GROUP" \
+            --start-time "$((($(date +%s) - 1800) * 1000))" \
+            --filter-pattern '"MIGRATION_VERSION_MISMATCH"' \
+            --query 'events[:5].message' --output text
+          echo "::endgroup::"
+          exit 0

--- a/.github/workflows/orchestration-dev.yml
+++ b/.github/workflows/orchestration-dev.yml
@@ -42,6 +42,26 @@ jobs:
         id: backend
         run: echo "backend=$(git --no-pager diff --name-only origin/main -- backend/ .github/workflows/backend.yml | grep -E '\.go$|\.sum$|Dockerfile|workflows/backend.yml' | head -n 1)" >> $GITHUB_OUTPUT
 
+      # Fail fast when main carries migrations this branch lacks. Deploying such
+      # an image against the shared dev DB (already migrated ahead by main) hits
+      # tern's BadVersionError, crash-loops, and burns the full 20m steady-state
+      # timeout, so name the mismatch and the remedy here in seconds instead.
+      # This is a git approximation: it cannot see a migration another open PR
+      # deployed to dev without merging; that case is caught by the
+      # deploy-failure diagnostics in infrastructure.yml. Context: ztmf-misc#298.
+      - name: Fail fast on migrations missing from this branch
+        run: |
+          MISSING=$(git diff --name-only --diff-filter=A HEAD...origin/main -- \
+            'backend/cmd/api/internal/migrations/[0-9][0-9][0-9][0-9]*.go' | grep -v '_test' || true)
+          if [ -n "$MISSING" ]; then
+            echo "::error::main has migrations this branch does not include:"
+            echo "$MISSING"
+            echo "An image built from this branch cannot start against the dev database once main has deployed (BadVersionError crash loop, seen as the 20m tfSTABLE timeout)."
+            echo "Remedy: rebase onto latest main, then push."
+            exit 1
+          fi
+          echo "No migrations on main are missing from this branch."
+
   backend:
     name: Backend
     needs:

--- a/backend/cmd/api/internal/migrations/migrations.go
+++ b/backend/cmd/api/internal/migrations/migrations.go
@@ -12,6 +12,8 @@ package migrations
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 
 	"github.com/CMS-Enterprise/ztmf/backend/internal/config"
@@ -55,7 +57,7 @@ func Run() {
 
 	err = migrator.Migrate(ctx)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(migrateFailureMsg(err))
 		return
 	}
 
@@ -76,4 +78,19 @@ func Run() {
 			log.Fatal(err)
 		}
 	}
+}
+
+// migrateFailureMsg names the failure class for whoever reads the log. tern
+// returns BadVersionError when the dbversions version is outside
+// 0..len(registry), and since Migrate() always targets the registry length,
+// the only reachable case in a deployed environment is a database migrated
+// ahead of this image's registry: a stale image, not a broken database. The
+// MIGRATION_VERSION_MISMATCH token is what CI's deploy-failure diagnostics
+// filter for (ztmf-misc#298).
+func migrateFailureMsg(err error) string {
+	var badVersion migrate.BadVersionError
+	if errors.As(err, &badVersion) {
+		return fmt.Sprintf("MIGRATION_VERSION_MISMATCH: %s; the database is ahead of this image's migration registry (image knows %d migrations). The image is stale, not the database: rebase onto latest main so the image includes the newer migration, then redeploy.", err, len(registry))
+	}
+	return err.Error()
 }

--- a/backend/cmd/api/internal/migrations/migrations_test.go
+++ b/backend/cmd/api/internal/migrations/migrations_test.go
@@ -1,6 +1,12 @@
 package migrations
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/tern/v2/migrate"
+)
 
 // TestRegistryPopulated pins the package's registration contract: init() funcs
 // only append to the registry, so building the test binary and running the
@@ -29,5 +35,23 @@ func TestRegistryPopulated(t *testing.T) {
 			t.Errorf("migration %d is an exact duplicate of migration %d (%q); a repeated registration shifts later version numbers", i, prev, m.name)
 		}
 		seen[key] = i
+	}
+}
+
+// TestMigrateFailureMsg pins the operator-facing classification: a tern
+// BadVersionError carries the MIGRATION_VERSION_MISMATCH token that CI's
+// deploy-failure diagnostics filter for, plus the remedy; every other error
+// passes through unchanged so no unrelated failure gets mislabeled.
+func TestMigrateFailureMsg(t *testing.T) {
+	bve := migrate.BadVersionError("current version 62 is outside the valid versions of 0 to 61")
+	msg := migrateFailureMsg(bve)
+	for _, want := range []string{"MIGRATION_VERSION_MISMATCH", "current version 62", "rebase onto latest main"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("mismatch message missing %q: %s", want, msg)
+		}
+	}
+	plain := errors.New("dial tcp: connection refused")
+	if got := migrateFailureMsg(plain); got != plain.Error() {
+		t.Errorf("non-version error must pass through unchanged, got %q", got)
 	}
 }


### PR DESCRIPTION
When a backend image starts against a database whose migration version is ahead of the image's registry, `migrations.Run()` hits tern's `BadVersionError` and `log.Fatal`s into CloudWatch, the task crash-loops, and the only symptom in Actions is the tfSTABLE timeout after 20 minutes, the same string a contention timeout produces. Grepping a failing run for the migration error finds nothing because the fatal never reaches the job output (ztmf-misc#298).

Three changes, per the ticket's two candidate shapes:

1. `migrations.Run()` now classifies tern's `BadVersionError` and fatals with a greppable `MIGRATION_VERSION_MISMATCH` message naming the version gap and the remedy (rebase onto latest main). Only this error class is reachable in a deployed environment since `Migrate()` always targets the registry length; other errors pass through unchanged.
2. `infrastructure.yml` gains a `Deploy failure diagnostics` step (`if: failure()`) that prints the ECS service events, stopped-task reasons and exit codes, and any `MIGRATION_VERSION_MISMATCH` lines from the last 30 minutes of the log group. This repo is public, so raw application logs are never dumped into job output; anything beyond the controlled token points at CloudWatch by name. A crash-looped startup fatal and a genuine contention timeout now look different in the job output.
3. `orchestration-dev.yml` fails fast, in the existing Check-for-Changes job, when main carries migration files the branch lacks, naming the mismatch and the remedy in seconds instead of after a 20-minute burn. This is a git approximation: it cannot see a migration another open PR deployed to dev without merging, which is the case changes 1 and 2 cover.

Gate: `go build`, unit, integration, and emberfall e2e all green locally. The fail-fast check was simulated from the parent of the newest migration-bearing commit (flags the missing migration and fails) and from HEAD (passes clean). No API contract change, so no `openapi.yaml` or `emberfall_tests.yml` changes.