### PR TITLE
chore(ci): bump the github-actions group with 9 updates

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -24,7 +24,7 @@ jobs:
       backend: ${{ steps.backend.outputs.backend }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: LINT backend/
         uses: dominikh/staticcheck-action@v1
@@ -61,10 +61,10 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
 
@@ -100,10 +100,10 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: TFLINT setup
-        uses: terraform-linters/setup-tflint@v4
+        uses: terraform-linters/setup-tflint@v6
 
       - name: TFLINT version
         run: tflint --version
@@ -123,10 +123,10 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/go.mod
 
@@ -146,7 +146,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: code test
         uses: snyk/actions/golang@master
@@ -163,7 +163,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: iac test
         uses: snyk/actions/golang@master

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -64,7 +64,7 @@ jobs:
         run: docker buildx build --platform linux/amd64 --tag ${{ secrets.ECR_REPO_URL }}:${{ steps.revParse.outputs.shaShort }} --load ./backend 
 
       - name: Snyk - Test Image
-        uses: snyk/actions/docker@12140f4059e244892ae643824a95459a102120dd # snyk/actions has no tagged releases; pinned master @ 2026-06-16
+        uses: snyk/actions/docker@12140f4059e244892ae643824a95459a102120dd # snyk/actions has no tagged releases; pinned master @ 2026-08-03
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -101,7 +101,7 @@ jobs:
           WORKSPACE: ${{ github.workspace }}
 
       - name: Emberfall Smoke Tests
-        uses: aquia-inc/emberfall@a0d970e3235fc42dd7b24c1b7dd18f924fcb5aed # main @ 2026-06-16 (composite; binary version set via `version` below)
+        uses: aquia-inc/emberfall@a0d970e3235fc42dd7b24c1b7dd18f924fcb5aed # main @ 2026-08-12 (composite; binary version set via `version` below)
         with:
           version: 0.4.1
           file: ./backend/emberfall_tests.yml

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # Read the required Go from go.mod (setup-go v6 sets GOTOOLCHAIN=local,
           # so a pinned version below go.mod's would not auto-download).
@@ -51,10 +51,10 @@ jobs:
       shaShort: ${{ steps.revParse.outputs.shaShort }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       
       - name: Get Commit SHA
         id: revParse
@@ -64,7 +64,7 @@ jobs:
         run: docker buildx build --platform linux/amd64 --tag ${{ secrets.ECR_REPO_URL }}:${{ steps.revParse.outputs.shaShort }} --load ./backend 
 
       - name: Snyk - Test Image
-        uses: snyk/actions/docker@8e119fbb6c251787721d34ba683ed48eba792766 # snyk/actions has no tagged releases; pinned master @ 2026-06-16
+        uses: snyk/actions/docker@12140f4059e244892ae643824a95459a102120dd # snyk/actions has no tagged releases; pinned master @ 2026-06-16
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -72,7 +72,7 @@ jobs:
           args: --severity-threshold=high --file=./backend/Dockerfile --policy-path=./backend/.snyk
       
       - name: Start API and Postgres Containers
-        uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
+        uses: hoverkraft-tech/compose-action@ee6af68587292d72db67743171809c19787df4c9 # v3.1.0
         with:
           compose-file: ./backend/actions-compose.yml
         env:
@@ -101,13 +101,13 @@ jobs:
           WORKSPACE: ${{ github.workspace }}
 
       - name: Emberfall Smoke Tests
-        uses: aquia-inc/emberfall@90b0381a446bb7ba326af24153bb0518e49fb279 # main @ 2026-06-16 (composite; binary version set via `version` below)
+        uses: aquia-inc/emberfall@a0d970e3235fc42dd7b24c1b7dd18f924fcb5aed # main @ 2026-06-16 (composite; binary version set via `version` below)
         with:
           version: 0.4.1
           file: ./backend/emberfall_tests.yml
 
       - name: AWS - Get Credentials
-        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.ROLEARN }}
           role-duration-seconds: 900
@@ -120,7 +120,7 @@ jobs:
         run: docker push ${{ secrets.ECR_REPO_URL }}:${{ steps.revParse.outputs.shaShort }}
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # Read the required Go from go.mod rather than hardcoding it. setup-go
           # v6 sets GOTOOLCHAIN=local, so a pinned version below go.mod's

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -23,10 +23,10 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Get AWS Creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.ROLEARN }}
           # 1 hour: dev/prod applies normally complete in a few minutes, but
@@ -37,7 +37,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3.1.2
+        uses: hashicorp/setup-terraform@v4.0.1
         with:
           terraform_version: "1.10.3"
       

--- a/.github/workflows/nightly-impl-sync.yml
+++ b/.github/workflows/nightly-impl-sync.yml
@@ -53,7 +53,7 @@ jobs:
     name: Open main -> impl sync PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.SYNC_PAT }}

--- a/.github/workflows/ops-image.yml
+++ b/.github/workflows/ops-image.yml
@@ -31,17 +31,17 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Get Commit SHA
         id: revParse
         run: echo "shaShort=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: AWS - Get Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.ROLEARN }}
           role-duration-seconds: 900

--- a/.github/workflows/orchestration-dev.yml
+++ b/.github/workflows/orchestration-dev.yml
@@ -24,7 +24,7 @@ jobs:
       backend: ${{ steps.backend.outputs.backend }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/orchestration-impl.yml
+++ b/.github/workflows/orchestration-impl.yml
@@ -56,7 +56,7 @@ jobs:
       backend: ${{ steps.backend.outputs.backend }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Rehomes #556 onto an in-repo branch, with the original commit's authorship preserved.

Dependabot-triggered runs read the Dependabot secret store rather than the repo and environment secrets, so `SNYK_TOKEN` was empty on #556 and all three Snyk jobs failed with a 401 rather than on anything in the diff. That PR could never go green, and so could never satisfy the required dev deployment on main. Pushing the same commit from an in-repo branch gives those jobs real credentials. #556 is closed in favor of this one.

The bump itself is unchanged: nine action updates across seven workflows, moving `actions/checkout` and `actions/setup-go` onto majors that run on Node 24. That part is not cosmetic - current runs already warn that `actions/checkout@v4` and `actions/setup-go@v5` are being forced onto Node 24 because Node 20 is deprecated.

The second commit corrects two provenance comments. `snyk/actions` and `aquia-inc/emberfall` are pinned by SHA because neither publishes tags the workflow can track, and each carries a trailing comment naming the date of the pinned commit. Both SHAs moved in this bump while the comments still named the old date, so each described a commit that is no longer the one pinned. They now read 2026-08-03 and 2026-08-12 respectively.

Verified before opening: the first commit's tree is identical to #556's head, and the branch as a whole differs from it only in those two comment lines. The residual mix of bare tags in `analysis.yml` and SHA pins elsewhere is untouched and remains the subject of #317.

Expect the Go scan to be red here for the same reason it is red on #558 - a Go standard-library advisory against the version pinned in `backend/go.mod`, unrelated to this diff.
