### PR TITLE
feat(#564): paginate GET /events with stable ordering and time-range filters

### DIFF
--- a/backend/cmd/api/internal/controller/controller.go
+++ b/backend/cmd/api/internal/controller/controller.go
@@ -144,6 +144,7 @@ func sanitizeErr(err error) (int, string, error) {
 		code = auth.CodeDelegateRequiresAdmin
 	case errors.Is(err, model.ErrNotUnique),
 		errors.Is(err, ErrMalformed),
+		errors.Is(err, ErrInvalidQueryParam),
 		errors.Is(err, model.ErrNotesTooLong),
 		errors.Is(err, model.ErrNoReference):
 		status = 400

--- a/backend/cmd/api/internal/controller/events.go
+++ b/backend/cmd/api/internal/controller/events.go
@@ -70,7 +70,8 @@ func RecordQuestionView(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-//	@Summary	List audit-trail events
+//	@Summary		List audit-trail events, newest first, one page at a time
+//	@Description	Returns one page of the audit trail ordered by createdat descending (ties broken by eventid, so paging is stable). The response echoes the limit and offset actually applied and carries the total count matching the filters, for page math.
 //	@Tags		events
 //	@Produce	json
 //	@Security	bearerAuth
@@ -81,7 +82,12 @@ func RecordQuestionView(w http.ResponseWriter, r *http.Request) {
 //	@Param		payload.scoreid			query		integer	false	"Filter by score ID referenced in the event payload"
 //	@Param		payload.datacallid		query		integer	false	"Filter by data call ID referenced in the event payload"
 //	@Param		payload.questionid		query		integer	false	"Filter by question ID referenced in the event payload"
-//	@Success	200	{object}	apiResponse[[]model.Event]
+//	@Param		limit					query		integer	false	"Page size; absent or 0 applies the default of 50, values above 500 clamp to 500"
+//	@Param		offset					query		integer	false	"Rows to skip before the page; defaults to 0"
+//	@Param		from					query		string	false	"Only events at or after this RFC3339 timestamp"
+//	@Param		to						query		string	false	"Only events at or before this RFC3339 timestamp"
+//	@Success	200	{object}	apiResponse[model.EventsPage]
+//	@Failure	400	{object}	apiResponse[any]
 //	@Failure	403	{object}	apiResponse[any]
 //	@Failure	500	{object}	apiResponse[any]
 //	@Router		/events [get]
@@ -96,14 +102,39 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// from/to are RFC3339 timestamps parsed by hand: the shared decoder has
+	// no time.Time converter and rejects unknown keys as a 400, so the two
+	// keys are pulled out of the values before it decodes the rest.
+	qs := r.URL.Query()
+	fromStr, toStr := qs.Get("from"), qs.Get("to")
+	qs.Del("from")
+	qs.Del("to")
+
 	findEventsInput := &model.FindEventsInput{}
-	err := decoder.Decode(findEventsInput, r.URL.Query())
+	err := decoder.Decode(findEventsInput, qs)
 	if err != nil {
 		respond(w, r, nil, err)
 		return
 	}
 
-	events, err := model.FindEvents(r.Context(), findEventsInput)
+	if fromStr != "" {
+		t, err := parseRFC3339(fromStr)
+		if err != nil {
+			respond(w, r, nil, ErrInvalidQueryParam)
+			return
+		}
+		findEventsInput.From = &t
+	}
+	if toStr != "" {
+		t, err := parseRFC3339(toStr)
+		if err != nil {
+			respond(w, r, nil, ErrInvalidQueryParam)
+			return
+		}
+		findEventsInput.To = &t
+	}
 
-	respond(w, r, events, err)
+	page, err := model.FindEvents(r.Context(), findEventsInput)
+
+	respond(w, r, page, err)
 }

--- a/backend/cmd/api/internal/migrations/0058eventspagination.go
+++ b/backend/cmd/api/internal/migrations/0058eventspagination.go
@@ -1,0 +1,35 @@
+package migrations
+
+func init() {
+	appendMigration(
+		"events pagination: identity tiebreaker and global order index",
+		`
+-- The admin events page (ztmf#564) reads the audit trail ordered by
+-- createdat DESC in pages. Two things the table lacks for that:
+--
+-- 1. A tiebreaker. events has no primary key, and bulk writers (imports,
+--    seed SQL) stamp batches of rows with identical createdat values, so
+--    ORDER BY createdat alone is not a total order: tied rows may swap
+--    between requests, duplicating or skipping rows across page
+--    boundaries. eventid only has to make the order stable, not
+--    chronological, so the backfill order Postgres assigns to existing
+--    rows is fine. GENERATED ALWAYS means the INSERT sites (which all
+--    name their columns) keep working unchanged and cannot supply their
+--    own values.
+--
+-- 2. An index serving the unfiltered scan. 0037's (resource, createdat)
+--    and 0054's (userid, createdat) indexes each need their leading
+--    column in the predicate, and the page's default view has no filter,
+--    so without this index every first page is a top-N sort over the
+--    whole table.
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS eventid BIGINT GENERATED ALWAYS AS IDENTITY;
+
+CREATE INDEX IF NOT EXISTS events_pagination_idx
+    ON public.events (createdat DESC, eventid DESC);
+`,
+		`
+DROP INDEX IF EXISTS public.events_pagination_idx;
+ALTER TABLE public.events DROP COLUMN IF EXISTS eventid;
+`,
+	)
+}

--- a/backend/emberfall_tests.yml
+++ b/backend/emberfall_tests.yml
@@ -2222,6 +2222,8 @@ tests:
         content-type: "application/json"
 
   # Events Endpoints (GET only)
+  # The audit trail is paginated (ztmf#564): the response is a page object
+  # echoing the applied limit/offset, defaulting to 50/0.
   - url: http://localhost:8080/api/v1/events
     method: GET
     headers:
@@ -2230,6 +2232,72 @@ tests:
       status: 200
       headers:
         content-type: "application/json"
+      body:
+        json:
+          data:
+            limit: 50
+            offset: 0
+
+  # Explicit paging params are honored and echoed.
+  - url: http://localhost:8080/api/v1/events?limit=1&offset=3
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            limit: 1
+            offset: 3
+
+  # A limit above the cap clamps to 500 rather than erroring, and the client
+  # sees the value that was actually applied.
+  - url: http://localhost:8080/api/v1/events?limit=9999
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            limit: 500
+
+  # A from bound in the far future matches nothing: an empty page with a zero
+  # total, not an error. (Runtime events are stamped now, seed events in the
+  # past, so nothing can exist past 2030 while this suite runs.)
+  - url: http://localhost:8080/api/v1/events?from=2030-01-01T00:00:00Z
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            total: 0
+
+  # Bad paging and time params are client errors, not 500s: a non-integer
+  # limit, an unparseable timestamp, and an inverted range.
+  - url: http://localhost:8080/api/v1/events?limit=abc
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 400
+  - url: http://localhost:8080/api/v1/events?from=not-a-timestamp
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 400
+  - url: http://localhost:8080/api/v1/events?from=2030-01-01T00:00:00Z&to=2020-01-01T00:00:00Z
+    method: GET
+    headers:
+      <<: *commonHeaders
+    expect:
+      status: 400
 
   # System Enrichment endpoint (generic enrichment payload, admin access)
   - url: http://localhost:8080/api/v1/systemenrichment/E1D00198-36D4-4EAB-8C00-501E1D000999

--- a/backend/internal/model/events.go
+++ b/backend/internal/model/events.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Event struct {
+	EventID   int64       `json:"eventid"`   // identity column; the paging tiebreaker (migration 0058)
 	UserID    string      `json:"userid"`    // who initiated the event
 	Action    string      `json:"action"`    // the action they took
 	Resource  string      `json:"type"`      // on what resource
@@ -93,6 +94,57 @@ type FindEventsInput struct {
 	Action   *string  `schema:"action" json:"action,omitempty"`
 	Resource *string  `schema:"resource" json:"resource,omitempty"`
 	Payload  *payload `schema:"payload" json:"payload,omitempty"`
+	// Limit and Offset are unsigned so the shared query decoder rejects
+	// negatives as a conversion error (a 400) without any range checks here.
+	// Absent or zero Limit means the default; values above the cap clamp.
+	Limit  *uint32 `schema:"limit" json:"limit,omitempty"`
+	Offset *uint32 `schema:"offset" json:"offset,omitempty"`
+	// From/To bound createdat inclusively. The shared decoder has no
+	// time.Time converter, so the controller parses them from RFC3339 and
+	// strips the keys from what the decoder sees; schema:"-" keeps the
+	// decoder from ever trying.
+	From *time.Time `schema:"-" json:"from,omitempty"`
+	To   *time.Time `schema:"-" json:"to,omitempty"`
+}
+
+// Paging bounds for FindEvents. GET /events returned the entire table before
+// the admin events page (ztmf#564); the cap guarantees no single request can
+// do that again.
+const (
+	defaultEventsLimit uint32 = 50
+	maxEventsLimit     uint32 = 500
+)
+
+// limit returns the page size to apply: the default when absent or zero, the
+// cap when the caller asks for more, the caller's value otherwise.
+func (i *FindEventsInput) limit() uint32 {
+	switch {
+	case i.Limit == nil || *i.Limit == 0:
+		return defaultEventsLimit
+	case *i.Limit > maxEventsLimit:
+		return maxEventsLimit
+	default:
+		return *i.Limit
+	}
+}
+
+func (i *FindEventsInput) offset() uint32 {
+	if i.Offset == nil {
+		return 0
+	}
+	return *i.Offset
+}
+
+// EventsPage is one page of the audit trail plus what a client needs to render
+// paging controls. Total counts every event matching the filters, not just this
+// page; Limit and Offset echo the values actually applied after defaulting and
+// clamping, so a client can trust them for page math without re-deriving the
+// rules.
+type EventsPage struct {
+	Events []*Event `json:"events"`
+	Total  int64    `json:"total"`
+	Limit  uint32   `json:"limit"`
+	Offset uint32   `json:"offset"`
 }
 
 // recordEvent uses the provided SqlBuilder to determin what write operation was performed (create, update, delete), and
@@ -254,31 +306,72 @@ func RecordLogin(ctx context.Context, userID string) error {
 	return insertEvent(ctx, userID, eventActionCreated, "session", payload{UserID: &userID})
 }
 
-func FindEvents(ctx context.Context, input *FindEventsInput) ([]*Event, error) {
+func FindEvents(ctx context.Context, input *FindEventsInput) (*EventsPage, error) {
 
-	sqlb := stmntBuilder.
-		Select("*").
-		From("events")
-
-	if input.UserID != nil {
-		sqlb = sqlb.Where("userid=?", input.UserID)
+	if input.From != nil && input.To != nil && input.From.After(*input.To) {
+		return nil, &InvalidInputError{data: map[string]any{"from": "must not be after to"}}
 	}
 
-	if input.Resource != nil {
-		sqlb = sqlb.Where("resource=?", input.Resource)
-	}
-
-	if input.Action != nil {
-		sqlb = sqlb.Where("action=?", input.Action)
-	}
-
+	// Marshaled once, ahead of the closure, so a marshal failure surfaces
+	// before any query is built.
+	var payloadJSON *string
 	if input.Payload != nil {
 		p, err := json.Marshal(input.Payload)
 		if err != nil {
 			return nil, err
 		}
-		sqlb = sqlb.Where("payload @> ?", string(p))
+		s := string(p)
+		payloadJSON = &s
 	}
 
-	return query(ctx, sqlb, pgx.RowToAddrOfStructByName[Event])
+	// The page query and the count query must agree on the filters or Total
+	// lies to the client's pager; one closure keeps them from drifting.
+	where := func(sqlb squirrel.SelectBuilder) squirrel.SelectBuilder {
+		if input.UserID != nil {
+			sqlb = sqlb.Where("userid=?", input.UserID)
+		}
+		if input.Resource != nil {
+			sqlb = sqlb.Where("resource=?", input.Resource)
+		}
+		if input.Action != nil {
+			sqlb = sqlb.Where("action=?", input.Action)
+		}
+		if input.From != nil {
+			sqlb = sqlb.Where("createdat >= ?", input.From)
+		}
+		if input.To != nil {
+			sqlb = sqlb.Where("createdat <= ?", input.To)
+		}
+		if payloadJSON != nil {
+			sqlb = sqlb.Where("payload @> ?", *payloadJSON)
+		}
+		return sqlb
+	}
+
+	limit, offset := input.limit(), input.offset()
+
+	// eventid breaks createdat ties (bulk writers stamp identical
+	// timestamps), making the order total so rows cannot swap across page
+	// boundaries between requests. See migration 0058.
+	sqlb := where(stmntBuilder.Select("*").From("events")).
+		OrderBy("createdat DESC", "eventid DESC").
+		Limit(uint64(limit)).
+		Offset(uint64(offset))
+
+	events, err := query(ctx, sqlb, pgx.RowToAddrOfStructByName[Event])
+	if err != nil {
+		return nil, err
+	}
+	if events == nil {
+		// CollectRows yields nil for zero rows; an empty page must serialize
+		// as [] rather than null.
+		events = []*Event{}
+	}
+
+	total, err := queryRow(ctx, where(stmntBuilder.Select("COUNT(*)").From("events")), pgx.RowTo[int64])
+	if err != nil {
+		return nil, err
+	}
+
+	return &EventsPage{Events: events, Total: *total, Limit: limit, Offset: offset}, nil
 }

--- a/backend/internal/model/events_pagination_integration_test.go
+++ b/backend/internal/model/events_pagination_integration_test.go
@@ -1,0 +1,103 @@
+package model
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/CMS-Enterprise/ztmf/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FindEvents pages the audit trail for the admin events page (ztmf#564). The
+// property that matters is a total order: bulk writers stamp batches of rows
+// with identical createdat values, and without the eventid tiebreaker tied
+// rows may swap between requests, duplicating or skipping rows across page
+// boundaries. The fixture therefore deliberately writes tied timestamps and
+// asserts that walking the pages covers every row exactly once.
+func TestFindEventsPaginationIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test")
+	}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+
+	// A resource name no writer uses keeps the fixture invisible to every
+	// other reader and makes cleanup a single predicate. Registered before
+	// any insert so every exit path cleans up; see events_login test for why
+	// this is a Cleanup, not a defer.
+	const resource = "pagination_test"
+	t.Cleanup(func() {
+		_, _ = conn.Exec(ctx, `DELETE FROM public.events WHERE resource=$1`, resource)
+		conn.Release()
+	})
+
+	// events.userid is a FK, so borrow any seeded user as the initiator.
+	var userID string
+	require.NoError(t, conn.QueryRow(ctx, `SELECT userid FROM public.users LIMIT 1`).Scan(&userID))
+
+	// Five rows sharing one timestamp (the case createdat alone cannot order)
+	// plus one strictly older row, all in the far past so they cannot collide
+	// with rows other tests write while this one runs.
+	tied := time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
+	older := tied.Add(-time.Hour)
+	for _, ts := range []time.Time{tied, tied, tied, tied, tied, older} {
+		_, err := conn.Exec(ctx,
+			`INSERT INTO public.events (userid, action, resource, createdat, payload) VALUES ($1, 'created', $2, $3, '{}')`,
+			userID, resource, ts)
+		require.NoError(t, err)
+	}
+
+	res := resource
+	limit := uint32(2)
+
+	// Walk the pages and require exactly-once coverage in a strictly
+	// decreasing (createdat, eventid) order.
+	seen := map[int64]bool{}
+	var prev *Event
+	for offset := uint32(0); ; offset += limit {
+		off := offset
+		page, err := FindEvents(ctx, &FindEventsInput{Resource: &res, Limit: &limit, Offset: &off})
+		require.NoError(t, err)
+		assert.EqualValues(t, 6, page.Total, "total counts all matches, not the page")
+		assert.Equal(t, limit, page.Limit, "applied limit is echoed")
+		assert.Equal(t, off, page.Offset, "applied offset is echoed")
+		if len(page.Events) == 0 {
+			break
+		}
+		for _, e := range page.Events {
+			require.Positive(t, e.EventID, "backfilled identity must be present on read")
+			require.False(t, seen[e.EventID], "row %d appeared on two pages", e.EventID)
+			seen[e.EventID] = true
+			if prev != nil {
+				after := e.CreatedAt.After(*prev.CreatedAt)
+				tie := e.CreatedAt.Equal(*prev.CreatedAt) && e.EventID > prev.EventID
+				require.False(t, after || tie, "order must be createdat DESC, eventid DESC")
+			}
+			prev = e
+		}
+	}
+	assert.Len(t, seen, 6, "paging must cover every row exactly once")
+
+	// Inclusive time bounds: from=tied keeps the tied five and drops the
+	// older row; to=older keeps only the older row.
+	page, err := FindEvents(ctx, &FindEventsInput{Resource: &res, From: &tied})
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, page.Total)
+	assert.Len(t, page.Events, 5, "five rows fit in the default limit")
+
+	page, err = FindEvents(ctx, &FindEventsInput{Resource: &res, To: &older})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, page.Total)
+
+	// A range matching nothing is an empty page, not an error, and the
+	// events list must be non-nil so it serializes as [] rather than null.
+	beforeAll := older.Add(-time.Hour)
+	page, err = FindEvents(ctx, &FindEventsInput{Resource: &res, To: &beforeAll})
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, page.Total)
+	assert.NotNil(t, page.Events)
+	assert.Empty(t, page.Events)
+}

--- a/backend/internal/model/events_test.go
+++ b/backend/internal/model/events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -100,4 +101,48 @@ func TestPayloadReadOnlyMarshal(t *testing.T) {
 		assert.NoError(t, err)
 		assert.JSONEq(t, `{}`, string(b), "a nil readonly pointer is omitted entirely")
 	})
+}
+
+// TestFindEventsInputPaging pins the defaulting and clamping rules the
+// EventsPage echoes back to clients: a pager doing page math on the returned
+// limit must get the value that was actually applied.
+func TestFindEventsInputPaging(t *testing.T) {
+	u := func(v uint32) *uint32 { return &v }
+
+	t.Run("Limit", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			in   *uint32
+			want uint32
+		}{
+			"NilDefaults":     {nil, defaultEventsLimit},
+			"ZeroDefaults":    {u(0), defaultEventsLimit},
+			"InRangePasses":   {u(25), 25},
+			"CapExactPasses":  {u(maxEventsLimit), maxEventsLimit},
+			"OverCapClamps":   {u(maxEventsLimit + 1), maxEventsLimit},
+		} {
+			t.Run(name, func(t *testing.T) {
+				in := FindEventsInput{Limit: tc.in}
+				assert.Equal(t, tc.want, in.limit())
+			})
+		}
+	})
+
+	t.Run("Offset", func(t *testing.T) {
+		in := FindEventsInput{}
+		assert.Equal(t, uint32(0), in.offset(), "nil offset defaults to 0")
+		in.Offset = u(7)
+		assert.Equal(t, uint32(7), in.offset())
+	})
+}
+
+// An inverted time range is a client mistake, rejected as a 400 before any
+// query runs (the check precedes the connection, so no DB is needed here).
+func TestFindEventsRejectsInvertedRange(t *testing.T) {
+	to := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	from := to.Add(time.Hour)
+	_, err := FindEvents(context.Background(), &FindEventsInput{From: &from, To: &to})
+	iie, ok := err.(*InvalidInputError)
+	if assert.True(t, ok, "want *InvalidInputError, got %T", err) {
+		assert.Contains(t, iie.Data(), "from")
+	}
 }

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -74,16 +74,6 @@ components:
         error:
           type: string
       type: object
-    controller.apiResponse-array_model_Event:
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/model.Event'
-          type: array
-          uniqueItems: false
-        error:
-          type: string
-      type: object
     controller.apiResponse-array_model_FismaSystem:
       properties:
         data:
@@ -225,6 +215,13 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/model.DataCall'
+        error:
+          type: string
+      type: object
+    controller.apiResponse-model_EventsPage:
+      properties:
+        data:
+          $ref: '#/components/schemas/model.EventsPage'
         error:
           type: string
       type: object
@@ -387,6 +384,9 @@ components:
         createdat:
           description: at what date and time
           type: string
+        eventid:
+          description: identity column; the paging tiebreaker (migration 0058)
+          type: integer
         payload:
           description: incoming data
         type:
@@ -395,6 +395,20 @@ components:
         userid:
           description: who initiated the event
           type: string
+      type: object
+    model.EventsPage:
+      properties:
+        events:
+          items:
+            $ref: '#/components/schemas/model.Event'
+          type: array
+          uniqueItems: false
+        limit:
+          type: integer
+        offset:
+          type: integer
+        total:
+          type: integer
       type: object
     model.FismaSystem:
       properties:
@@ -1251,6 +1265,10 @@ paths:
       - datacentermismatches
   /events:
     get:
+      description: Returns one page of the audit trail ordered by createdat descending
+        (ties broken by eventid, so paging is stable). The response echoes the limit
+        and offset actually applied and carries the total count matching the filters,
+        for page math.
       parameters:
       - description: Filter by initiating user ID
         in: query
@@ -1287,13 +1305,40 @@ paths:
         name: payload.questionid
         schema:
           type: integer
+      - description: Page size; absent or 0 applies the default of 50, values above
+          500 clamp to 500
+        in: query
+        name: limit
+        schema:
+          type: integer
+      - description: Rows to skip before the page; defaults to 0
+        in: query
+        name: offset
+        schema:
+          type: integer
+      - description: Only events at or after this RFC3339 timestamp
+        in: query
+        name: from
+        schema:
+          type: string
+      - description: Only events at or before this RFC3339 timestamp
+        in: query
+        name: to
+        schema:
+          type: string
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/controller.apiResponse-array_model_Event'
+                $ref: '#/components/schemas/controller.apiResponse-model_EventsPage'
           description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/controller.apiResponse-any'
+          description: Bad Request
         "403":
           content:
             application/json:
@@ -1308,7 +1353,7 @@ paths:
           description: Internal Server Error
       security:
       - bearerAuth: []
-      summary: List audit-trail events
+      summary: List audit-trail events, newest first, one page at a time
       tags:
       - events
   /events/view:


### PR DESCRIPTION
Closes #564. First slice of the admin events page epic (CMS-Enterprise/ztmf-ui#183).

`GET /events` returned the entire events table unordered: no ORDER BY, no limit, no time filter, roughly 200k rows in prod. This makes it a paginated contract: results order by `createdat` DESC with `eventid` as tiebreaker, `limit` (default 50, capped at 500) and `offset` page through, and `from`/`to` bound `createdat` inclusively as RFC3339. The response becomes a page object, `{events, total, limit, offset}`, echoing the values actually applied so a client pager never re-derives the defaulting rules. No frontend consumer exists yet, so nothing breaks; the page in CMS-Enterprise/ztmf-ui#711 builds on this contract.

Two deviations from the ticket text, worked out in scoping. Offset pagination instead of a cursor, because the consumer is MUI DataGrid server-side paging, which wants page and pageSize with arbitrary jumps. And a migration (0058) the ticket didn't call for: the events table has no primary key and bulk writers stamp identical createdat values, so createdat alone is not a total order and tied rows could swap across page boundaries; 0058 adds an `eventid` identity column as tiebreaker plus a `(createdat DESC, eventid DESC)` index, since the 0037/0054 indexes both need their leading column in the predicate and cannot serve the unfiltered scan. Event rows now expose `eventid`, which the UI can use as a row key.

Also folded in: `sanitizeErr` now maps `ErrInvalidQueryParam` to 400 when a handler returns it directly. Previously only the schema-decode branch produced it; the new from/to parse path returns it, and unmapped it fell through to 500.

Gate: `make test-unit`, `make test-integration`, and `make test-e2e` all green locally (emberfall 217 ran, 0 failed, including seven new /events cases covering the page shape, echo and clamp behavior, and 400s for bad params). New unit tests pin the limit defaulting and clamping and the inverted-range 400; a new integration test writes tied timestamps and proves paging covers every row exactly once, with the range bounds inclusive. `openapi.yaml` regenerated via `make generate-openapi`; redocly lint is clean with the same 8 pre-existing warnings as main.
