### PR TITLE
ci: require migration-touching PRs to be current with main (misc#303)

### DIFF
--- a/.github/workflows/orchestration-dev.yml
+++ b/.github/workflows/orchestration-dev.yml
@@ -49,9 +49,14 @@ jobs:
       # This is a git approximation: it cannot see a migration another open PR
       # deployed to dev without merging; that case is caught by the
       # deploy-failure diagnostics in infrastructure.yml. Context: ztmf-misc#298.
+      #
+      # The diff must run from the PR head, not HEAD: on pull_request events the
+      # checkout is refs/pull/N/merge, whose main-side diff is empty by
+      # construction. The head SHA is the merge commit's second parent, so the
+      # full-history checkout already has it.
       - name: Fail fast on migrations missing from this branch
         run: |
-          MISSING=$(git diff --name-only --diff-filter=A HEAD...origin/main -- \
+          MISSING=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.head.sha }}...origin/main -- \
             'backend/cmd/api/internal/migrations/[0-9][0-9][0-9][0-9]*.go' | grep -v '_test' || true)
           if [ -n "$MISSING" ]; then
             echo "::error::main has migrations this branch does not include:"
@@ -61,6 +66,25 @@ jobs:
             exit 1
           fi
           echo "No migrations on main are missing from this branch."
+
+      # Migrations are globally ordered state, so a PR that touches them must be
+      # authored against the schema main actually has: an edited migration or a
+      # schema change merged behind this branch will not show up as a missing
+      # file above, but still diverges dev the moment this deploys. Require
+      # currency with main instead of guessing. Only migration-touching PRs pay
+      # this cost. Context: ztmf-misc#303.
+      - name: Require migration-touching branches to be current with main
+        run: |
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          TOUCHES=$(git diff --name-only origin/main...$HEAD_SHA -- backend/cmd/api/internal/migrations/ | head -n 1)
+          BEHIND=$(git rev-list --count $HEAD_SHA..origin/main)
+          if [ -n "$TOUCHES" ] && [ "$BEHIND" -gt 0 ]; then
+            echo "::error::This PR touches the migrations package and is $BEHIND commit(s) behind main."
+            echo "Migrations are globally ordered; a migration authored against a stale schema can collide or diverge silently at merge."
+            echo "Remedy: rebase onto latest main, then push."
+            exit 1
+          fi
+          echo "Migration currency check passed (touches=${TOUCHES:-none}, behind=$BEHIND)."
 
   backend:
     name: Backend


### PR DESCRIPTION
Requires PRs that touch the migrations package to be current with the head of main, and fixes the missing-migration fail-fast from #558 so it compares against the PR head instead of the merge-ref checkout.

Migrations are globally ordered state. A migration authored against a stale schema can collide on version number at merge, and an edited migration or schema change merged behind an open branch never shows up as a missing file, so the existing check could not see it. The new step fails the Check for Changes job with a rebase instruction whenever the PR diff touches backend/cmd/api/internal/migrations and the branch is behind main. PRs that do not touch migrations are unaffected.

The #558 fix: on pull_request events the default checkout is refs/pull/N/merge, whose main side diffs empty by construction, so the missing-migration step could only fire if main advanced in the seconds between the merge ref being computed and the job's fetch. Diffing from github.event.pull_request.head.sha (the merge commit's second parent, already present in the full-history checkout) makes it do what its comment says. Verified both behaviors in a scratch repo: the head-sha diff reports main's migration missing from a stale branch where the merge-ref diff returns nothing.

Known limit, recorded not solved: these steps run on PR events only, so a migration merging to main does not re-trigger open PRs. Making the rule binding at merge time is a branch-protection question (require branches up to date), not a workflow one.

Gate: unit, integration, and emberfall e2e suites pass locally; actionlint clean on the changed steps (one pre-existing SC2086 info on the untouched backend-gating step).

Closes CMS-Enterprise/ztmf-misc#303.