### PR TITLE
chore(backend): move the Go toolchain to 1.25.14

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-bookworm AS builder
+FROM golang:1.25.14-bookworm AS builder
 
 WORKDIR /src
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/CMS-Enterprise/ztmf/backend
 
-go 1.25.11
+go 1.25.14
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
The dependency scan is red across the whole backend queue on a Go standard-library advisory against 1.25.11, the version pinned in `backend/go.mod`. Nothing in any of the open PRs causes it, but because the backend and infrastructure jobs are gated on `!failure()` they skip while that scan is red, so no backend PR can reach the dev deploy main's ruleset requires. #558 and #559 are both sitting behind it.

This moves the module directive and the builder image in `backend/Dockerfile` together, so the binary that gets scanned is built with the same toolchain the scan is checking. 1.25.14 rather than the minimum 1.25.13: both exist upstream, and taking the current patch in the series avoids landing on a release that carries its own open advisory.

Verified before opening: `go build ./...` clean, and the full DB-free unit suite green at 630 tests across 19 packages.
